### PR TITLE
Fix inconsistent config parameter name

### DIFF
--- a/shell/server.cpp
+++ b/shell/server.cpp
@@ -322,7 +322,7 @@ struct server::impl : boost::noncopyable
 		{
 			for (auto& predefined_client : pt | witerate_children(L"configuration.osc.predefined-clients") | welement_context_iteration)
 			{
-				ptree_verify_element_name(predefined_client, L"predefined_client");
+				ptree_verify_element_name(predefined_client, L"predefined-client");
 
 				const auto address =
 						ptree_get<std::wstring>(predefined_client.second, L"address");


### PR DESCRIPTION
Changed predefined_client to predefined-client to match predefined-clients group name (also in example config file it is predefined-client).