### PR TITLE
Fix CPU hogging on EOF in ffmpeg producer.

### DIFF
--- a/modules/ffmpeg/producer/input/input.cpp
+++ b/modules/ffmpeg/producer/input/input.cpp
@@ -385,7 +385,7 @@ private:
 				{
 					boost::unique_lock<boost::mutex> lock(mutex_);
 
-					while(full() && !seek_target_ && is_running_)
+					while((eof_ || full()) && !seek_target_ && is_running_)
 						cond_.wait(lock);
 					
 					tick();


### PR DESCRIPTION
This PR fixes the CPU-usage going up when a file has finished playing in the ffmpeg-producer.

Related issue: #461