### PR TITLE
Fix regression in playing progressive clips.

### DIFF
--- a/modules/ffmpeg/producer/util/util.cpp
+++ b/modules/ffmpeg/producer/util/util.cpp
@@ -338,14 +338,6 @@ double read_fps(AVFormatContext& context, double fail_value)
 	{
 		const auto video_context = context.streams[video_index]->codec;
 		const auto video_stream  = context.streams[video_index];
-					
-		auto frame_rate_time_base = video_stream->avg_frame_rate;
-		std::swap(frame_rate_time_base.num, frame_rate_time_base.den);
- 
-		if(is_sane_fps(frame_rate_time_base))
-		{
-			return static_cast<double>(frame_rate_time_base.den) / static_cast<double>(frame_rate_time_base.num);
-		}
 
 		AVRational time_base = video_context->time_base;
 


### PR DESCRIPTION
This fixes regression introduced in a95f6d84f. The problem is
that using avg_frame_rate causes fps to double for progressive
clips which is not what we want.

This patch removes the only place where avg_frame_rate was used
and fixes issue #264.
