### PR TITLE
Remove platform name from linux build script

### DIFF
--- a/build-scripts/build-linux.sh
+++ b/build-scripts/build-linux.sh
@@ -25,7 +25,7 @@ cd ../build || fail "Could not enter ../build"
 
 # Run cmake
 echo Running cmake...
-cmake -G "Unix Makefiles" -A x64 -DCMAKE_BUILD_TYPE=RelWithDebInfo .. || fail "cmake failed"
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=RelWithDebInfo .. || fail "cmake failed"
 
 # Run make using the number of hardware threads in BUILD_PARALLEL_THREADS
 echo Building...


### PR DESCRIPTION
Option "-A x64" throws error:
Generator Unix Makefiles does not support platform specification, but platform x64 was specified.
Removing this option allows mi to run script without problems.
According to docs only "Visual Studio" generator supports this option, so it probably should be removed for "Unix Makefiles" generator.
https://cmake.org/cmake/help/v3.2/manual/cmake.1.html