### PR TITLE
Safely parse predefined OSC addresses

### DIFF
--- a/shell/server.cpp
+++ b/shell/server.cpp
@@ -345,10 +345,15 @@ struct server::impl : boost::noncopyable
 						ptree_get<std::wstring>(predefined_client.second, L"address");
 				const auto port =
 						ptree_get<unsigned short>(predefined_client.second, L"port");
-				predefined_osc_subscriptions_.push_back(
+
+				boost::system::error_code ec;
+				auto ipaddr = address_v4::from_string(u8(address), ec);
+				if (!ec)
+					predefined_osc_subscriptions_.push_back(
 						osc_client_->get_subscription_token(udp::endpoint(
-								address_v4::from_string(u8(address)),
-								port)));
+							ipaddr, port)));
+				else
+					CASPAR_LOG(warning) << "Invalid OSC client. Must be valid ipv4 address: " << address;
 			}
 		}
 


### PR DESCRIPTION
Fixes #634 where a vague exception is thrown if the address is not a valid ipv4 address.

Example config:
```
[2017-11-06 20:56:59.299] [10396] [info]       <osc>
[2017-11-06 20:56:59.299] [10396] [info]          <default-port>6250</default-port>
[2017-11-06 20:56:59.299] [10396] [info]          <predefined-clients>
[2017-11-06 20:56:59.299] [10396] [info]             <predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]                <address>10.42.13.110</address>
[2017-11-06 20:56:59.299] [10396] [info]                <port>5253</port>
[2017-11-06 20:56:59.299] [10396] [info]             </predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]             <predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]                <address>127.0.0.1</address>
[2017-11-06 20:56:59.299] [10396] [info]                <port>5253</port>
[2017-11-06 20:56:59.299] [10396] [info]             </predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]             <predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]                <address>localhost</address>
[2017-11-06 20:56:59.299] [10396] [info]                <port>5253</port>
[2017-11-06 20:56:59.299] [10396] [info]             </predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]             <predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]                <address>nope.home</address>
[2017-11-06 20:56:59.299] [10396] [info]                <port>5253</port>
[2017-11-06 20:56:59.299] [10396] [info]             </predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]             <predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]                <address>nope.1.2.3</address>
[2017-11-06 20:56:59.299] [10396] [info]                <port>5253</port>
[2017-11-06 20:56:59.299] [10396] [info]             </predefined-client>
[2017-11-06 20:56:59.299] [10396] [info]          </predefined-clients>
[2017-11-06 20:56:59.299] [10396] [info]       </osc>
```
Output:
```
[2017-11-06 20:56:59.799] [10396] [info]    Initialized controllers.
[2017-11-06 20:56:59.799] [10396] [warning] Invalid OSC client. Must be valid ipv4 address: localhost
[2017-11-06 20:56:59.799] [10396] [warning] Invalid OSC client. Must be valid ipv4 address: nope.home
[2017-11-06 20:56:59.799] [10396] [warning] Invalid OSC client. Must be valid ipv4 address: nope.1.2.3
[2017-11-06 20:56:59.799] [10396] [info]    Initialized osc.
[2017-11-06 20:56:59.800] [10396] [info]    Started initial media information retrieval.
```