### PR TITLE
Fix #623 (prec_timer running fast) by increasing prec_timer resolution

### DIFF
--- a/common/os/linux/prec_timer.cpp
+++ b/common/os/linux/prec_timer.cpp
@@ -39,9 +39,8 @@ prec_timer::prec_timer()
 {
 }
 
-void prec_timer::tick_millis(int64_t ticks_to_wait)
+void prec_timer::tick_nanos(int64_t ticks_to_wait)
 {
-	ticks_to_wait *= 1000000;
 	auto t = duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch()).count();
 
 	if (time_ != 0)

--- a/common/os/windows/prec_timer.cpp
+++ b/common/os/windows/prec_timer.cpp
@@ -23,9 +23,11 @@
 
 #include "../../prec_timer.h"
 
+#include <boost/chrono/system_clocks.hpp>
+
 #include "windows.h"
 
-#include <Mmsystem.h>
+using namespace boost::chrono;
 
 namespace caspar {
 	
@@ -34,9 +36,9 @@ prec_timer::prec_timer()
 {
 }
 
-void prec_timer::tick_millis(int64_t ticks_to_wait)
+void prec_timer::tick_nanos(int64_t ticks_to_wait)
 {
-	auto t = ::timeGetTime();
+	auto t = duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch()).count();
 
 	if (time_ != 0)
 	{
@@ -59,14 +61,14 @@ void prec_timer::tick_millis(int64_t ticks_to_wait)
 				// otherwise, do a few Sleep(0)'s, which just give up the timeslice,
 				//   but don't really save cpu or battery, but do pass a tiny
 				//   amount of time.
-				if (ticks_left > 2)
+				if (ticks_left > 2000000)
 					Sleep(1);
 				else
 					for (int i = 0; i < 10; ++i)
 						Sleep(0);  // causes thread to give up its timeslice
 			}
 
-			t = ::timeGetTime();
+			t = duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch()).count();
 		} while (!done);
 	}
 

--- a/common/prec_timer.h
+++ b/common/prec_timer.h
@@ -32,15 +32,20 @@ public:
 
 	void tick(double interval)
 	{
-		tick_millis(static_cast<int64_t>(interval * 1000.0));
+		tick_nanos(static_cast<int64_t>(interval * 1000000000.0));
+	}
+	
+	void tick_millis(int64_t interval)
+	{
+		tick_nanos(interval * 1000000);
 	}
 
 	// Author: Ryan M. Geiss
 	// http://www.geisswerks.com/ryan/FAQS/timing.html
-	void tick_millis(int64_t interval);
+	void tick_nanos(int64_t interval);
 
 private:	
-	unsigned long time_;
+	int64_t time_;
 };
 
 


### PR DESCRIPTION
Fixes issue #623.

Here's a detailed list of changes:
- Switched to boost high_resolution_clock in the Windows implementation of prec_timer.
- Changed tick_millis to tick_nanos, which accepts nanoseconds instad of milliseconds.
- Changed time_ in prec_timer.h from an unsigned long to a 64-bit int, because an unsigned long is only guaranteed to be a 32-bit int, which is too small to contain nanoseconds since UNIX epoch. I guess it must have already been compiling to a 64-bit integer on Linux, though.
- ~Increased minimum remaining time to perform a Sleep(1) from 2 ms to 20 ms on Windows, because Sleep(1) may sleep for up to 16 ms. An alternative fix could have been to call [timeBeginPeriod](https://msdn.microsoft.com/en-us/library/windows/desktop/dd757624(v=vs.85).aspx) during initialization.~ (Looks like this is already being called, so I left the min time at 2 ms (2000000 ns).)

Note that I have not tried compiling this on Linux.