### PR TITLE
ffmpeg dshow: Fix packet life preserver in video_decoder

### DIFF
--- a/modules/ffmpeg/ffmpeg.cpp
+++ b/modules/ffmpeg/ffmpeg.cpp
@@ -245,7 +245,7 @@ void init()
 	//fix_yadif_filter_format_query();
 	av_register_all();
     avformat_network_init();
-	//avcodec_init();
+	avcodec_init();
     avcodec_register_all();
 	
 	core::register_consumer_factory([](const std::vector<std::wstring>& params){return create_consumer(params);});

--- a/modules/ffmpeg/producer/video/video_decoder.cpp
+++ b/modules/ffmpeg/producer/video/video_decoder.cpp
@@ -93,30 +93,29 @@ public:
 					
 		if(packet->data == nullptr)
 		{			
-			packets_.pop();
 			if(codec_context_->codec->capabilities & CODEC_CAP_DELAY)
 			{
-				auto video = decode(packet.get());
+				auto video = decode(packet);
 				if(video)
 					return video;
 			}
 					
-			//packets_.pop();
+			packets_.pop();
 			file_frame_number_ = static_cast<size_t>(packet->pos);
 			avcodec_flush_buffers(codec_context_.get());
 			return flush_video();	
 		}
 			
 		packets_.pop();
-		return decode(packet.get());
+		return decode(packet);
 	}
 
-	std::shared_ptr<AVFrame> decode(AVPacket* pkt)
+	std::shared_ptr<AVFrame> decode(safe_ptr<AVPacket> pkt)
 	{
 		std::shared_ptr<AVFrame> decoded_frame(avcodec_alloc_frame(), av_free);
 
 		int frame_finished = 0;
-		THROW_ON_ERROR2(avcodec_decode_video2(codec_context_.get(), decoded_frame.get(), &frame_finished, pkt), "[video_decocer]");
+		THROW_ON_ERROR2(avcodec_decode_video2(codec_context_.get(), decoded_frame.get(), &frame_finished, pkt.get()), "[video_decoder]");
 		
 		// If a decoder consumes less then the whole packet then something is wrong
 		// that might be just harmless padding at the end, or a problem with the
@@ -132,7 +131,9 @@ public:
 		
 		++file_frame_number_;
 
-		//return decoded_frame;
+		// This ties the life of the decoded_frame to the packet that it came from. For the
+		// current version of ffmpeg (0.8 or c17808c) the RAW_VIDEO codec returns frame data
+		// owned by the packet.
 		return std::shared_ptr<AVFrame>(decoded_frame.get(), [decoded_frame, pkt](AVFrame*){});
 	}
 	


### PR DESCRIPTION
Fix packet life preserver in video_decoder and revert move of packet pop.  Without this patch the recent dshow mods crash.
