### PR TITLE
Support for playing rtmp video streams

### DIFF
--- a/core/producer/frame_producer.h
+++ b/core/producer/frame_producer.h
@@ -158,6 +158,9 @@ public:
 	spl::shared_ptr<core::frame_producer> create_producer(const frame_producer_dependencies&, const std::vector<std::wstring>& params) const;
 	spl::shared_ptr<core::frame_producer> create_producer(const frame_producer_dependencies&, const std::wstring& params) const;
 	draw_frame create_thumbnail(const frame_producer_dependencies&, const std::wstring& media_file) const;
+
+	static bool filename_is_url(std::wstring const& s);
+
 private:
 	struct impl;
 	spl::shared_ptr<impl> impl_;

--- a/modules/ffmpeg/ffmpeg_pipeline.cpp
+++ b/modules/ffmpeg/ffmpeg_pipeline.cpp
@@ -37,6 +37,7 @@ ffmpeg_pipeline::ffmpeg_pipeline()
 
 ffmpeg_pipeline			ffmpeg_pipeline::graph(spl::shared_ptr<caspar::diagnostics::graph> g)													{ impl_->graph(std::move(g)); return *this; }
 ffmpeg_pipeline			ffmpeg_pipeline::from_file(std::string filename)																		{ impl_->from_file(std::move(filename)); return *this; }
+ffmpeg_pipeline			ffmpeg_pipeline::from_url(std::string url)																				{ impl_->from_url(std::move(url)); return *this; }
 ffmpeg_pipeline			ffmpeg_pipeline::from_memory_only_audio(int num_channels, int samplerate)												{ impl_->from_memory_only_audio(num_channels, samplerate); return *this; }
 ffmpeg_pipeline			ffmpeg_pipeline::from_memory_only_video(int width, int height, boost::rational<int> framerate)							{ impl_->from_memory_only_video(width, height, std::move(framerate)); return *this; }
 ffmpeg_pipeline			ffmpeg_pipeline::from_memory(int num_channels, int samplerate, int width, int height, boost::rational<int> framerate)	{ impl_->from_memory(num_channels, samplerate, width, height, std::move(framerate)); return *this; }

--- a/modules/ffmpeg/ffmpeg_pipeline.h
+++ b/modules/ffmpeg/ffmpeg_pipeline.h
@@ -46,6 +46,7 @@ public:
 	ffmpeg_pipeline			graph(spl::shared_ptr<caspar::diagnostics::graph> g);
 
 	ffmpeg_pipeline			from_file(std::string filename);
+	ffmpeg_pipeline			from_url(std::string url);
 	ffmpeg_pipeline			from_memory_only_audio(int num_channels, int samplerate);
 	ffmpeg_pipeline			from_memory_only_video(int width, int height, boost::rational<int> framerate);
 	ffmpeg_pipeline			from_memory(int num_channels, int samplerate, int width, int height, boost::rational<int> framerate);

--- a/modules/ffmpeg/ffmpeg_pipeline_backend.h
+++ b/modules/ffmpeg/ffmpeg_pipeline_backend.h
@@ -37,6 +37,7 @@ struct ffmpeg_pipeline_backend
 	virtual void					graph(spl::shared_ptr<caspar::diagnostics::graph> g) = 0;
 
 	virtual void					from_file(std::string filename) = 0;
+	virtual void					from_url(std::string filename) = 0;
 	virtual void					from_memory_only_audio(int num_channels, int samplerate) = 0;
 	virtual void					from_memory_only_video(int width, int height, boost::rational<int> framerate) = 0;
 	virtual void					from_memory(int num_channels, int samplerate, int width, int height, boost::rational<int> framerate) = 0;

--- a/modules/ffmpeg/ffmpeg_pipeline_backend_internal.cpp
+++ b/modules/ffmpeg/ffmpeg_pipeline_backend_internal.cpp
@@ -412,6 +412,41 @@ private:
 	}
 };
 
+
+class stream_source : public file_source
+{
+public:
+	stream_source(std::string url)
+		: file_source(url)
+	{
+	}
+
+	void start_frame(std::uint32_t frame) override
+	{
+		// Can't seek in a stream
+	}
+
+	std::uint32_t start_frame() const override
+	{
+		return 0;
+	}
+
+	void length(std::uint32_t frames) override
+	{
+		// Can't set length of a stream
+	}
+
+	std::uint32_t length() const override
+	{
+		return std::numeric_limits<uint32_t>::max();
+	}
+
+	void seek(std::uint32_t frame) override
+	{
+		// Can't seek in a stream
+	}
+};
+
 class memory_source : public source
 {
 	int															samplerate_		= -1;
@@ -941,6 +976,14 @@ public:
 		source_->graph(graph_);
 	}
 
+	void from_url(std::string url) override
+	{
+		source_ = spl::make_unique<stream_source>(std::move(url));
+		try_push_audio_ = std::function<bool(caspar::array<const std::int32_t>)>();
+		try_push_video_ = std::function<bool(caspar::array<const std::uint8_t>)>();
+		source_->graph(graph_);
+	}
+
 	void from_memory_only_audio(int num_channels, int samplerate) override
 	{
 		auto source		= spl::make_unique<memory_source>();
@@ -1329,3 +1372,4 @@ spl::shared_ptr<struct ffmpeg_pipeline_backend> create_internal_pipeline()
 }
 
 }}
+


### PR DESCRIPTION
This adds support for playing video streams (rtmp/http/udp etc) through ffmpeg.

Inspired by #131 

Note: Only works for streams with 48K audio, as normal video playback was failing when resampling is required (#451)