### PR TITLE
linux DV/HDV video device support

### DIFF
--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build-ubuntu.sh
@@ -2,6 +2,6 @@
 #compile ffmpeg successful on ubuntu 14.04.3 & 16.04.1 amd64 using the CasparCG build requirments described here:
 #https://raw.githubusercontent.com/casparcg/Server/2.1.0/BUILDING
 
-sudo apt-get -y install curl tar pkg-config python2.7-dev zlib1g-dev autoconf libtool subversion libfontconfig1-dev ant default-jre default-jdk frei0r-plugins-dev libv4l-dev
+sudo apt-get -y install curl tar pkg-config python2.7-dev zlib1g-dev autoconf libtool subversion libfontconfig1-dev ant default-jre default-jdk frei0r-plugins-dev libv4l-dev libiec61883-dev libavc1394-dev
 
 ./build.sh

--- a/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
+++ b/dependencies64/ffmpeg/ffmpeg-build-linux/build.sh
@@ -419,6 +419,7 @@ CFLAGS="-I$TARGET_DIR/include -I$TARGET_DIR/usr/local/include" LDFLAGS="-L$TARGE
 	--enable-libfreetype \
 	--enable-libgme \
 	--enable-libgsm \
+	--enable-libiec61883 \
 	--enable-libilbc \
 	--enable-libmodplug \
 	--enable-libmp3lame \

--- a/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -633,7 +633,7 @@ void describe_producer(core::help_sink& sink, const core::help_repository& repo)
 		->text(L"H.264, FLV, WMV and several audio codecs as well as uncompressed audio.");
 	sink.definitions()
 		->item(L"clip", L"The file without the file extension to play. It should reside under the media folder.")
-		->item(L"url", L"If clip contains :// it is instead treated as the URL parameter. The URL can either be any streaming protocol supported by FFmpeg, dshow://video={webcam_name} or v4l2://{video device}.")
+		->item(L"url", L"If clip contains :// it is instead treated as the URL parameter. The URL can either be any streaming protocol supported by FFmpeg, dshow://video={webcam_name} or v4l2://{video device} or iec61883://{auto}.")
 		->item(L"loop", L"Will cause the media file to loop between in and out.")
 		->item(L"in", L"Optionally sets the first frame. 0 by default. If loop is specified, this will be the frame where it starts over again.")
 		->item(L"out", L"Optionally sets the last frame. If not specified the clip will be played to the end. If loop is specified, the file will jump to start position once it reaches the last frame.")
@@ -654,6 +654,7 @@ void describe_producer(core::help_sink& sink, const core::help_repository& repo)
 	sink.example(L">> PLAY 1-10 rtmp://example.com/live/stream", L"to play an RTMP stream.");
 	sink.example(L">> PLAY 1-10 \"dshow://video=Live! Cam Chat HD VF0790\"", L"to use a web camera as video input on Windows.");
 	sink.example(L">> PLAY 1-10 v4l2:///dev/video0", L"to use a web camera as video input on Linux.");
+	sink.example(L">> PLAY 1-10 iec61883://auto", L"to use a FireWire (H)DV video device as video input on Linux.");
 	sink.para()->text(L"The FFmpeg producer also supports changing some of the settings via ")->code(L"CALL")->text(L":");
 	sink.example(L">> CALL 1-10 LOOP 1");
 	sink.example(L">> CALL 1-10 IN 10");

--- a/modules/ffmpeg/producer/input/input.cpp
+++ b/modules/ffmpeg/producer/input/input.cpp
@@ -259,7 +259,7 @@ struct input::impl : boost::noncopyable
 		auto path					= parts.at(1);
 		AVInputFormat* input_format	= nullptr;
 
-		static const std::set<std::wstring> PROTOCOLS_TREATED_AS_FORMATS = { L"dshow", L"v4l2" };
+		static const std::set<std::wstring> PROTOCOLS_TREATED_AS_FORMATS = { L"dshow", L"v4l2", L"iec61883" };
 
 		if (protocol.empty())
 			resource_name = path;


### PR DESCRIPTION
Add ffmpeg linux build dependencies and build flag for DV/HDV video devices using iec61883.
Add ffmpeg producer support using the same URL parameter as v4l2 instead use iec61883 and simple usage example.

The old pull request #502 can/will be dropped if this is committed!
