### PR TITLE
[screen_consumer] Enable display selection on windows

### DIFF
--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -99,7 +99,7 @@
                 <latency>200 [0..]</latency>
             </system-audio>
             <screen>
-                <device>[0..]</device>
+                <device>1 [1..]</device>
                 <aspect-ratio>default [default|4:3|16:9]</aspect-ratio>
                 <stretch>fill [none|fill|uniform|uniform_to_fill]</stretch>
                 <windowed>true [true|false]</windowed>


### PR DESCRIPTION
Rebase of #620 for 2.2.0
Fixes: https://github.com/CasparCG/Server/issues/619

Currently, this only enables screen selection on windows as libX11 does not present a method of determining the position of screens. xrandr appears to calculate by looking at the relative positions of the screens, and adding this logic to CasparCG feels messy. An alternate solution would be to implement https://github.com/CasparCG/Server/issues/487

Some docs have been added to indicate that the property only works on windows, including a warning to the console if used on linux.

This also fixes issues:
- the size of a fullscreen consumer would use the dimensions of the primary screen when on a secondary screen
- a windowed consumer would always be positioned on the primary screen (this required removing the close button from the window)