### PR TITLE
Consumer improvements (enables streaming output!)

### DIFF
--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -110,6 +110,7 @@
                 <path></path>
                 <vcodec>libx264 [libx264|qtrle]</vcodec>
                 <separate-key>false [true|false]</separate-key>
+                <extra-params></extra-params>
             </file>
         </consumers>
     </channel>


### PR DESCRIPTION
These patches enable disk consumer to act like a streaming output consumer. Afterr the patches are applied the following works as expected (adds stream output with the chosen settings):

> ADD 1 FILE output.ts -f mpegts -o udp://239.78.78.78:5000?pkt_size=1316&reuse=1 -vcodec libx264 -crf 24 -preset ultrafast -tune fastdecode -b:v 512k -s cif -r 25 -acodec aac -b:a 96k

The extra settings needed can also be added in the configuration file using <extra-params></extra-params>, for example to have streaming output by default add this in caspar.config:

      <consumers>
        <file>
          <path>output.ts</path>
          <codec>libx264</codec>
          <separate-key>false</separate-key>
          <extra-params>-f mpegts -o udp://239.78.78.78:5000?pkt_size=1316&amp;ttl=1&amp;reuse=1 -vcodec libx264 -crf 24 -preset ultrafast -tune fastdecode -b:v 512k -s cif -aspect 16:9 -acodec aac -b:a 96k</extra-params>
        </file>
      </consumers>
