### PR TITLE
[ffmpeg_producer] Add relative and "from end" seeking

### DIFF
--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -391,7 +391,7 @@ public:
 	std::future<std::wstring> call(const std::vector<std::wstring>& params) override
 	{
 		static const boost::wregex loop_exp(LR"(LOOP\s*(?<VALUE>\d?)?)", boost::regex::icase);
-		static const boost::wregex seek_exp(LR"(SEEK\s+(?<VALUE>\d+))", boost::regex::icase);
+		static const boost::wregex seek_exp(LR"(SEEK\s+(?<VALUE>(\+|-)?\d+)(\s+(?<WHENCE>REL|END))?)", boost::regex::icase);
 		static const boost::wregex length_exp(LR"(LENGTH\s+(?<VALUE>\d+)?)", boost::regex::icase);
 		static const boost::wregex start_exp(LR"(START\\s+(?<VALUE>\\d+)?)", boost::regex::icase);
 
@@ -409,8 +409,19 @@ public:
 		}
 		else if(boost::regex_match(param, what, seek_exp))
 		{
-			auto value = what["VALUE"].str();
-			input_.seek(boost::lexical_cast<uint32_t>(value));
+			auto value = boost::lexical_cast<uint32_t>(what["VALUE"].str());
+			auto whence = what["WHENCE"].str();
+
+			if(boost::iequals(whence, L"REL"))
+			{
+				value = file_frame_number() + value;
+			}
+			else if(boost::iequals(whence, L"END"))
+			{
+				value = file_nb_frames() - value;
+			}
+
+			input_.seek(value);
 		}
 		else if(boost::regex_match(param, what, length_exp))
 		{


### PR DESCRIPTION
This patch adds optional "REL" (relative) and "END" suffixes to the SEEK command to seek from the current position and from the end of the currently playing file.

So, one can do something like this:

`CALL 1-10 SEEK -30 REL`    to jump 30 frames back; or
`CALL 1-10 SEEK  60 REL`    to jump 60 frames forward

This essentially enables scrubbing. I ran the following:

    for i in `seq 1 100`; do casparcg-send "CALL 1-10 SEEK 30 REL"; done
    for i in `seq 1 100`; do casparcg-send "CALL 1-10 SEEK -30 REL"; done

and I saw that it was good. :)

Additionally, to jump to 30 seconds before the end of the video, one can do:

`CALL 1-10 SEEK 900 END` (assuming 30fps)

This is useful, when doing a run-through of an event and wanting to skip to the end of the video.