### PR TITLE
[mixer] Directional blur

### DIFF
--- a/core/frame/frame_transform.cpp
+++ b/core/frame/frame_transform.cpp
@@ -73,6 +73,8 @@ image_transform& image_transform::operator*=(const image_transform &other)
 
 	anchor[0]				+= other.anchor[0] * fill_scale[0];
 	anchor[1]				+= other.anchor[1] * fill_scale[1];
+	blur[0]					+= other.blur[0];
+	blur[1]					+= other.blur[1];
 	fill_translation[0]		+= rotated[0] * fill_scale[0];
 	fill_translation[1]		+= rotated[1] * fill_scale[1];
 	fill_scale[0]			*= other.fill_scale[0];
@@ -149,6 +151,8 @@ image_transform image_transform::tween(double time, const image_transform& sourc
 	result.opacity							= do_tween(time, source.opacity,							dest.opacity,							duration, tween);
 	result.anchor[0]						= do_tween(time, source.anchor[0],							dest.anchor[0],							duration, tween);
 	result.anchor[1]						= do_tween(time, source.anchor[1],							dest.anchor[1],							duration, tween);
+	result.blur[0]							= do_tween(time, source.blur[0],							dest.blur[0],							duration, tween);
+	result.blur[1]							= do_tween(time, source.blur[1],							dest.blur[1],							duration, tween);
 	result.fill_translation[0]				= do_tween(time, source.fill_translation[0],				dest.fill_translation[0],				duration, tween);
 	result.fill_translation[1]				= do_tween(time, source.fill_translation[1],				dest.fill_translation[1],				duration, tween);
 	result.fill_scale[0]					= do_tween(time, source.fill_scale[0],						dest.fill_scale[0],						duration, tween);
@@ -214,6 +218,7 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
 		eq(lhs.brightness, rhs.brightness) &&
 		eq(lhs.saturation, rhs.saturation) &&
 		boost::range::equal(lhs.anchor, rhs.anchor, eq) &&
+		boost::range::equal(lhs.blur, rhs.blur, eq) &&
 		boost::range::equal(lhs.fill_translation, rhs.fill_translation, eq) &&
 		boost::range::equal(lhs.fill_scale, rhs.fill_scale, eq) &&
 		boost::range::equal(lhs.clip_translation, rhs.clip_translation, eq) &&

--- a/core/frame/frame_transform.h
+++ b/core/frame/frame_transform.h
@@ -87,6 +87,7 @@ struct image_transform final
 	// boost::array<double, 2> fill_translation = { { 0.0, 0.0 } };
 	// See http://blogs.msdn.com/b/vcblog/archive/2014/08/19/the-future-of-non-static-data-member-initialization.aspx
 	boost::array<double, 2>	anchor				= boost::array<double, 2> { { 0.0, 0.0 } };
+	boost::array<double, 2>	blur				= boost::array<double, 2> { { 0.0, 0.0 } };
 	boost::array<double, 2>	fill_translation	= boost::array<double, 2> { { 0.0, 0.0 } };
 	boost::array<double, 2>	fill_scale			= boost::array<double, 2> { { 1.0, 1.0 } };
 	boost::array<double, 2>	clip_translation	= boost::array<double, 2> { { 0.0, 0.0 } };

--- a/core/producer/scene/scene.xsd
+++ b/core/producer/scene/scene.xsd
@@ -85,6 +85,8 @@
                     </xs:element>
                     <xs:element type="number_expression" name="anchor_x" minOccurs="0" default="0">                         <xs:annotation><xs:documentation>The X anchor within the layer coordinate system where position and rotation are done relative to/around. Can be an expression.</xs:documentation></xs:annotation></xs:element>
                     <xs:element type="number_expression" name="anchor_y" minOccurs="0" default="0">                         <xs:annotation><xs:documentation>The Y anchor within the layer coordinate system where position and rotation are done relative to/around. Can be an expression.</xs:documentation></xs:annotation></xs:element>
+                    <xs:element type="number_expression" name="blur_x" minOccurs="0" default="0">                           <xs:annotation><xs:documentation>The X blur strength in number of pixels. Can be an expression.</xs:documentation></xs:annotation></xs:element>
+                    <xs:element type="number_expression" name="blur_y" minOccurs="0" default="0">                           <xs:annotation><xs:documentation>The Y blur strength in number of pixels. Can be an expression.</xs:documentation></xs:annotation></xs:element>
                     <xs:element type="number_expression" name="rotation" minOccurs="0" default="0.0">                       <xs:annotation><xs:documentation>The rotation of the layer around anchor_x/anchor_y expressed in degrees. Can be an expression.</xs:documentation></xs:annotation></xs:element>
                     <xs:element name="crop" minOccurs="0">
                       <xs:annotation>

--- a/core/producer/scene/scene_producer.cpp
+++ b/core/producer/scene/scene_producer.cpp
@@ -291,6 +291,7 @@ struct scene_producer::impl
 		frame_transform transform;
 
 		auto& anchor		= transform.image_transform.anchor;
+		auto& blur			= transform.image_transform.blur;
 		auto& pos			= transform.image_transform.fill_translation;
 		auto& scale			= transform.image_transform.fill_scale;
 		auto& clip_pos		= transform.image_transform.clip_translation;
@@ -302,6 +303,8 @@ struct scene_producer::impl
 
 		anchor[0]		= layer.anchor.x.get()										/ layer.producer.get()->pixel_constraints().width.get();
 		anchor[1]		= layer.anchor.y.get()										/ layer.producer.get()->pixel_constraints().height.get();
+		blur[0]			= layer.blur.x.get();
+		blur[1]			= layer.blur.y.get();
 
 		pos[0]			= layer.position.x.get()									/ pixel_constraints_.width.get();
 		pos[1]			= layer.position.y.get()									/ pixel_constraints_.height.get();

--- a/core/producer/scene/scene_producer.h
+++ b/core/producer/scene/scene_producer.h
@@ -89,6 +89,7 @@ struct layer
 	binding<std::wstring>						name;
 	scene::coord								anchor;
 	scene::coord								position;
+	scene::coord								blur;
 	scene::rect									crop;
 	scene::corners								perspective;
 	scene::rect									clip;
@@ -221,6 +222,7 @@ public:
 					//CASPAR_LOG(info) << relative_frame << L" " << *start_value << L" " << duration << L" " << tweened;
 				};
 
+		// TODO - this can exception is two keyframes have the same number
 		store_keyframe(to_affect.identity(), k);
 	}
 

--- a/core/producer/scene/xml_scene_producer.cpp
+++ b/core/producer/scene/xml_scene_producer.cpp
@@ -168,6 +168,8 @@ spl::shared_ptr<core::frame_producer> create_xml_scene_producer(
 		layer.position.y							= scene->create_variable<double>(variable_prefix + L"y", false, ptree_get<std::wstring>(elem.second, L"y"));
 		layer.anchor.x								= scene->create_variable<double>(variable_prefix + L"anchor_x", false, elem.second.get<std::wstring>(L"anchor_x", L"0.0"));
 		layer.anchor.y								= scene->create_variable<double>(variable_prefix + L"anchor_y", false, elem.second.get<std::wstring>(L"anchor_y", L"0.0"));
+		layer.blur.x								= scene->create_variable<double>(variable_prefix + L"blur_x", false, elem.second.get<std::wstring>(L"blur_x", L"0.0"));
+		layer.blur.y								= scene->create_variable<double>(variable_prefix + L"blur_y", false, elem.second.get<std::wstring>(L"blur_y", L"0.0"));
 		layer.clip.upper_left.x						= scene->create_variable<double>(variable_prefix + L"clip.upper_left_x", false, elem.second.get<std::wstring>(L"clip.upper_left_x", L"0.0"));
 		layer.clip.upper_left.y						= scene->create_variable<double>(variable_prefix + L"clip.upper_left_y", false, elem.second.get<std::wstring>(L"clip.upper_left_y", L"0.0"));
 		layer.clip.lower_right.x					= scene->create_variable<double>(variable_prefix + L"clip.lower_right_x", false, elem.second.get<std::wstring>(L"clip.lower_right_x", L"${scene_width}"));


### PR DESCRIPTION
Potentially fixes #585 

This adds direction blurs to caspar. Intended to be used as motion blur. Available as MIXER BLUR and from the scene producer.

I used https://john-chapman-graphics.blogspot.co.uk/2013/01/what-is-motion-blur-motion-pictures-are.html as a reference for doing a blur in GLSL. 
I had to composite the layers into a new texture before applying the blur as otherwise if it was applied to a transformed image, it would not blur beyond the bounds of the image, or for the text producer would have some bleed from other characters in the source texture.

This may not be the most optimised of solutions as I haven't done much OpenGL development before.