### PR TITLE
Add support for Hw/ application watchdog to Bluefish consumer

### DIFF
--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -93,6 +93,7 @@
                 <key-only>false [true|false]</key-only>
                 <keyer>disabled [external|internal|disabled] (external only supported on channels 1 and 3, using 3 requires 4 out connectors) ( internal only available on devices with a hardware keyer) </keyer>
                 <internal-keyer-audio-source> videooutputchannel [videooutputchannel|sdivideoinput] ( only valid when using internal keyer option) </internal-keyer-audio-source>
+                <watchdog>2[0..] ( set to 0 to disable the HW watchdog functionality, otherwise this value indicates how many frames to wait after a crash, before enabling the bypass relay's on the card - only works on sdi-stream 1) </watchdog>
             </bluefish>
             <system-audio>
                 <channel-layout>stereo [mono|stereo|matrix]</channel-layout>

--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -91,7 +91,7 @@
                 <embedded-audio>false [true|false]</embedded-audio>
                 <channel-layout>stereo [mono|stereo|matrix|film|smpte|ebu_r123_8a|ebu_r123_8b|8ch|16ch]</channel-layout>
                 <key-only>false [true|false]</key-only>
-                <keyer>disabled [external|internal|disabled] (external only supported on channels 1 and 3, using 3 requires 4 out connectors) ( internal only available on devices with a hardware keyer) </keyer>
+                <keyer>disabled [external|internal|disabled] (external only supported on sdi-stream 1 and 3, 1 sets up sdi 1 & 2 and 3 sets up sdi 3 & 4)( internal only available on devices with a hardware keyer) </keyer>
                 <internal-keyer-audio-source> videooutputchannel [videooutputchannel|sdivideoinput] ( only valid when using internal keyer option) </internal-keyer-audio-source>
             </bluefish>
             <system-audio>

--- a/shell/casparcg.config
+++ b/shell/casparcg.config
@@ -91,7 +91,7 @@
                 <embedded-audio>false [true|false]</embedded-audio>
                 <channel-layout>stereo [mono|stereo|matrix|film|smpte|ebu_r123_8a|ebu_r123_8b|8ch|16ch]</channel-layout>
                 <key-only>false [true|false]</key-only>
-                <keyer>disabled [external|internal|disabled] (external only supported on sdi-stream 1 and 3, 1 sets up sdi 1 & 2 and 3 sets up sdi 3 & 4)( internal only available on devices with a hardware keyer) </keyer>
+                <keyer>disabled [external|internal|disabled] (external only supported on channels 1 and 3, using 3 requires 4 out connectors) ( internal only available on devices with a hardware keyer) </keyer>
                 <internal-keyer-audio-source> videooutputchannel [videooutputchannel|sdivideoinput] ( only valid when using internal keyer option) </internal-keyer-audio-source>
             </bluefish>
             <system-audio>


### PR DESCRIPTION
Add support for an application level watchdog, that talks to the bluefish device driver and can enable bypass relays if the application ( casparCG) crashes,

Watchdog only works on the first sdi- stream.  
watchdog is enabled by default, but can be disabled by setting a value of in the config file for the given channel.