### PR TITLE
AMCP PING command

### DIFF
--- a/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/protocol/amcp/AMCPCommandsImpl.cpp
@@ -3001,6 +3001,15 @@ void req_describer(core::help_sink& sink, const core::help_repository& repo)
 		L"<< RES unique 202 PLAY OK");
 }
 
+void ping_describer(core::help_sink& sink, const core::help_repository& repo)
+{
+	sink.short_description(L"Pings the server to ensure the amcp connection is still active.");
+	sink.syntax(LR"(PING {[tokens:string]})");
+	sink.example(
+		L">> PING abcdef123\n"
+		L"<< PONG abcdef123");
+}
+
 
 void register_commands(amcp_command_repository& repo)
 {
@@ -3090,6 +3099,7 @@ void register_commands(amcp_command_repository& repo)
 	repo.register_command(			L"Query Commands",		L"HELP CONSUMER",				help_consumer_describer,			help_consumer_command,			0);
 
 	repo.help_repo()->register_item({ L"AMCP", L"Protocol Commands" }, L"REQ", req_describer);
+	repo.help_repo()->register_item({ L"AMCP", L"Protocol Commands" }, L"PING", ping_describer);
 }
 
 }	//namespace amcp

--- a/protocol/util/AsyncEventServer.cpp
+++ b/protocol/util/AsyncEventServer.cpp
@@ -69,7 +69,7 @@ class connection : public spl::enable_shared_from_this<connection>
 		explicit connection_holder(std::weak_ptr<connection> conn) : connection_(std::move(conn))
 		{}
 
-		void send(std::basic_string<char>&& data) override
+		void send(std::basic_string<char>&& data, bool skip_log) override
 		{
 			auto conn = connection_.lock();
 

--- a/protocol/util/ClientInfo.h
+++ b/protocol/util/ClientInfo.h
@@ -34,7 +34,7 @@ typedef spl::shared_ptr<client_connection<wchar_t>> ClientInfoPtr;
 
 struct ConsoleClientInfo : public client_connection<wchar_t>
 {
-	void send(std::wstring&& data) override
+	void send(std::wstring&& data, bool skip_log) override
 	{
 		std::wcout << (L"#" + caspar::log::replace_nonprintable_copy(data, L'?')) << std::flush;
 	}

--- a/protocol/util/protocol_strategy.h
+++ b/protocol/util/protocol_strategy.h
@@ -62,7 +62,7 @@ public:
 
 	virtual ~client_connection() { }
 
-	virtual void send(std::basic_string<CharT>&& data) = 0;
+	virtual void send(std::basic_string<CharT>&& data, bool skip_log = false) = 0;
 	virtual void disconnect() = 0;
 	virtual std::wstring address() const = 0;
 

--- a/protocol/util/strategy_adapters.cpp
+++ b/protocol/util/strategy_adapters.cpp
@@ -64,11 +64,14 @@ public:
 	{
 	}
 
-	void send(std::basic_string<wchar_t>&& data) override
+	void send(std::basic_string<wchar_t>&& data, bool skip_log) override
 	{
 		auto str = boost::locale::conv::from_utf<wchar_t>(data, codepage_);
 
-		client_->send(std::move(str));
+		client_->send(std::move(str), skip_log);
+
+		if (skip_log)
+			return;
 
 		if (data.length() < 512)
 		{


### PR DESCRIPTION
#640

Rebase of #667 for 2.2.0

Sending a PING to the server causes it to respond with PONG. Additional tokens can be added which will be returned with the PONG.
This command does not support the REQ/RES syntax as in order for it to be excluded from the logs the command has to be filtered out before that handling is applied.