### PR TITLE
Fix #157: Can now open media with digit only names.

### DIFF
--- a/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1095,7 +1095,7 @@ bool LoadbgCommand::DoExecute()
 	{
 		auto uri_tokens = core::parameters::protocol_split(_parameters.at_original(0));
 		auto pFP = frame_producer::empty();
-		if (uri_tokens[0].empty() || uri_tokens[0] == L"route")
+		if (uri_tokens[0] == L"route")
 		{
 			pFP = RouteCommand::TryCreateProducer(*this, _parameters.at_original(0));
 		}


### PR DESCRIPTION
Fix to only PLAY or LOADBG a route if route:// is given explicitly.
