### PR TITLE
Added AMCP Resume command

### DIFF
--- a/casparcg.sln
+++ b/casparcg.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual C++ Express 2010
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "core", "core\core.vcxproj", "{79388C20-6499-4BF6-B8B9-D8C33D7D4DDD}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "shell", "shell\shell.vcxproj", "{8C26C94F-8092-4769-8D84-DEA479721C5B}"

--- a/common/common.vcxproj
+++ b/common/common.vcxproj
@@ -101,6 +101,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <ExceptionHandling>Async</ExceptionHandling>
       <ForcedIncludeFiles>compiler/vs/disable_silly_warnings.h</ForcedIncludeFiles>
+      <AdditionalIncludeDirectories>E:\Software\WinDDK\inc\mfc42;E:\Software\WinDDK\inc\atl71;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/core/producer/layer.cpp
+++ b/core/producer/layer.cpp
@@ -204,6 +204,7 @@ void layer::swap(layer& other)
 void layer::load(const safe_ptr<frame_producer>& frame_producer, bool preview, int auto_play_delta){return impl_->load(frame_producer, preview, auto_play_delta);}	
 void layer::play(){impl_->play();}
 void layer::pause(){impl_->pause();}
+void layer::resume(){impl_->resume();}
 void layer::stop(){impl_->stop();}
 bool layer::is_paused() const{return impl_->is_paused_;}
 int64_t layer::frame_number() const{return impl_->frame_number_;}

--- a/core/producer/layer.h
+++ b/core/producer/layer.h
@@ -50,6 +50,7 @@ public:
 	void load(const safe_ptr<frame_producer>& producer, bool preview, int auto_play_delta); // nothrow
 	void play(); // nothrow
 	void pause(); // nothrow
+	void resume(); // nothrow
 	void stop(); // nothrow
 	boost::unique_future<std::wstring> call(bool foreground, const std::wstring& param);
 

--- a/core/producer/stage.cpp
+++ b/core/producer/stage.cpp
@@ -306,6 +306,14 @@ public:
 		}, high_priority);
 	}
 
+	void resume(int index)
+	{		
+		executor_.begin_invoke([=]
+		{
+			get_layer(index).resume();
+		}, high_priority);
+	}
+
 	void play(int index)
 	{		
 		executor_.begin_invoke([=]
@@ -491,6 +499,7 @@ frame_transform stage::get_current_transform(int index) { return impl_->get_curr
 void stage::spawn_token(){impl_->spawn_token();}
 void stage::load(int index, const safe_ptr<frame_producer>& producer, bool preview, int auto_play_delta){impl_->load(index, producer, preview, auto_play_delta);}
 void stage::pause(int index){impl_->pause(index);}
+void stage::resume(int index){impl_->resume(index);}
 void stage::play(int index){impl_->play(index);}
 void stage::stop(int index){impl_->stop(index);}
 void stage::clear(int index){impl_->clear(index);}

--- a/core/producer/stage.h
+++ b/core/producer/stage.h
@@ -67,6 +67,7 @@ public:
 			
 	void load(int index, const safe_ptr<frame_producer>& producer, bool preview = false, int auto_play_delta = -1);
 	void pause(int index);
+	void resume(int index);
 	void play(int index);
 	void stop(int index);
 	void clear(int index);

--- a/modules/decklink/decklink.vcxproj
+++ b/modules/decklink/decklink.vcxproj
@@ -96,7 +96,7 @@
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\Software\WinDDK\inc\mfc42;E:\Software\WinDDK\inc\atl71;../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -109,7 +109,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <PreprocessorDefinitions>TBB_USE_DEBUG;TBB_USE_CAPTURED_EXCEPTION=0;TBB_USE_ASSERT=1;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FloatingPointModel>Fast</FloatingPointModel>
       <ForcedIncludeFiles>common/compiler/vs/disable_silly_warnings.h</ForcedIncludeFiles>

--- a/modules/flash/flash.vcxproj
+++ b/modules/flash/flash.vcxproj
@@ -96,7 +96,7 @@
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\Software\WinDDK\inc\mfc42;E:\Software\WinDDK\inc\atl71;../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -109,7 +109,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <PreprocessorDefinitions>TBB_USE_DEBUG;TBB_USE_CAPTURED_EXCEPTION=0;TBB_USE_ASSERT=1;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <TreatWarningAsError>false</TreatWarningAsError>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FloatingPointModel>Fast</FloatingPointModel>
       <ForcedIncludeFiles>common/compiler/vs/disable_silly_warnings.h</ForcedIncludeFiles>

--- a/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1158,6 +1158,22 @@ bool PauseCommand::DoExecute()
 	return false;
 }
 
+bool ResumeCommand::DoExecute()
+{
+	try
+	{
+		GetChannel()->stage()->resume(GetLayerIndex());
+		SetReplyString(TEXT("202 RESUME OK\r\n"));
+		return true;
+	}
+	catch(...)
+	{
+		SetReplyString(TEXT("501 RESUME FAILED\r\n"));
+	}
+
+	return false;
+}
+
 bool PlayCommand::DoExecute()
 {
 	try

--- a/protocol/amcp/AMCPCommandsImpl.h
+++ b/protocol/amcp/AMCPCommandsImpl.h
@@ -130,6 +130,12 @@ class PauseCommand: public AMCPCommandBase<true, AddToQueue, 0>
 	bool DoExecute();
 };
 
+class ResumeCommand: public AMCPCommandBase<true, AddToQueue, 0>
+{
+	std::wstring print() const { return L"ResumeCommand";}
+	bool DoExecute();
+};
+
 class StopCommand : public AMCPCommandBase<true, AddToQueue, 0>
 {
 	std::wstring print() const { return L"StopCommand";}

--- a/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -327,6 +327,7 @@ AMCPCommandPtr AMCPProtocolStrategy::CommandFactory(const std::wstring& str)
 	else if(s == TEXT("ADD"))			return std::make_shared<AddCommand>();
 	else if(s == TEXT("REMOVE"))		return std::make_shared<RemoveCommand>();
 	else if(s == TEXT("PAUSE"))			return std::make_shared<PauseCommand>();
+	else if(s == TEXT("RESUME"))		return std::make_shared<ResumeCommand>();
 	else if(s == TEXT("PLAY"))			return std::make_shared<PlayCommand>();
 	else if(s == TEXT("STOP"))			return std::make_shared<StopCommand>();
 	else if(s == TEXT("CLEAR"))			return std::make_shared<ClearCommand>();

--- a/shell/shell.vcxproj
+++ b/shell/shell.vcxproj
@@ -167,7 +167,7 @@
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>E:\Software\WinDDK\inc\mfc42;E:\Software\WinDDK\inc\atl71;../</AdditionalIncludeDirectories>
       <MinimalRebuild>false</MinimalRebuild>
       <ExceptionHandling>Async</ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -189,7 +189,7 @@
       <AdditionalDependencies>sfml-system-s-d.lib;sfml-audio-s-d.lib;sfml-window-s-d.lib;sfml-graphics-s-d.lib;OpenGL32.lib;FreeImage.lib;Winmm.lib;Ws2_32.lib;avformat.lib;avcodec.lib;avdevice.lib;avutil.lib;avfilter.lib;swscale.lib;swresample.lib;tbb.lib;glew32.lib;zdll.lib;berkelium.lib</AdditionalDependencies>
       <Version>
       </Version>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>E:\Software\WinDDK\lib\ATL\i386;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBC.lib;libcmt.lib</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(TargetDir)$(TargetName).pdb</ProgramDatabaseFile>
@@ -216,6 +216,9 @@ copy "$(SolutionDir)dependencies\SFML-1.6\extlibs\bin\*.dll" "$(OutDir)"
 copy "$(ProjectDir)casparcg.config" "$(OutDir)"
 copy "$(ProjectDir)casparcg_auto_restart.bat" "$(OutDir)"</Command>
     </PostBuildEvent>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>E:\Software\WinDDK\inc\mfc42;E:\Software\WinDDK\inc\atl71;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PreBuildEvent>


### PR DESCRIPTION
This commit adds a resume function to safely unpause a paused layer. It will always unpause the foreground clip, other than the PLAY-command.
