### PR TITLE
[image_consumer] Un-multiply frame colours before writing png to file

### DIFF
--- a/modules/image/consumer/image_consumer.cpp
+++ b/modules/image/consumer/image_consumer.cpp
@@ -47,6 +47,7 @@
 #include <algorithm>
 
 #include "../util/image_view.h"
+#include "image/util/image_algorithms.h"
 
 namespace caspar { namespace image {
 
@@ -112,6 +113,10 @@ public:
 
 				auto bitmap = std::shared_ptr<FIBITMAP>(FreeImage_Allocate(static_cast<int>(frame.width()), static_cast<int>(frame.height()), 32), FreeImage_Unload);
 				std::memcpy(FreeImage_GetBits(bitmap.get()), frame.image_data().begin(), frame.image_data().size());
+
+				image_view<bgra_pixel> original_view(FreeImage_GetBits(bitmap.get()), static_cast<int>(frame.width()), static_cast<int>(frame.height()));
+				unmultiply(original_view);
+
 				FreeImage_FlipVertical(bitmap.get());
 #ifdef WIN32
 				FreeImage_SaveU(FIF_PNG, bitmap.get(), filename2.c_str(), 0);

--- a/modules/image/util/image_algorithms.h
+++ b/modules/image/util/image_algorithms.h
@@ -206,4 +206,36 @@ void premultiply(SrcDstView& view_to_modify)
 	});
 }
 
+/**
+* Un-multiply with alpha for each pixel in an ImageView. The modifications is
+* done in place. The pixel type of the ImageView must model the RGBAPixel
+* concept.
+*
+* @param view_to_modify The image view to unmultiply in place. Has to model
+*                       the ImageView concept and have a pixel type that
+*                       models RGBAPixel.
+*/
+template<class SrcDstView>
+void unmultiply(SrcDstView& view_to_modify)
+{
+	std::for_each(view_to_modify.begin(), view_to_modify.end(), [&](typename SrcDstView::pixel_type& pixel)
+	{
+		int alpha = static_cast<int>(pixel.a());
+
+		if (alpha != 0 && alpha != 255)
+		{
+			// We don't event try to premultiply 0 since it will be unaffected.
+			if (pixel.r())
+				pixel.r() = static_cast<uint8_t>(static_cast<int>(pixel.r()) * 255 / alpha);
+
+			if (pixel.g())
+				pixel.g() = static_cast<uint8_t>(static_cast<int>(pixel.g()) * 255 / alpha);
+
+			if (pixel.b())
+				pixel.b() = static_cast<uint8_t>(static_cast<int>(pixel.b()) * 255 / alpha);
+		}
+	});
+}
+
+
 }}


### PR DESCRIPTION
Fixes #648

https://drive.google.com/open?id=1huOSoaoawhlPin_D_gtlac-_LMu5Qlvt
