### PR TITLE
Ability to sent data through OSC inside a flash template

### DIFF
--- a/modules/flash/producer/FlashAxContainer.cpp
+++ b/modules/flash/producer/FlashAxContainer.cpp
@@ -21,6 +21,7 @@
 
 #include "../stdafx.h"
 
+#include <core/monitor/monitor.h>
 #include "FlashAxContainer.h"
 #include "../interop/TimerHelper.h"
 
@@ -727,7 +728,7 @@ bool FlashAxContainer::CheckForFlashSupport()
 
 HRESULT FlashAxContainer::CreateAxControl()
 {
-	CLSID clsid;
+	CLSID clsid;	
 	HRESULT hr = CLSIDFromString((LPOLESTR)flashGUID_, &clsid); 
 	if(SUCCEEDED(hr))
 		hr = CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER, __uuidof(IUnknown), (void**)&m_spUnknown);
@@ -851,6 +852,11 @@ void FlashAxContainer::SetSize(size_t width, size_t height) {
 		bInvalidRect_ = true;
 	}
 }
+
+void FlashAxContainer::SetMonitor(core::monitor::subject& monitor_subject) {
+	monitor_subject_ = monitor_subject;
+}
+
 
 HRESULT FlashAxContainer::QueryControl(REFIID iid, void** ppUnk)
 {

--- a/modules/flash/producer/FlashAxContainer.cpp
+++ b/modules/flash/producer/FlashAxContainer.cpp
@@ -21,7 +21,7 @@
 
 #include "../stdafx.h"
 
-#include <core/monitor/monitor.h>
+#include "core/monitor/monitor.h"
 #include "FlashAxContainer.h"
 #include "../interop/TimerHelper.h"
 
@@ -619,7 +619,9 @@ void STDMETHODCALLTYPE FlashAxContainer::OnFlashCall(BSTR request)
 	else if(str.find(L"Activity") != std::wstring::npos)
 	{
 		CASPAR_LOG(debug) << print_() << L" [activity]     " << str;
-
+		if (monitor_subject_) {
+			*monitor_subject_ << core::monitor::message("/flashtrace") % str;
+		}
 		//this is how templatehost 1.7 reports that a command has been received
 		if(str.find(L"Command recieved") != std::wstring::npos)
 			bCallSuccessful_ = true;
@@ -853,7 +855,7 @@ void FlashAxContainer::SetSize(size_t width, size_t height) {
 	}
 }
 
-void FlashAxContainer::SetMonitor(core::monitor::subject& monitor_subject) {
+void FlashAxContainer::SetMonitor(core::monitor::subject* monitor_subject) {
 	monitor_subject_ = monitor_subject;
 }
 

--- a/modules/flash/producer/FlashAxContainer.h
+++ b/modules/flash/producer/FlashAxContainer.h
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include <core/video_format.h>
+#include <core/monitor/monitor.h>
 #include "../interop/axflash.h"
 //#import "progid:ShockwaveFlash.ShockwaveFlash.9" no_namespace, named_guids
 
@@ -258,6 +259,7 @@ public:
 	bool IsEmpty() const { return bIsEmpty_; }
 
 	void SetSize(size_t width, size_t height);
+	void SetMonitor(core::monitor::subject& monitor_subject);
 	bool IsReadyToRender() const;
 	void EnterFullscreen();
 
@@ -273,6 +275,7 @@ private:
 	volatile bool bReadyToRender_;
 	volatile bool bIsEmpty_;
 	volatile bool bHasNewTiming_;
+	core::monitor::subject monitor_subject_;
 	//std::vector<DirtyRect> bDirtyRects_;
 
 

--- a/modules/flash/producer/FlashAxContainer.h
+++ b/modules/flash/producer/FlashAxContainer.h
@@ -259,7 +259,7 @@ public:
 	bool IsEmpty() const { return bIsEmpty_; }
 
 	void SetSize(size_t width, size_t height);
-	void SetMonitor(core::monitor::subject& monitor_subject);
+	void SetMonitor(core::monitor::subject* monitor_subject);
 	bool IsReadyToRender() const;
 	void EnterFullscreen();
 
@@ -275,7 +275,7 @@ private:
 	volatile bool bReadyToRender_;
 	volatile bool bIsEmpty_;
 	volatile bool bHasNewTiming_;
-	core::monitor::subject monitor_subject_;
+	core::monitor::subject* monitor_subject_;
 	//std::vector<DirtyRect> bDirtyRects_;
 
 

--- a/modules/flash/producer/flash_producer.cpp
+++ b/modules/flash/producer/flash_producer.cpp
@@ -239,6 +239,7 @@ public:
 			CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to Set Scale Mode"));
 						
 		ax_->SetSize(width_, height_);
+		ax_->SetMonitor(monitor_subject_);
 		render_frame(0.0);
 
 		CASPAR_LOG(info) << print() << L" Initialized.";

--- a/modules/flash/producer/flash_producer.cpp
+++ b/modules/flash/producer/flash_producer.cpp
@@ -239,7 +239,7 @@ public:
 			CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to Set Scale Mode"));
 						
 		ax_->SetSize(width_, height_);
-		ax_->SetMonitor(monitor_subject_);
+		ax_->SetMonitor(&monitor_subject_);
 		render_frame(0.0);
 
 		CASPAR_LOG(info) << print() << L" Initialized.";


### PR DESCRIPTION
Add ability to broadcast data from a flash template out through OSC.  This is still experimental but you should be able to call TraceToLog(someString); from a flash template and it will get sent over OSC to the path /CHANNEL/#/STAGE/LAYER/####/FLASHTRACE