### PR TITLE
[image_producer] Correctly apply alpha to base64 encoded pngs from AMCP

### DIFF
--- a/modules/image/util/image_loader.cpp
+++ b/modules/image/util/image_loader.cpp
@@ -97,6 +97,13 @@ std::shared_ptr<FIBITMAP> load_png_from_memory(const void* memory_location, size
 			CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("Unsupported image format."));
 	}
 
+	//PNG-images need to be premultiplied with their alpha
+	if (fif == FIF_PNG)
+	{
+		image_view<bgra_pixel> original_view(FreeImage_GetBits(bitmap.get()), FreeImage_GetWidth(bitmap.get()), FreeImage_GetHeight(bitmap.get()));
+		premultiply(original_view);
+	}
+
 	return bitmap;
 }
 


### PR DESCRIPTION
Rebase of #614 against 2.2.0