### PR TITLE
Bases docker images on 'scratch' when possible...

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ resources
 .git
 .vscode
 CMakeFiles
+casparcg_server

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -1,7 +1,7 @@
 FROM casparcg/base:1.1.0 as build-casparcg
-	COPY --from=casparcg/boost:1.66 /opt/boost /opt/boost
-	COPY --from=casparcg/ffmpeg:3.4.1 /opt/ffmpeg /opt/ffmpeg
-	COPY --from=casparcg/cef:3.3239.1723 /opt/cef /opt/cef
+	COPY --from=casparcg/boost:1.66-1 /opt/boost /opt/boost
+	COPY --from=casparcg/ffmpeg:master-acdea9e-1 /opt/ffmpeg /opt/ffmpeg
+	COPY --from=casparcg/cef:3.3239.1723-1 /opt/cef /opt/cef
 
 	RUN mkdir /source && mkdir /build && mkdir /install
 

--- a/tools/linux/boost/Dockerfile
+++ b/tools/linux/boost/Dockerfile
@@ -7,5 +7,5 @@ FROM casparcg/base:1.0.0 as BUILD
 		./bootstrap.sh --prefix=/opt/boost && \
 		./b2 --with=all -j8 install || exit 0
 
-FROM ubuntu:artful
+FROM scratch
 	COPY --from=BUILD /opt/boost /opt/boost

--- a/tools/linux/cef/Dockerfile
+++ b/tools/linux/cef/Dockerfile
@@ -3,5 +3,5 @@ FROM casparcg/base:1.0.0 as BUILD
 	WORKDIR /opt
 	RUN tar -jxf cef.tar.bz2 && mv /opt/cef_binary_* /opt/cef
 
-FROM ubuntu:artful
+FROM scratch
 	COPY --from=BUILD /opt/cef /opt/cef

--- a/tools/linux/ffmpeg/Dockerfile
+++ b/tools/linux/ffmpeg/Dockerfile
@@ -1,5 +1,5 @@
 FROM casparcg/base:1.0.0 as BUILD
-	ENV FFMPEG_VERSION 3.4.1
+	ENV FFMPEG_COMMIT acdea9e7c56b74b05c56b4733acc855b959ba073
 
 	RUN apt-get install -yq --no-install-recommends \
 		autoconf \
@@ -57,10 +57,9 @@ FROM casparcg/base:1.0.0 as BUILD
 		libx265-dev \
 		libxvidcore-dev \
 		libfdk-aac-dev
-	RUN wget http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz && \
-		tar zxf ffmpeg-${FFMPEG_VERSION}.tar.gz && \
-		cd ffmpeg-${FFMPEG_VERSION}
-	WORKDIR ffmpeg-${FFMPEG_VERSION}
+	RUN wget https://github.com/FFmpeg/FFmpeg/archive/${FFMPEG_COMMIT}.tar.gz && \
+		tar zxf ${FFMPEG_COMMIT}.tar.gz
+	WORKDIR FFmpeg-${FFMPEG_COMMIT}
 	RUN ./configure \
 			--enable-version3 \
 			--enable-gpl \

--- a/tools/linux/ffmpeg/Dockerfile
+++ b/tools/linux/ffmpeg/Dockerfile
@@ -87,5 +87,5 @@ FROM casparcg/base:1.0.0 as BUILD
 		make -j8 && \
 		make install
 
-FROM ubuntu:artful
+FROM scratch
 	COPY --from=BUILD /opt/ffmpeg /opt/ffmpeg


### PR DESCRIPTION
@ronag when you merge this PR, please create new docker images and upload to the docker-hub.

If we change the docker image version, we should then update tools/linux/Dockerfile

I suggest we add a suffix to the version if we're not updating the source code it's built on.
casparcg/boost:1.66 => casparcg/boost:1.66-1
casparcg/ffmpeg:3.4.1 => casparcg/ffmpeg:3.4.1-1
casparcg/cef:3.3239.1723 => casparcg/cef:3.3239.1723-1