### PR TITLE
GCC optimizations for the CPU mixer

### DIFF
--- a/accelerator/CMakeLists.txt
+++ b/accelerator/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required (VERSION 2.6)
 project (accelerator)
 
-if (MSVC)
-	set(OS_SPECIFIC_SOURCES
-			cpu/image/image_mixer.cpp
-			cpu/image/image_mixer.h
-
-			cpu/util/xmm.h
-	)
-else ()
-
-endif ()
-
 set(SOURCES
 
 		ogl/image/image_kernel.cpp
@@ -22,6 +11,8 @@ set(SOURCES
 		ogl/util/device.cpp
 		ogl/util/shader.cpp
 		ogl/util/texture.cpp
+
+		cpu/image/image_mixer.cpp
 
 		accelerator.cpp
 		StdAfx.cpp
@@ -36,6 +27,9 @@ set(HEADERS
 		ogl/util/device.h
 		ogl/util/shader.h
 		ogl/util/texture.h
+
+		cpu/image/image_mixer.h
+		cpu/util/xmm.h
 
 		accelerator.h
 		StdAfx.h

--- a/accelerator/accelerator.cpp
+++ b/accelerator/accelerator.cpp
@@ -2,9 +2,7 @@
 
 #include "accelerator.h"
 
-#ifdef _MSC_VER
 #include "cpu/image/image_mixer.h"
-#endif
 #include "ogl/image/image_mixer.h"
 #include "ogl/util/device.h"
 
@@ -50,11 +48,7 @@ struct accelerator::impl
 			if(path_ == L"gpu" || path_ == L"ogl")
 				CASPAR_LOG_CURRENT_EXCEPTION();
 		}
-#ifdef _MSC_VER
 		return std::unique_ptr<core::image_mixer>(new cpu::image_mixer(channel_id));
-#else
-		CASPAR_THROW_EXCEPTION(not_supported());
-#endif
 	}
 };
 

--- a/accelerator/cpu/image/image_mixer.cpp
+++ b/accelerator/cpu/image/image_mixer.cpp
@@ -161,20 +161,21 @@ public:
 
 		convert(items, format_desc.width, format_desc.height);
 
-		auto result = spl::make_shared<buffer>(format_desc.size, static_cast<uint8_t>(0));
+		auto result = std::shared_ptr<uint8_t[]>(new uint8_t[format_desc.size]);
+		memset(result.get(), 0, format_desc.size);
 		if(format_desc.field_mode != core::field_mode::progressive)
 		{
-			draw(items, result->data(), format_desc.width, format_desc.height, core::field_mode::upper);
-			draw(items, result->data(), format_desc.width, format_desc.height, core::field_mode::lower);
+			draw(items, result.get(), format_desc.width, format_desc.height, core::field_mode::upper);
+			draw(items, result.get(), format_desc.width, format_desc.height, core::field_mode::lower);
 		}
 		else
 		{
-			draw(items, result->data(), format_desc.width, format_desc.height,  core::field_mode::progressive);
+			draw(items, result.get(), format_desc.width, format_desc.height,  core::field_mode::progressive);
 		}
 
 		temp_buffers_.clear();
 
-		return make_ready_future(array<const std::uint8_t>(result->data(), format_desc.size, true, result));
+		return make_ready_future(array<const std::uint8_t>(result.get(), format_desc.size, true, result));
 	}
 
 private:

--- a/accelerator/cpu/util/xmm.h
+++ b/accelerator/cpu/util/xmm.h
@@ -89,34 +89,34 @@ private:
 public:
 	typedef s16_x xmm_epi_tag;
 
-	s16_x();
-	explicit s16_x(const s32_x& other);
-	explicit s16_x(const s8_x& other);
-	explicit s16_x(const u8_x& other);
-	s16_x(const __m128i& value);
-	s16_x(short value);
+	inline s16_x();
+	explicit inline s16_x(const s32_x& other);
+	explicit inline s16_x(const s8_x& other);
+	explicit inline s16_x(const u8_x& other);
+	inline s16_x(const __m128i& value);
+	inline s16_x(short value);
 
-	s16_x& operator+=(const s16_x& other);	
-	s16_x& operator-=(const s16_x& other);
-	s16_x& operator>>=(int count);
-	s16_x& operator<<=(int count);
-	s16_x& operator|=(const s16_x& other);
-	s16_x& operator&=(const s16_x& other);	
-	int16_t operator[](int index) const;
-	int16_t& operator[](int index);
+	inline s16_x& operator+=(const s16_x& other);	
+	inline s16_x& operator-=(const s16_x& other);
+	inline s16_x& operator>>=(int count);
+	inline s16_x& operator<<=(int count);
+	inline s16_x& operator|=(const s16_x& other);
+	inline s16_x& operator&=(const s16_x& other);	
+	inline int16_t operator[](int index) const;
+	inline int16_t& operator[](int index);
 	
-	static s16_x unpack_low(const s8_x& lhs, const s8_x& rhs);
-	static s16_x unpack_high(const s8_x& lhs, const s8_x& rhs);
-	static s32_x horizontal_add(const s16_x& lhs);
-	static s16_x multiply_low(const s16_x& lhs, const s16_x& rhs);
-	static s16_x multiply_high(const s16_x& lhs, const s16_x& rhs);
-	static s16_x umultiply_low(const s16_x& lhs, const s16_x& rhs);
-	static s16_x umultiply_high(const s16_x& lhs, const s16_x& rhs);	
-	static s16_x unpack_low(const s16_x& lhs, const s16_x& rhs);
-	static s16_x unpack_high(const s16_x& lhs, const s16_x& rhs);
-	static s16_x and_not(const s16_x& lhs, const s16_x& rhs);	
-	static s16_x max(const s16_x& lhs, const s16_x& rhs);
-	static s16_x min(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x unpack_low(const s8_x& lhs, const s8_x& rhs);
+	static inline s16_x unpack_high(const s8_x& lhs, const s8_x& rhs);
+	static inline s32_x horizontal_add(const s16_x& lhs);
+	static inline s16_x multiply_low(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x multiply_high(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x umultiply_low(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x umultiply_high(const s16_x& lhs, const s16_x& rhs);	
+	static inline s16_x unpack_low(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x unpack_high(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x and_not(const s16_x& lhs, const s16_x& rhs);	
+	static inline s16_x max(const s16_x& lhs, const s16_x& rhs);
+	static inline s16_x min(const s16_x& lhs, const s16_x& rhs);
 };
 
 template<typename T>
@@ -141,31 +141,31 @@ private:
 public:
 	typedef s8_x xmm_epi_tag;
 
-	s8_x();
-	explicit s8_x(const s32_x& other);
-	explicit s8_x(const s16_x& other);
-	explicit s8_x(const u8_x& other);
-	s8_x(const __m128i& value);	
-	s8_x(char b);
-	s8_x(char b3,  char b2,  char b1,  char b0);
-	s8_x(char b15, char b14, char b13, char b12, 
-		 char b11, char b10, char b9,  char b8,  
+	inline s8_x();
+	inline explicit s8_x(const s32_x& other);
+	inline explicit s8_x(const s16_x& other);
+	inline explicit s8_x(const u8_x& other);
+	inline s8_x(const __m128i& value);	
+	inline s8_x(char b);
+	inline s8_x(char b3,  char b2,  char b1,  char b0);
+	inline s8_x(char b15, char b14, char b13, char b12, 
+	         char b11, char b10, char b9,  char b8,  
 		 char b7,  char b6,  char b5,  char b4,  
 		 char b3,  char b2,  char b1,  char b0);
 
-	s8_x& operator+=(const s8_x& other);
-	s8_x& operator-=(const s8_x& other);	
-	char operator[](int index) const;
-	char& operator[](int index);
+	inline s8_x& operator+=(const s8_x& other);
+	inline s8_x& operator-=(const s8_x& other);	
+	inline char operator[](int index) const;
+	inline char& operator[](int index);
 	
-	static s8_x upack(const s16_x& lhs, const s16_x& rhs);
+	static inline s8_x upack(const s16_x& lhs, const s16_x& rhs);
 
-	static s16_x multiply_add(const u8_x& lhs, const s8_x& rhs);
-	static s8_x max(const s8_x& lhs, const s8_x& rhs);
-	static s8_x min(const s8_x& lhs, const s8_x& rhs);
+	static inline s16_x multiply_add(const u8_x& lhs, const s8_x& rhs);
+	static inline s8_x max(const s8_x& lhs, const s8_x& rhs);
+	static inline s8_x min(const s8_x& lhs, const s8_x& rhs);
 
-	static s8_x shuffle(const s8_x& lhs, const s8_x& rhs);
-	static s8_x blend(const s8_x& lhs, const s8_x& rhs, const s8_x& mask);
+	static inline s8_x shuffle(const s8_x& lhs, const s8_x& rhs);
+	static inline s8_x blend(const s8_x& lhs, const s8_x& rhs, const s8_x& mask);
 };
 
 class u8_x : public base_x<u8_x>
@@ -183,26 +183,26 @@ private:
 public:
 	typedef u8_x xmm_epu_tag;
 
-	u8_x();
-	explicit u8_x(const s32_x& other);
-	explicit u8_x(const s16_x& other);
-	explicit u8_x(const s8_x& other);
-	u8_x(const __m128i& value);	
-	u8_x(char b);
-	u8_x(char b3,  char b2,  char b1,  char b0);
-	u8_x(char b15, char b14, char b13, char b12, 
+	inline u8_x();
+	explicit inline u8_x(const s32_x& other);
+	explicit inline u8_x(const s16_x& other);
+	explicit inline u8_x(const s8_x& other);
+	inline u8_x(const __m128i& value);	
+	inline u8_x(char b);
+	inline u8_x(char b3,  char b2,  char b1,  char b0);
+	inline u8_x(char b15, char b14, char b13, char b12, 
 		 char b11, char b10, char b9,  char b8,  
 		 char b7,  char b6,  char b5,  char b4,  
 		 char b3,  char b2,  char b1,  char b0);
 										
-	char operator[](int index) const;
-	char& operator[](int index);
+	inline char operator[](int index) const;
+	inline char& operator[](int index);
 			
-	static u8_x max(const u8_x& lhs, const u8_x& rhs);
-	static u8_x min(const u8_x& lhs, const u8_x& rhs);
+	static inline u8_x max(const u8_x& lhs, const u8_x& rhs);
+	static inline u8_x min(const u8_x& lhs, const u8_x& rhs);
 		
-	static u8_x shuffle(const u8_x& lhs, const u8_x& rhs);
-	static u8_x blend(const u8_x& lhs, const u8_x& rhs, const u8_x& mask);
+	static inline u8_x shuffle(const u8_x& lhs, const u8_x& rhs);
+	static inline u8_x blend(const u8_x& lhs, const u8_x& rhs, const u8_x& mask);
 };
 
 // base_x

--- a/accelerator/cpu/util/xmm.h
+++ b/accelerator/cpu/util/xmm.h
@@ -48,7 +48,11 @@ public:
 class s32_x : public base_x<s32_x>
 {
 	__m128i value_;
+#ifdef WIN32
 	template<typename> friend class base_x;
+#else
+	friend class base_x;
+#endif
 	friend class s16_x;
 	friend class s8_x;
 	friend class u8_x;
@@ -74,7 +78,11 @@ class s16_x : public base_x<s16_x>
 	__m128i value_;
 
 private:
+#ifdef WIN32
 	template<typename> friend class base_x;
+#else
+	friend class base_x;
+#endif
 	friend class s32_x;
 	friend class s8_x;
 	friend class u8_x;
@@ -122,7 +130,11 @@ class s8_x : public base_x<s8_x>
 {
 	__m128i value_;
 private:
+#ifdef WIN32
 	template<typename> friend class base_x;
+#else
+	friend class base_x;
+#endif
 	friend class s32_x;
 	friend class s16_x;
 	friend class u8_x;
@@ -160,7 +172,11 @@ class u8_x : public base_x<u8_x>
 {
 	__m128i value_;
 private:
+#ifdef WIN32
 	template<typename> friend class base_x;
+#else
+	friend class base_x;
+#endif
 	friend class s32_x;
 	friend class s16_x;
 	friend class s8_x;
@@ -272,12 +288,20 @@ s32_x& s32_x::operator&=(const s32_x& other)
 		
 int32_t s32_x::operator[](int index) const
 {
+#ifdef WIN32
 	return value_.m128i_i32[index];
+#else
+	return ((int32_t *)&value_)[index];
+#endif
 }
 
 int32_t& s32_x::operator[](int index)
 {
+#ifdef WIN32
 	return value_.m128i_i32[index];
+#else
+        return ((int32_t *)&value_)[index];
+#endif
 }
 
 inline s32_x operator>>(const s32_x& lhs, int count)
@@ -369,12 +393,20 @@ s16_x& s16_x::operator&=(const s16_x& other)
 			
 int16_t s16_x::operator[](int index) const
 {
+#ifdef WIN32
 	return value_.m128i_i16[index];
+#else
+        return ((int16_t *)&value_)[index];
+#endif
 }
 
 int16_t& s16_x::operator[](int index)
 {
+#ifdef WIN32
 	return value_.m128i_i16[index];
+#else
+        return ((int16_t *)&value_)[index];
+#endif
 }
 
 s16_x s16_x::unpack_low(const s8_x& lhs, const s8_x& rhs)
@@ -519,12 +551,20 @@ s8_x& s8_x::operator-=(const s8_x& other)
 									
 char s8_x::operator[](int index) const
 {
+#ifdef WIN32
 	return value_.m128i_i8[index];
+#else
+        return ((char *)&value_)[index];
+#endif
 }
 
 char& s8_x::operator[](int index)
 {
+#ifdef WIN32
 	return value_.m128i_i8[index];
+#else
+        return ((char *)&value_)[index];
+#endif
 }
 	
 s8_x s8_x::upack(const s16_x& lhs, const s16_x& rhs)
@@ -613,12 +653,20 @@ u8_x::u8_x(char b15, char b14, char b13, char b12,
 										
 char u8_x::operator[](int index) const
 {
+#ifdef WIN32
 	return value_.m128i_i8[index];
+#else
+        return ((char *)&value_)[index];
+#endif
 }
 
 char& u8_x::operator[](int index)
 {
+#ifdef WIN32
 	return value_.m128i_i8[index];
+#else
+        return ((char *)&value_)[index];
+#endif
 }
 
 u8_x u8_x::max(const u8_x& lhs, const u8_x& rhs)


### PR DESCRIPTION
Speeds up the CPU mixer significantly when using GCC. Rebased on top of @Julusian's patch to enable the CPU mixer for Linux.