### PR TITLE
Fix issue #366 - return false instead of nullptr

### DIFF
--- a/modules/ffmpeg/producer/util/util.cpp
+++ b/modules/ffmpeg/producer/util/util.cpp
@@ -588,7 +588,7 @@ bool is_valid_file(const std::wstring& filename, bool only_video)
 		buf.push_back(*file_it);
 
 	if(buf.empty())
-		return nullptr;
+		return false;
 
 	pb.buf		= buf.data();
 	pb.buf_size = static_cast<int>(buf.size());


### PR DESCRIPTION
CasparCG doesn't compile with GCC 5.1.1 and above - problem is related to modules/ffmpeg/producer/util/util.cpp which in function
bool is_valid_file(const std::wstring& filename, bool only_video)
returns nullptr instead of proper bool (false).
Please apply this small fix.