### PR TITLE
Fixes image trembling when intrelaced video is paused

### DIFF
--- a/core/mixer/image/image_kernel.cpp
+++ b/core/mixer/image/image_kernel.cpp
@@ -323,7 +323,7 @@ struct image_kernel::implementation : boost::noncopyable
 
 		// Setup drawing area
 		
-		ogl_->viewport(0, 0, params.background->width(), params.background->height());
+		ogl_->viewport(0, (params.transform.is_paused && params.transform.field_mode == core::field_mode::upper) ? 1 : 0, params.background->width(), params.background->height());
 								
 		auto m_p = params.transform.clip_translation;
 		auto m_s = params.transform.clip_scale;

--- a/core/producer/frame/basic_frame.cpp
+++ b/core/producer/frame/basic_frame.cpp
@@ -167,5 +167,14 @@ safe_ptr<basic_frame> disable_audio(const safe_ptr<basic_frame>& frame)
 	frame2.get_frame_transform().volume = 0.0;
 	return make_safe<basic_frame>(std::move(frame2));
 }
+
+safe_ptr<basic_frame> pause(const safe_ptr<basic_frame>& frame)
+{
+	if(frame == basic_frame::empty() || frame->get_frame_transform().is_paused)
+		return frame;
+	basic_frame frame2 = frame;
+	frame2.get_frame_transform().is_paused = true;
+	return make_safe<basic_frame>(std::move(frame2));
+}
 	
 }}

--- a/core/producer/frame/basic_frame.h
+++ b/core/producer/frame/basic_frame.h
@@ -87,6 +87,8 @@ private:
 
 safe_ptr<basic_frame> disable_audio(const safe_ptr<basic_frame>& frame);
 
+safe_ptr<basic_frame> pause(const safe_ptr<basic_frame>& frame);
+
 inline bool is_concrete_frame(const safe_ptr<basic_frame>& frame)
 {
 	return frame != basic_frame::empty() && frame != basic_frame::eof() && frame != basic_frame::late();

--- a/core/producer/frame/frame_transform.cpp
+++ b/core/producer/frame/frame_transform.cpp
@@ -59,6 +59,7 @@ frame_transform::frame_transform()
 	, field_mode(field_mode::progressive)
 	, is_key(false)
 	, is_mix(false)
+	, is_paused(false)
 {
 	std::fill(anchor.begin(), anchor.end(), 0.0);
 	std::fill(fill_translation.begin(), fill_translation.end(), 0.0);
@@ -129,6 +130,7 @@ frame_transform& frame_transform::operator*=(const frame_transform &other)
 	field_mode				 = static_cast<field_mode::type>(field_mode & other.field_mode);
 	is_key					|= other.is_key;
 	is_mix					|= other.is_mix;
+	is_paused				|= other.is_paused;
 
 	return *this;
 }
@@ -188,6 +190,7 @@ frame_transform tween(double time, const frame_transform& source, const frame_tr
 	result.field_mode			= static_cast<field_mode::type>(source.field_mode & dest.field_mode);
 	result.is_key				= source.is_key | dest.is_key;
 	result.is_mix				= source.is_mix | dest.is_mix;
+	result.is_paused			= source.is_paused | dest.is_paused;
 
 	do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tweener);
 	do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tweener);

--- a/core/producer/frame/frame_transform.h
+++ b/core/producer/frame/frame_transform.h
@@ -90,7 +90,8 @@ public:
 	field_mode::type		field_mode;
 	bool					is_key;
 	bool					is_mix;
-	
+	bool					is_paused;
+
 	frame_transform& frame_transform::operator*=(const frame_transform &other);
 	frame_transform frame_transform::operator*(const frame_transform &other) const;
 };

--- a/core/producer/layer.cpp
+++ b/core/producer/layer.cpp
@@ -115,7 +115,7 @@ public:
 				if(foreground_->last_frame() == basic_frame::empty())
 					foreground_->receive(frame_producer::NO_HINT);
 
-				return disable_audio(foreground_->last_frame());
+				return caspar::core::pause(disable_audio(foreground_->last_frame()));
 			}
 
 			auto foreground = foreground_;

--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -195,7 +195,7 @@ public:
 
 	virtual safe_ptr<core::basic_frame> last_frame() const override
 	{
-		return disable_audio(last_frame_);
+		return pause(disable_audio(last_frame_));
 	}
 
 	std::pair<safe_ptr<core::basic_frame>, uint32_t> render_frame(int hints)


### PR DESCRIPTION
This is probably simplest solution to avoid shaking image when image is paused. When interlaced video is paused (from ffmpeg producer - when last frame is repeatedly displaying, and when layer's PAUSE command is invoked), only the 2nd (lower) field displays. This reduces vertical resolution by two, but eliminates this strange effect. 
Theoretically deinterlacing the last frame would be better solution, but is much more complex, because deinterlaced image should originate from time of second field (so this field should be unchanged, and only first field should be processed).
Not tested with lower field first (LFF) files, nor other producers than FFmpeg and blackmagic.