### PR TITLE
Make sure DIAG window shows play channel and layer of HTML producer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -73,7 +73,7 @@ class html_client
     , public CefLoadHandler
 {
     std::wstring                        url_;
-    spl::shared_ptr<diagnostics::graph> graph_;
+	spl::shared_ptr<diagnostics::graph> graph_;
     caspar::timer                       tick_timer_;
     caspar::timer                       frame_timer_;
     caspar::timer                       paint_timer_;
@@ -95,9 +95,11 @@ class html_client
 
   public:
     html_client(spl::shared_ptr<core::frame_factory> frame_factory,
+				spl::shared_ptr<diagnostics::graph>  graph,
                 const core::video_format_desc&       format_desc,
                 const std::wstring&                  url)
         : url_(url)
+		, graph_(graph)
         , frame_factory_(std::move(frame_factory))
         , format_desc_(format_desc)
         , executor_(L"html_producer")
@@ -353,6 +355,7 @@ class html_producer : public core::frame_producer_base
     core::video_format_desc format_desc_;
     core::monitor::state    state_;
     const std::wstring      url_;
+	spl::shared_ptr<diagnostics::graph> graph_;
 
     CefRefPtr<html_client> client_;
 
@@ -364,7 +367,7 @@ class html_producer : public core::frame_producer_base
         , url_(url)
     {
         html::invoke([&] {
-            client_ = new html_client(frame_factory, format_desc, url_);
+            client_ = new html_client(frame_factory, graph_, format_desc, url_);
 
             CefWindowInfo window_info;
             window_info.width                        = format_desc.square_width;

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -73,7 +73,7 @@ class html_client
     , public CefLoadHandler
 {
     std::wstring                        url_;
-	spl::shared_ptr<diagnostics::graph> graph_;
+    spl::shared_ptr<diagnostics::graph> graph_;
     caspar::timer                       tick_timer_;
     caspar::timer                       frame_timer_;
     caspar::timer                       paint_timer_;
@@ -95,11 +95,11 @@ class html_client
 
   public:
     html_client(spl::shared_ptr<core::frame_factory> frame_factory,
-				spl::shared_ptr<diagnostics::graph>  graph,
+                spl::shared_ptr<diagnostics::graph>  graph,
                 const core::video_format_desc&       format_desc,
                 const std::wstring&                  url)
         : url_(url)
-		, graph_(graph)
+        , graph_(graph)
         , frame_factory_(std::move(frame_factory))
         , format_desc_(format_desc)
         , executor_(L"html_producer")
@@ -355,7 +355,7 @@ class html_producer : public core::frame_producer_base
     core::video_format_desc format_desc_;
     core::monitor::state    state_;
     const std::wstring      url_;
-	spl::shared_ptr<diagnostics::graph> graph_;
+    spl::shared_ptr<diagnostics::graph> graph_;
 
     CefRefPtr<html_client> client_;
 


### PR DESCRIPTION
This is currently not working because the graph sink is being created within a CEF context. I've fixed this by creating the sink while still in a Caspar context and then passing it.

This fixes the issue that the DIAG window wouldn't show the channel and layer where it's playing