### PR TITLE
FFMPEG Producer - report correct nb_frames() when using SEEK

### DIFF
--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -362,7 +362,7 @@ public:
 
 		uint32_t nb_frames = file_nb_frames();
 
-		nb_frames = std::min(length_, nb_frames);
+		nb_frames = std::min(length_, nb_frames - start_);
 		nb_frames = muxer_->calc_nb_frames(nb_frames);
 		
 		return nb_frames;


### PR DESCRIPTION
Related to a problem reported after #219 was merged.
