### PR TITLE
Linux hdv dv camera support

### DIFF
--- a/dependencies64/ffmpeg/README.txt
+++ b/dependencies64/ffmpeg/README.txt
@@ -32,6 +32,7 @@ This FFmpeg build was configured with:
   --enable-libfreetype
   --enable-libgme
   --enable-libgsm
+  --enable-libiec61883
   --enable-libilbc
   --enable-libmodplug
   --enable-libmp3lame

--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -615,7 +615,7 @@ void describe_producer(core::help_sink& sink, const core::help_repository& repo)
 		->text(L"H.264, FLV, WMV and several audio codecs as well as uncompressed audio.");
 	sink.definitions()
 		->item(L"clip", L"The file without the file extension to play. It should reside under the media folder.")
-		->item(L"url", L"If clip contains :// it is instead treated as the URL parameter. The URL can either be any streaming protocol supported by FFmpeg, dshow://video={webcam_name} or v4l2://{video device}.")
+		->item(L"url", L"If clip contains :// it is instead treated as the URL parameter. The URL can either be any streaming protocol supported by FFmpeg, dshow://video={webcam_name} or v4l2://{video device} or iec61883://{auto}.")
 		->item(L"loop", L"Will cause the media file to loop between start and start + length")
 		->item(L"start", L"Optionally sets the start frame. 0 by default. If loop is specified this will be the frame where it starts over again.")
 		->item(L"length", L"Optionally sets the length of the clip. If not specified the clip will be played to the end. If loop is specified the file will jump to start position once this number of frames has been played.")
@@ -635,6 +635,7 @@ void describe_producer(core::help_sink& sink, const core::help_repository& repo)
 	sink.example(L">> PLAY 1-10 rtmp://example.com/live/stream", L"to play an RTMP stream.");
 	sink.example(L">> PLAY 1-10 \"dshow://video=Live! Cam Chat HD VF0790\"", L"to use a web camera as video input on Windows.");
 	sink.example(L">> PLAY 1-10 v4l2:///dev/video0", L"to use a web camera as video input on Linux.");
+	sink.example(L">> PLAY 1-10 iec61883://auto", L"to use a FireWire (H)DV video device as video input on Linux.");
 	sink.para()->text(L"The FFmpeg producer also supports changing some of the settings via ")->code(L"CALL")->text(L":");
 	sink.example(L">> CALL 1-10 LOOP 1");
 	sink.example(L">> CALL 1-10 START 10");

--- a/modules/ffmpeg/producer/input/input.cpp
+++ b/modules/ffmpeg/producer/input/input.cpp
@@ -264,7 +264,7 @@ struct input::implementation : boost::noncopyable
 		auto path					= parts.at(1);
 		AVInputFormat* input_format	= nullptr;
 
-		static const std::set<std::wstring> PROTOCOLS_TREATED_AS_FORMATS = { L"dshow", L"v4l2" };
+		static const std::set<std::wstring> PROTOCOLS_TREATED_AS_FORMATS = { L"dshow", L"v4l2", L"iec61883" };
 
 		if (protocol.empty())
 			resource_name = path;


### PR DESCRIPTION
To complement the v4l2 patch https://github.com/CasparCG/Server/commit/c4e32e6af54000d4ef22b74e4c29529151f695e1 by adding (H)DV FireWire 1394 video device support.

Since I couldn't find a good place to describe the ffmpeg changes, I just added it to the dependencies64/ffmpeg/README.txt see comments about "--enable-libiec61883" and required packages for compiling ffmpeg.

Hope this is in time for the 2.1.0 beta 2?