### PR TITLE
BUG FIX: FFMPEG Producer. When using LOABG with AUTO, and a SEEK or LENGTH

### DIFF
--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -365,7 +365,7 @@ public:
 		nb_frames = std::min(length_, nb_frames);
 		nb_frames = muxer_->calc_nb_frames(nb_frames);
 		
-		return nb_frames > start_ ? nb_frames - start_ : 0;
+		return nb_frames;
 	}
 
 	uint32_t file_nb_frames() const


### PR DESCRIPTION
The frame count calculation was incorrect and could result in 0.

http://casparcg.com/forum/viewtopic.php?f=3&t=1609
