### PR TITLE
Add *.ts extension to media whitelist

### DIFF
--- a/modules/ffmpeg/producer/util/util.cpp
+++ b/modules/ffmpeg/producer/util/util.cpp
@@ -581,7 +581,8 @@ bool is_valid_file(const std::wstring& filename, bool only_video)
 		L".h264",
 		L".prores",
 		L".mkv",
-		L".mxf"
+		L".mxf",
+		L".ts"
 	};
 
 	auto ext = boost::to_lower_copy(boost::filesystem::path(filename).extension().wstring());


### PR DESCRIPTION
This is a pull request for adding a possibility to play MPEG-2 (*.ts) files from media folder.

I have tested some files with the commands used to manage these files (LOADBG, PLAY etc.), everything looks working fine. 