### PR TITLE
Fixes termination on Ctrl+C pressed in console window

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -126,9 +126,10 @@ auto run(const std::wstring& config_file_name, std::atomic<bool>& should_wait_fo
     std::thread([&]() mutable {
         std::wstring wcmd;
         while (true) {
-            if (!std::getline(std::wcin, wcmd)) // TODO: It's blocking...
-                wcmd = L"EXIT";                 // EOF, handle as EXIT
-
+            if (!std::getline(std::wcin, wcmd)) { // TODO: It's blocking...
+                std::wcin.clear();
+                continue;
+            }
             if (boost::iequals(wcmd, L"EXIT") || boost::iequals(wcmd, L"Q") || boost::iequals(wcmd, L"QUIT") ||
                 boost::iequals(wcmd, L"BYE")) {
                 CASPAR_LOG(info) << L"Received message from Console: " << wcmd << L"\\r\\n";

--- a/src/shell/windows_specific.cpp
+++ b/src/shell/windows_specific.cpp
@@ -84,7 +84,7 @@ void setup_console_window()
     // Disable close button in console to avoid shutdown without cleanup.
     EnableMenuItem(GetSystemMenu(GetConsoleWindow(), FALSE), SC_CLOSE, MF_GRAYED);
     DrawMenuBar(GetConsoleWindow());
-    // SetConsoleCtrlHandler(HandlerRoutine, true);
+    SetConsoleCtrlHandler(NULL, true);
 
     // Configure console size and position.
     auto coord = GetLargestConsoleWindowSize(hOut);


### PR DESCRIPTION
Fixes termination on Ctrl+C pressed in console window (Ctrl+Break remains working)
Re-posted #317 (sorry for delay)