### PR TITLE
[image_consumer] Add support for returning base64 encoded png snapshots over amcp

### DIFF
--- a/core/consumer/frame_consumer.cpp
+++ b/core/consumer/frame_consumer.cpp
@@ -282,7 +282,7 @@ public:
 };
 
 spl::shared_ptr<core::frame_consumer> frame_consumer_registry::create_consumer(
-		const std::vector<std::wstring>& params, interaction_sink* sink, std::vector<spl::shared_ptr<video_channel>> channels) const
+		const std::vector<std::wstring>& params, interaction_sink* sink, std::vector<spl::shared_ptr<video_channel>> channels, spl::shared_ptr<consumer_delayed_responder> responder) const
 {
 	if(params.empty())
 		CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("params cannot be empty"));
@@ -293,7 +293,7 @@ spl::shared_ptr<core::frame_consumer> frame_consumer_registry::create_consumer(
 		{
 			try
 			{
-				consumer = factory(params, sink, channels);
+				consumer = factory(params, sink, channels, responder);
 			}
 			catch(...)
 			{

--- a/core/consumer/syncto/syncto_consumer.cpp
+++ b/core/consumer/syncto/syncto_consumer.cpp
@@ -158,7 +158,8 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 spl::shared_ptr<core::frame_consumer> create_consumer(
 		const std::vector<std::wstring>& params,
 		core::interaction_sink*,
-		std::vector<spl::shared_ptr<video_channel>> channels)
+		std::vector<spl::shared_ptr<video_channel>> channels, 
+		spl::shared_ptr<core::consumer_delayed_responder>)
 {
 	if (params.size() < 1 || !boost::iequals(params.at(0), L"SYNCTO"))
 		return core::frame_consumer::empty();

--- a/core/fwd.h
+++ b/core/fwd.h
@@ -34,6 +34,7 @@ FORWARD2(caspar, core, class frame_factory);
 FORWARD2(caspar, core, class frame_producer);
 FORWARD2(caspar, core, class frame_consumer);
 FORWARD2(caspar, core, struct interaction_sink);
+FORWARD2(caspar, core, class consumer_delayed_responder);
 FORWARD2(caspar, core, class draw_frame);
 FORWARD2(caspar, core, class mutable_frame);
 FORWARD2(caspar, core, class const_frame);

--- a/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -777,7 +777,8 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 
 spl::shared_ptr<core::frame_consumer> create_consumer(	const std::vector<std::wstring>& params,
 														core::interaction_sink*,
-														std::vector<spl::shared_ptr<core::video_channel>> channels)
+														std::vector<spl::shared_ptr<core::video_channel>> channels,
+														spl::shared_ptr<core::consumer_delayed_responder> responder)
 {
 	if(params.size() < 1 || !boost::iequals(params.at(0), L"BLUEFISH"))
 		return core::frame_consumer::empty();

--- a/modules/bluefish/consumer/bluefish_consumer.h
+++ b/modules/bluefish/consumer/bluefish_consumer.h
@@ -36,7 +36,8 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 
 spl::shared_ptr<core::frame_consumer> create_consumer(	const std::vector<std::wstring>& params, 
 														core::interaction_sink*,
-														std::vector<spl::shared_ptr<core::video_channel>> channels);
+														std::vector<spl::shared_ptr<core::video_channel>> channels,
+														spl::shared_ptr<core::consumer_delayed_responder> responder);
 
 
 spl::shared_ptr<core::frame_consumer> create_preconfigured_consumer(

--- a/modules/decklink/consumer/decklink_consumer.cpp
+++ b/modules/decklink/consumer/decklink_consumer.cpp
@@ -811,7 +811,7 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 }
 
 spl::shared_ptr<core::frame_consumer> create_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels)
+		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder>)
 {
 	if (params.size() < 1 || !boost::iequals(params.at(0), L"DECKLINK"))
 		return core::frame_consumer::empty();

--- a/modules/decklink/consumer/decklink_consumer.h
+++ b/modules/decklink/consumer/decklink_consumer.h
@@ -35,7 +35,8 @@ namespace caspar { namespace decklink {
 void describe_consumer(core::help_sink& sink, const core::help_repository& repo);
 spl::shared_ptr<core::frame_consumer> create_consumer(
 		const std::vector<std::wstring>& params, core::interaction_sink*,
-		std::vector<spl::shared_ptr<core::video_channel>> channels);
+		std::vector<spl::shared_ptr<core::video_channel>> channels, 
+		spl::shared_ptr<core::consumer_delayed_responder>);
 spl::shared_ptr<core::frame_consumer> create_preconfigured_consumer(
 		const boost::property_tree::wptree& ptree, core::interaction_sink*,
 		std::vector<spl::shared_ptr<core::video_channel>> channels);

--- a/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -1316,7 +1316,7 @@ void describe_ffmpeg_consumer(core::help_sink& sink, const core::help_repository
 }
 
 spl::shared_ptr<core::frame_consumer> create_ffmpeg_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels)
+		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder)
 {
 	if (params.size() < 1 || (!boost::iequals(params.at(0), L"STREAM") && !boost::iequals(params.at(0), L"FILE")))
 		return core::frame_consumer::empty();

--- a/modules/ffmpeg/consumer/ffmpeg_consumer.h
+++ b/modules/ffmpeg/consumer/ffmpeg_consumer.h
@@ -13,7 +13,7 @@ namespace caspar { namespace ffmpeg {
 
 void describe_ffmpeg_consumer(core::help_sink& sink, const core::help_repository& repo);
 spl::shared_ptr<core::frame_consumer> create_ffmpeg_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
+		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder);
 spl::shared_ptr<core::frame_consumer> create_preconfigured_ffmpeg_consumer(
 		const boost::property_tree::wptree& ptree, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
 

--- a/modules/image/consumer/image_consumer.h
+++ b/modules/image/consumer/image_consumer.h
@@ -44,6 +44,6 @@ void write_cropped_png(
 
 void describe_consumer(core::help_sink& sink, const core::help_repository& repo);
 spl::shared_ptr<core::frame_consumer> create_consumer(
-		const std::vector<std::wstring>& params, struct core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
+		const std::vector<std::wstring>& params, struct core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder);
 
 }}

--- a/modules/image/producer/image_producer.cpp
+++ b/modules/image/producer/image_producer.cpp
@@ -97,12 +97,12 @@ struct image_producer : public core::frame_producer_base
 			CASPAR_LOG(info) << print() << L" Initialized";
 	}
 
-	image_producer(const spl::shared_ptr<core::frame_factory>& frame_factory, const void* png_data, size_t size, uint32_t length)
+	image_producer(const spl::shared_ptr<core::frame_factory>& frame_factory, std::string png_data, uint32_t length)
 		: description_(L"png from memory")
 		, frame_factory_(frame_factory)
 		, length_(length)
 	{
-		load(load_png_from_memory(png_data, size));
+		load(bitmap_from_base64_png(png_data));
 
 		CASPAR_LOG(info) << print() << L" Initialized";
 	}
@@ -259,9 +259,9 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
 		if (params.size() < 2)
 			return core::frame_producer::empty();
 
-		auto png_data = from_base64(std::string(params.at(1).begin(), params.at(1).end()));
+		auto png_data = std::string(params.at(1).begin(), params.at(1).end());
 
-		return spl::make_shared<image_producer>(dependencies.frame_factory, png_data.data(), png_data.size(), length);
+		return spl::make_shared<image_producer>(dependencies.frame_factory, png_data, length);
 	}
 
 	std::wstring filename = env::media_folder() + params.at(0);

--- a/modules/image/util/image_loader.h
+++ b/modules/image/util/image_loader.h
@@ -30,7 +30,8 @@
 namespace caspar { namespace image {
 
 std::shared_ptr<FIBITMAP> load_image(const std::wstring& filename);
-std::shared_ptr<FIBITMAP> load_png_from_memory(const void* memory_location, size_t size);
+std::shared_ptr<FIBITMAP> bitmap_from_base64_png(const std::string png_data);
+std::string bitmap_to_base64_png(std::shared_ptr<FIBITMAP> src);
 const std::set<std::wstring>& supported_extensions();
 
 }}

--- a/modules/newtek/consumer/newtek_ivga_consumer.cpp
+++ b/modules/newtek/consumer/newtek_ivga_consumer.cpp
@@ -202,7 +202,7 @@ void describe_ivga_consumer(core::help_sink& sink, const core::help_repository& 
 	sink.example(L">> ADD 1 NEWTEK_IVGA");
 }
 
-spl::shared_ptr<core::frame_consumer> create_ivga_consumer(const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels)
+spl::shared_ptr<core::frame_consumer> create_ivga_consumer(const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder)
 {
 	if (params.size() < 1 || !boost::iequals(params.at(0), L"NEWTEK_IVGA"))
 		return core::frame_consumer::empty();

--- a/modules/newtek/consumer/newtek_ivga_consumer.h
+++ b/modules/newtek/consumer/newtek_ivga_consumer.h
@@ -32,7 +32,7 @@
 namespace caspar { namespace newtek {
 
 void describe_ivga_consumer(core::help_sink& sink, const core::help_repository& repo);
-spl::shared_ptr<core::frame_consumer> create_ivga_consumer(const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
+spl::shared_ptr<core::frame_consumer> create_ivga_consumer(const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder);
 spl::shared_ptr<core::frame_consumer> create_preconfigured_ivga_consumer(const boost::property_tree::wptree& ptree, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
 
 }}

--- a/modules/oal/consumer/oal_consumer.cpp
+++ b/modules/oal/consumer/oal_consumer.cpp
@@ -294,7 +294,7 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 }
 
 spl::shared_ptr<core::frame_consumer> create_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels)
+		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder>)
 {
 	if(params.size() < 1 || !boost::iequals(params.at(0), L"AUDIO"))
 		return core::frame_consumer::empty();

--- a/modules/oal/consumer/oal_consumer.h
+++ b/modules/oal/consumer/oal_consumer.h
@@ -33,7 +33,7 @@ namespace caspar { namespace oal {
 
 void describe_consumer(core::help_sink& sink, const core::help_repository& repo);
 spl::shared_ptr<core::frame_consumer> create_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
+		const std::vector<std::wstring>& params, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder> responder);
 spl::shared_ptr<core::frame_consumer> create_preconfigured_consumer(
 		const boost::property_tree::wptree&, core::interaction_sink*, std::vector<spl::shared_ptr<core::video_channel>> channels);
 

--- a/modules/screen/consumer/screen_consumer.cpp
+++ b/modules/screen/consumer/screen_consumer.cpp
@@ -704,7 +704,7 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 }
 
 spl::shared_ptr<core::frame_consumer> create_consumer(
-		const std::vector<std::wstring>& params, core::interaction_sink* sink, std::vector<spl::shared_ptr<core::video_channel>> channels)
+		const std::vector<std::wstring>& params, core::interaction_sink* sink, std::vector<spl::shared_ptr<core::video_channel>> channels, spl::shared_ptr<core::consumer_delayed_responder>)
 {
 	if (params.size() < 1 || !boost::iequals(params.at(0), L"SCREEN"))
 		return core::frame_consumer::empty();

--- a/modules/screen/consumer/screen_consumer.h
+++ b/modules/screen/consumer/screen_consumer.h
@@ -34,7 +34,8 @@ void describe_consumer(core::help_sink& sink, const core::help_repository& repo)
 spl::shared_ptr<core::frame_consumer> create_consumer(
 		const std::vector<std::wstring>& params,
 		core::interaction_sink* sink,
-		std::vector<spl::shared_ptr<core::video_channel>> channels);
+		std::vector<spl::shared_ptr<core::video_channel>> channels, 
+		spl::shared_ptr<core::consumer_delayed_responder>);
 spl::shared_ptr<core::frame_consumer> create_preconfigured_consumer(
 		const boost::property_tree::wptree& ptree,
 		core::interaction_sink* sink,

--- a/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -216,7 +216,7 @@ private:
 			// Create command instance
 			if (is_channel_command)
 			{
-				result.command = repo_->create_channel_command(result.command_name, client, channel_index, layer_index, tokens);
+				result.command = repo_->create_channel_command(result.command_name, result.request_id, client, channel_index, layer_index, tokens);
 
 				if (result.command)
 				{
@@ -227,7 +227,7 @@ private:
 				{
 					// Restore backed up channel spec string.
 					tokens.push_front(channel_spec);
-					result.command = repo_->create_command(result.command_name, client, tokens);
+					result.command = repo_->create_command(result.command_name, result.request_id, client, tokens);
 
 					if (result.command)
 						result.queue = commandQueues_.at(0);
@@ -235,7 +235,7 @@ private:
 			}
 			else
 			{
-				result.command = repo_->create_command(result.command_name, client, tokens);
+				result.command = repo_->create_command(result.command_name, result.request_id, client, tokens);
 
 				if (result.command)
 					result.queue = commandQueues_.at(0);
@@ -252,9 +252,6 @@ private:
 				if (result.command->parameters().size() < result.command->minimum_parameters())
 					result.error = error_state::parameters_error;
 			}
-
-			if (result.command)
-				result.command->set_request_id(result.request_id);
 		}
 		catch (std::out_of_range&)
 		{

--- a/protocol/amcp/amcp_command_repository.h
+++ b/protocol/amcp/amcp_command_repository.h
@@ -48,9 +48,10 @@ public:
 			const std::shared_ptr<accelerator::ogl::device>& ogl_device,
 			std::promise<bool>& shutdown_server_now);
 
-	AMCPCommand::ptr_type create_command(const std::wstring& s, IO::ClientInfoPtr client, std::list<std::wstring>& tokens) const;
+	AMCPCommand::ptr_type create_command(const std::wstring& s, const std::wstring& id, IO::ClientInfoPtr client, std::list<std::wstring>& tokens) const;
 	AMCPCommand::ptr_type create_channel_command(
 			const std::wstring& s,
+			const std::wstring& id,
 			IO::ClientInfoPtr client,
 			unsigned int channel_index,
 			int layer_index,
@@ -58,7 +59,9 @@ public:
 
 	const std::vector<channel_context>& channels() const;
 
+	void register_command(std::wstring category, std::wstring name, core::help_item_describer describer, amcp_simple_command_func command, int min_num_params);
 	void register_command(std::wstring category, std::wstring name, core::help_item_describer describer, amcp_command_func command, int min_num_params);
+	void register_channel_command(std::wstring category, std::wstring name, core::help_item_describer describer, amcp_simple_command_func command, int min_num_params);
 	void register_channel_command(std::wstring category, std::wstring name, core::help_item_describer describer, amcp_command_func command, int min_num_params);
 	spl::shared_ptr<core::help_repository> help_repo() const;
 private:


### PR DESCRIPTION
#474

[PNG_BASE64] can be used as the filename when taking a channel snapshot to return over amcp instead of saving to file
```
ADD 1 IMAGE [PNG_BASE64] 
PRINT 1 [PNG_BASE64] 
```