### PR TITLE
Changes to info() to make 2.1.0 the same as 2.0.7

### DIFF
--- a/core/producer/separated/separated_producer.cpp
+++ b/core/producer/separated/separated_producer.cpp
@@ -116,7 +116,11 @@ public:
 
 	boost::property_tree::wptree info() const override
 	{
-		return fill_producer_->info();;
+		boost::property_tree::wptree info;
+		info.add(L"type", L"separated-producer");
+		info.add_child(L"fill.producer",	fill_producer_->info());
+		info.add_child(L"key.producer",	key_producer_->info());
+		return info;
 	}
 
 	monitor::subject& monitor_output() { return *monitor_subject_; }

--- a/core/producer/transition/transition_producer.cpp
+++ b/core/producer/transition/transition_producer.cpp
@@ -144,7 +144,11 @@ public:
 
 	boost::property_tree::wptree info() const override
 	{
-		return dest_producer_->info();
+		boost::property_tree::wptree info;
+		info.add(L"type", L"transition-producer");
+		info.add_child(L"source.producer",	   source_producer_->info());
+		info.add_child(L"destination.producer", dest_producer_->info());
+		return info;
 	}
 
 	std::future<std::wstring> call(const std::vector<std::wstring>& params) override


### PR DESCRIPTION
Changes to info() in separated and transition producers to make the output of "info #" the same as in 2.0.7, the main reason Is to bring it in line, and to make justmacros and a couple of other tools I use work correctly.


The original differences are below, 2.1 is missing key/fill info and transition-producer info

here are the original differences
2.0
```
<channel>
   <video-mode>PAL</video-mode>
   <stage>
      <layers>
         <layer>
            <status>playing</status>
            <auto_delta>0</auto_delta>
            <frame-number>52</frame-number>
            <nb_frames>260</nb_frames>
            <frames-left>208</frames-left>
            <frame-age>44</frame-age>
            <foreground>
               <producer>
                  <type>separated-producer</type>
                  <fill>
                     <producer>
                        <type>ffmpeg-producer</type>
                        <filename>media\CG1080i50.mp4</filename>
                        <width>1920</width>
                        <height>1080</height>
                        <progressive>true</progressive>
                        <fps>25</fps>
                        <loop>false</loop>
                        <frame-number>52</frame-number>
                        <nb-frames>260</nb-frames>
                        <file-frame-number>52</file-frame-number>
                        <file-nb-frames>260</file-nb-frames>
                     </producer>
                  </fill>
                  <key>
                     <producer>
                        <type>ffmpeg-producer</type>
                        <filename>media\CG1080i50_A.mp4</filename>
                        <width>1920</width>
                        <height>1080</height>
                        <progressive>true</progressive>
                        <fps>25</fps>
                        <loop>false</loop>
                        <frame-number>52</frame-number>
                        <nb-frames>260</nb-frames>
                        <file-frame-number>52</file-frame-number>
                        <file-nb-frames>260</file-nb-frames>
                     </producer>
                  </key>
               </producer>
            </foreground>
            <background>
               <producer>
                  <type>transition-producer</type>
                  <source>
                     <producer>
                        <type>empty-producer</type>
                     </producer>
                  </source>
                  <destination>
                     <producer>
                        <type>separated-producer</type>
                        <fill>
                           <producer>
                              <type>ffmpeg-producer</type>
                              <filename>media\CG1080i50.mp4</filename>
                              <width>1920</width>
                              <height>1080</height>
                              <progressive>true</progressive>
                              <fps>25</fps>
                              <loop>false</loop>
                              <frame-number>0</frame-number>
                              <nb-frames>260</nb-frames>
                              <file-frame-number>0</file-frame-number>
                              <file-nb-frames>260</file-nb-frames>
                           </producer>
                        </fill>
                        <key>
                           <producer>
                              <type>ffmpeg-producer</type>
                              <filename>media\CG1080i50_A.mp4</filename>
                              <width>1920</width>
                              <height>1080</height>
                              <progressive>false</progressive>
                              <fps>25</fps>
                              <loop>false</loop>
                              <frame-number>0</frame-number>
                              <nb-frames>260</nb-frames>
                              <file-frame-number>0</file-frame-number>
                              <file-nb-frames>260</file-nb-frames>
                           </producer>
                        </key>
                     </producer>
                  </destination>
               </producer>
            </background>
            <index>1</index>
         </layer>
      </layers>
   </stage>
   <mixer>
      <mix-time>19</mix-time>
   </mixer>
   <output>
      <consumers>
         <consumer>
            <type>oal-consumer</type>
            <index>500</index>
         </consumer>
         <consumer>
            <type>ogl-consumer</type>
            <key-only>false</key-only>
            <windowed>true</windowed>
            <auto-deinterlace>true</auto-deinterlace>
            <index>600</index>
         </consumer>
      </consumers>
   </output>
   <index>0</index>
</channel>
```
2.1
```
<channel>
   <video-mode>PAL</video-mode>
   <audio-channel-layout>[audio_channel_layout] num_channels=2 type=STEREO channel_order=FL FR</audio-channel-layout>
   <stage>
      <layers>
         <layer>
            <auto_delta>0</auto_delta>
            <frame-number>218</frame-number>
            <nb_frames>260</nb_frames>
            <frames-left>42</frames-left>
            <frame-age>82</frame-age>
            <foreground>
               <producer>
                  <type>ffmpeg-producer</type>
                  <filename>media\CG1080i50.mp4</filename>
                  <width>1920</width>
                  <height>1080</height>
                  <progressive>true</progressive>
                  <fps>25</fps>
                  <loop>false</loop>
                  <frame-number>218</frame-number>
                  <nb-frames>260</nb-frames>
                  <file-frame-number>219</file-frame-number>
                  <file-nb-frames>260</file-nb-frames>
               </producer>
            </foreground>
            <background>
               <producer>
                  <type>ffmpeg-producer</type>
                  <filename>media\CG1080i50.mp4</filename>
                  <width>1920</width>
                  <height>1080</height>
                  <progressive>true</progressive>
                  <fps>25</fps>
                  <loop>false</loop>
                  <frame-number>0</frame-number>
                  <nb-frames>4294967295</nb-frames>
                  <file-frame-number>0</file-frame-number>
                  <file-nb-frames>260</file-nb-frames>
               </producer>
            </background>
            <index>1</index>
         </layer>
      </layers>
   </stage>
   <mixer>
      <mix-time>1</mix-time>
   </mixer>
   <output>
      <consumers>
         <consumer>
            <type>system-audio</type>
            <index>500</index>
         </consumer>
         <consumer>
            <type>screen</type>
            <key-only>false</key-only>
            <windowed>true</windowed>
            <auto-deinterlace>true</auto-deinterlace>
            <vsync>false</vsync>
            <index>600</index>
         </consumer>
      </consumers>
   </output>
   <index>0</index>
</channel>
```



