### PR TITLE
Fix ffmpeg build dependencies on clean ubuntu desktop amd64 14.04.3 or higher

### DIFF
--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+#compile ffmpeg successful on ubuntu 14.04.3 & 16.04.1 amd64 using the CasparCG build requirments described here:
+#https://raw.githubusercontent.com/casparcg/Server/2.1.0/BUILDING
 
-sudo apt-get install build-essential curl tar pkg-config
+sudo apt-get -y update
+sudo apt-get -y upgrade
+sudo apt-get -y install build-essential curl tar pkg-config python2.7-dev zlib1g-dev autoconf libtool subversion libfontconfig1-dev ant default-jre default-jdk frei0r-plugins-dev libv4l-dev
 
 ./build.sh

--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
@@ -3,7 +3,6 @@
 #https://raw.githubusercontent.com/casparcg/Server/2.1.0/BUILDING
 
 sudo apt-get -y update
-sudo apt-get -y upgrade
-sudo apt-get -y install build-essential curl tar pkg-config python2.7-dev zlib1g-dev autoconf libtool subversion libfontconfig1-dev ant default-jre default-jdk frei0r-plugins-dev libv4l-dev
+sudo apt-get -y install curl tar pkg-config python2.7-dev zlib1g-dev autoconf libtool subversion libfontconfig1-dev ant default-jre default-jdk frei0r-plugins-dev libv4l-dev
 
 ./build.sh

--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
@@ -451,8 +451,9 @@ make -j $jval && make install
 
 #dirty hack
 #replace shipped ffmpeg linux libs with compiled ones from here!
-cd $BUILD_DIR
-mv ../../bin/linux ../../bin/linux-shipped
-cp -r ../target/lib ../../bin/linux
+#also check modules/ffmpeg/CMakeLists.txt for lib version/name changes!
+#cd $BUILD_DIR
+#mv ../../bin/linux ../../bin/linux-shipped
+#cp -r ../target/lib ../../bin/linux
 #some ffmpeg libs are build in a different shared target folder
-cp ../target/usr/local/lib/* ../../bin/linux/
+#cp ../target/usr/local/lib/* ../../bin/linux/

--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
@@ -448,3 +448,11 @@ CFLAGS="-I$TARGET_DIR/include -I$TARGET_DIR/usr/local/include" LDFLAGS="-L$TARGE
 	--enable-libv4l2 \
 	--enable-zlib
 make -j $jval && make install
+
+#dirty hack
+#replace shipped ffmpeg linux libs with compiled ones from here!
+cd $BUILD_DIR
+mv ../../bin/linux ../../bin/linux-shipped
+cp -r ../target/lib ../../bin/linux
+#some ffmpeg libs are build in a different shared target folder
+cp ../target/usr/local/lib/* ../../bin/linux/

--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
@@ -40,7 +40,7 @@ mkdir -p "$BUILD_DIR" "$TARGET_DIR"
 echo "#### FFmpeg static build, by STVS SA ####"
 cd $BUILD_DIR
 ../fetchurl "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz"
-../fetchurl "http://zlib.net/zlib-1.2.8.tar.gz"
+../fetchurl "http://www.zlib.net/fossils/zlib-1.2.8.tar.gz"
 ../fetchurl "http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz"
 #../fetchurl "http://downloads.sf.net/project/libpng/libpng15/older-releases/1.5.14/libpng-1.5.14.tar.gz"
 ../fetchurl "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"


### PR DESCRIPTION
To fix commit 8fcbd65d178c051bd1ead43be5c746dad84e02b0 and form a base for building the current ffmpeg libs used on ubuntu linux so ffmpeg required changes like extra compile flags for DV/HDV could be added later with more ease and control.

PS: libiec61883 DV/HDV firewire camere support will be added in a new Pull request based using this one as base!