### PR TITLE
Build Scripts for Ubuntu 16.04 / 17.10

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -50,6 +50,19 @@ Extracting CasparCG Server from Docker
 
 You will then find a folder called `casparcg_server` which should contain everything you need to run CasparCG Server.
 
+Development under Ubuntu
+-----------
+
+2 Scripts have been created to install dependencies and build boost/ffmpeg/cef.
+
+Ubuntu 16.04 (Xenial):
+From the base of the git repo, please run tools/linux/casparcg_build_dev_xenial.sh
+
+Ubuntu 17.10 (Artful):
+From the base of the git repo, please run tools/linux/casparcg_build_dev_artful.sh
+
+If all goes to plan, a folder called 'staging' has been created with everything you need to run CasparCG server.
+
 Development
 -----------
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ INSTALLATION ON WINDOWS
 
 INSTALLATION ON LINUX
 ---------------------
-   
+
+DEVELOPMENT / BUILDING FROM SOURCE 
+---------------------
+Please refer to BUILDING.md
+
+
 RESOLVING COMMON ISSUES ON LINUX
 --------------------------------
 

--- a/tools/linux/casparcg_build_dev_artful.sh
+++ b/tools/linux/casparcg_build_dev_artful.sh
@@ -65,54 +65,65 @@ apt-get install -yq --no-install-recommends \
 		libglfw3-dev \
 		libsfml-dev
 
+
 mkdir build_deps
 cd build_deps
-#wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
-#tar -zvxf boost_1_66_0.tar.gz
-#cd boost_1_66_0
-#./bootstrap.sh --prefix=/opt/boost
-#./b2 --with=all -j8 install
+
+echo "Build Boost"
+
+wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+tar -zvxf boost_1_66_0.tar.gz
+cd boost_1_66_0
+./bootstrap.sh --prefix=/opt/boost
+./b2 --with=all -j8 install
 
 
-#cd ../
-#wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
-#tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
-#cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
-#./configure \
-#                        --enable-version3 \
-#                        --enable-gpl \
-#                        --enable-nonfree \
-#                        --enable-small \
-#                        --enable-libmp3lame \
-#                        --enable-libx264 \
-#                        --enable-libx265 \
-#                        --enable-libvpx \
-#                        --enable-libtheora \
-#                        --enable-libvorbis \
-#                        --enable-libopus \
-#                        --enable-libfdk-aac \
-#                        --enable-libass \
-#                        --enable-libwebp \
-#                        --enable-librtmp \
-#                        --enable-postproc \
-#                        --enable-avresample \
-#                        --enable-libfreetype \
-#                        --enable-openssl \
- #                       --disable-debug \
-#                        --prefix=/opt/ffmpeg
+echo "Build FFMPEG"
 
-#make -j8
-#make install
+cd ../
+wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
+./configure \
+                        --enable-version3 \
+                        --enable-gpl \
+                        --enable-nonfree \
+                        --enable-small \
+                        --enable-libmp3lame \
+                        --enable-libx264 \
+                        --enable-libx265 \
+                        --enable-libvpx \
+                        --enable-libtheora \
+                        --enable-libvorbis \
+                        --enable-libopus \
+                        --enable-libfdk-aac \
+                        --enable-libass \
+                        --enable-libwebp \
+                        --enable-librtmp \
+                        --enable-postproc \
+                        --enable-avresample \
+                        --enable-libfreetype \
+                        --enable-openssl \
+                        --disable-debug \
+                        --prefix=/opt/ffmpeg
 
-#wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O /opt/cef.tar.bz2
-#cd /opt
-#tar -jxvf cef.tar.bz2 && mv /opt/cef_binary_* /opt/cef
-#rm -rf /opt/cef.tar.bz2
+make -j8
+make install
 
-cd ~/casparcg-server-master
+echo "Copy CEF"
+
+cd ../
+wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O cef.tar.bz2
+
+tar -jxvf cef.tar.bz2
+mkdir /opt/cef
+mv cef_binary_*/* /opt/cef
+
+cd ..
 mkdir build
 cd build
 
+echo "Build CasparCG"
 export BOOST_ROOT=/opt/boost
 export PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
 cmake ../src

--- a/tools/linux/casparcg_build_dev_artful.sh
+++ b/tools/linux/casparcg_build_dev_artful.sh
@@ -138,6 +138,6 @@ make -j8
 
 cd ..
 # Find a better way to copy deps
-ln -s staging build/staging
+ln -s build/staging staging
 src/shell/copy_deps.sh build/shell/casparcg staging/lib
 echo "DONE - See staging/ for app"

--- a/tools/linux/casparcg_build_dev_artful.sh
+++ b/tools/linux/casparcg_build_dev_artful.sh
@@ -1,12 +1,3 @@
-mkdir build_deps
-cd build_deps
-wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
-tar -zvxf boost_1_66_0.tar.gz
-cd boost_1_66_0
-./bootstrap.sh --prefix=/opt/boost
-./b2 --with=all -j8 install
-
-
 apt-get install -yq --no-install-recommends \
                 autoconf \
                 automake \
@@ -62,44 +53,63 @@ apt-get install -yq --no-install-recommends \
                 libx264-dev \
                 libx265-dev \
                 libxvidcore-dev \
-                libfdk-aac-dev
+                libfdk-aac-dev \
+		libwebp-dev \
+		build-essential \
+		cmake \
+		libtbb-dev \
+		libxrandr-dev \
+		libxcursor-dev \
+		libxinerama-dev \
+		libxi-dev \
+		libglfw3-dev \
+		libsfml-dev
 
-cd ../build_deps
-wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
-tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
-cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
-./configure \
-                        --enable-version3 \
-                        --enable-gpl \
-                        --enable-nonfree \
-                        --enable-small \
-                        --enable-libmp3lame \
-                        --enable-libx264 \
-                        --enable-libx265 \
-                        --enable-libvpx \
-                        --enable-libtheora \
-                        --enable-libvorbis \
-                        --enable-libopus \
-                        --enable-libfdk-aac \
-                        --enable-libass \
-                        --enable-libwebp \
-                        --enable-librtmp \
-                        --enable-postproc \
-                        --enable-avresample \
-                        --enable-libfreetype \
-                        --enable-openssl \
-                        --disable-debug \
-                        --prefix=/opt/ffmpeg
+mkdir build_deps
+cd build_deps
+#wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+#tar -zvxf boost_1_66_0.tar.gz
+#cd boost_1_66_0
+#./bootstrap.sh --prefix=/opt/boost
+#./b2 --with=all -j8 install
 
-make -j8
-make install
 
-wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O /opt/cef.tar.bz2
-cd /opt
-tar -jxvf cef.tar.bz2 && mv /opt/cef_binary_* /opt/cef
-rm -rf /opt/cef.tar.bz2
+#cd ../
+#wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+#tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+#cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
+#./configure \
+#                        --enable-version3 \
+#                        --enable-gpl \
+#                        --enable-nonfree \
+#                        --enable-small \
+#                        --enable-libmp3lame \
+#                        --enable-libx264 \
+#                        --enable-libx265 \
+#                        --enable-libvpx \
+#                        --enable-libtheora \
+#                        --enable-libvorbis \
+#                        --enable-libopus \
+#                        --enable-libfdk-aac \
+#                        --enable-libass \
+#                        --enable-libwebp \
+#                        --enable-librtmp \
+#                        --enable-postproc \
+#                        --enable-avresample \
+#                        --enable-libfreetype \
+#                        --enable-openssl \
+ #                       --disable-debug \
+#                        --prefix=/opt/ffmpeg
 
-cd ~/casparcg_server_master
+#make -j8
+#make install
+
+#wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O /opt/cef.tar.bz2
+#cd /opt
+#tar -jxvf cef.tar.bz2 && mv /opt/cef_binary_* /opt/cef
+#rm -rf /opt/cef.tar.bz2
+
+cd ~/casparcg-server-master
 mkdir build
 cd build
 

--- a/tools/linux/casparcg_build_dev_artful.sh
+++ b/tools/linux/casparcg_build_dev_artful.sh
@@ -1,0 +1,115 @@
+mkdir build_deps
+cd build_deps
+wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+tar -zvxf boost_1_66_0.tar.gz
+cd boost_1_66_0
+./bootstrap.sh --prefix=/opt/boost
+./b2 --with=all -j8 install
+
+
+apt-get install -yq --no-install-recommends \
+                autoconf \
+                automake \
+                cmake \
+                curl \
+                bzip2 \
+                libexpat1-dev \
+                g++ \
+                gcc \
+                git \
+                gperf \
+                libtool \
+                make \
+                nasm \
+                perl \
+                pkg-config \
+                python \
+                libssl-dev \
+                yasm \
+                zlib1g-dev \
+                libjpeg-dev \
+                libsndfile1-dev \
+                libglu1-mesa-dev \
+                libharfbuzz0b \
+                libpangoft2-1.0-0 \
+                libcairo2 \
+                libv4l-0 \
+                libraw1394-11 \
+                libavc1394-0 \
+                libiec61883-0 \
+                libxtst6 \
+                libnss3 \
+                libnspr4 \
+                libgconf-2-4 \
+                libasound2 \
+                libfreeimage-dev \
+                libglew-dev \
+                libopenal-dev \
+                libopus-dev \
+                libgsm1-dev \
+                libmodplug-dev \
+                libvpx-dev \
+                libass-dev \
+                libbluray-dev \
+                libfribidi-dev \
+		libgmp-dev \
+                libgnutls28-dev \
+                libmp3lame-dev \
+                libopencore-amrnb-dev \
+                libopencore-amrwb-dev \
+                librtmp-dev \
+                libtheora-dev \
+                libx264-dev \
+                libx265-dev \
+                libxvidcore-dev \
+                libfdk-aac-dev
+
+cd ../build_deps
+wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
+./configure \
+                        --enable-version3 \
+                        --enable-gpl \
+                        --enable-nonfree \
+                        --enable-small \
+                        --enable-libmp3lame \
+                        --enable-libx264 \
+                        --enable-libx265 \
+                        --enable-libvpx \
+                        --enable-libtheora \
+                        --enable-libvorbis \
+                        --enable-libopus \
+                        --enable-libfdk-aac \
+                        --enable-libass \
+                        --enable-libwebp \
+                        --enable-librtmp \
+                        --enable-postproc \
+                        --enable-avresample \
+                        --enable-libfreetype \
+                        --enable-openssl \
+                        --disable-debug \
+                        --prefix=/opt/ffmpeg
+
+make -j8
+make install
+
+wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O /opt/cef.tar.bz2
+cd /opt
+tar -jxvf cef.tar.bz2 && mv /opt/cef_binary_* /opt/cef
+rm -rf /opt/cef.tar.bz2
+
+cd ~/casparcg_server_master
+mkdir build
+cd build
+
+export BOOST_ROOT=/opt/boost
+export PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+cmake ../src
+make -j8
+
+cd ..
+# Find a better way to copy deps
+ln -s staging build/staging
+src/shell/copy_deps.sh build/shell/casparcg staging/lib
+echo "DONE - See staging/ for app"

--- a/tools/linux/casparcg_build_dev_artful.sh
+++ b/tools/linux/casparcg_build_dev_artful.sh
@@ -63,7 +63,14 @@ apt-get install -yq --no-install-recommends \
 		libxinerama-dev \
 		libxi-dev \
 		libglfw3-dev \
-		libsfml-dev
+		libsfml-dev \
+		libxcomposite-dev \
+		libpangocairo-1.0-0 \
+		libxss-dev \
+		libatk1.0-dev \
+		libcups2-dev \
+		libgtk2.0-dev \
+		libgdk-pixbuf2.0-dev
 
 
 mkdir build_deps

--- a/tools/linux/casparcg_build_dev_xenial.sh
+++ b/tools/linux/casparcg_build_dev_xenial.sh
@@ -70,7 +70,8 @@ apt-get install -yq --no-install-recommends \
 		libatk1.0-dev \
 		libcups2-dev \
 		libgtk2.0-dev \
-		libgdk-pixbuf2.0-dev
+		libgdk-pixbuf2.0-dev \
+		libicu-dev
 
 add-apt-repository ppa:ubuntu-toolchain-r/test -y
 apt-get update

--- a/tools/linux/casparcg_build_dev_xenial.sh
+++ b/tools/linux/casparcg_build_dev_xenial.sh
@@ -1,0 +1,147 @@
+apt-get install -yq --no-install-recommends \
+                autoconf \
+                automake \
+                cmake \
+                curl \
+                bzip2 \
+                libexpat1-dev \
+                g++ \
+                gcc \
+                git \
+                gperf \
+                libtool \
+                make \
+                nasm \
+                perl \
+                pkg-config \
+                python \
+                libssl-dev \
+                yasm \
+                zlib1g-dev \
+                libjpeg-dev \
+                libsndfile1-dev \
+                libglu1-mesa-dev \
+                libharfbuzz0b \
+                libpangoft2-1.0-0 \
+                libcairo2 \
+                libv4l-0 \
+                libraw1394-11 \
+                libavc1394-0 \
+                libiec61883-0 \
+                libxtst6 \
+                libnss3 \
+                libnspr4 \
+                libgconf-2-4 \
+                libasound2 \
+                libfreeimage-dev \
+                libglew-dev \
+                libopenal-dev \
+                libopus-dev \
+                libgsm1-dev \
+                libmodplug-dev \
+                libvpx-dev \
+                libass-dev \
+                libbluray-dev \
+                libfribidi-dev \
+		libgmp-dev \
+                libgnutls28-dev \
+                libmp3lame-dev \
+                libopencore-amrnb-dev \
+                libopencore-amrwb-dev \
+                librtmp-dev \
+                libtheora-dev \
+                libx264-dev \
+                libx265-dev \
+                libxvidcore-dev \
+                libfdk-aac-dev \
+		libwebp-dev \
+		build-essential \
+		cmake \
+		libtbb-dev \
+		libxrandr-dev \
+		libxcursor-dev \
+		libxinerama-dev \
+		libxi-dev \
+		libglfw3-dev \
+		libsfml-dev \
+		libxcomposite-dev \
+		libpangocairo-1.0-0 \
+		libxss-dev \
+		libatk1.0-dev \
+		libcups2-dev \
+		libgtk2.0-dev \
+		libgdk-pixbuf2.0-dev
+
+add-apt-repository ppa:ubuntu-toolchain-r/test -y
+apt-get update
+apt-get install gcc-7 g++-7 -y
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+
+mkdir build_deps
+cd build_deps
+
+echo "Build Boost"
+
+wget https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz
+tar -zvxf boost_1_66_0.tar.gz
+cd boost_1_66_0
+./bootstrap.sh --prefix=/opt/boost
+./b2 --with=all -j8 install
+
+
+echo "Build FFMPEG"
+
+cd ../
+wget https://github.com/FFmpeg/FFmpeg/archive/acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+tar -zxvf  acdea9e7c56b74b05c56b4733acc855b959ba073.tar.gz
+cd FFmpeg-acdea9e7c56b74b05c56b4733acc855b959ba073
+./configure \
+                        --enable-version3 \
+                        --enable-gpl \
+                        --enable-nonfree \
+                        --enable-small \
+                        --enable-libmp3lame \
+                        --enable-libx264 \
+                        --enable-libx265 \
+                        --enable-libvpx \
+                        --enable-libtheora \
+                        --enable-libvorbis \
+                        --enable-libopus \
+                        --enable-libfdk-aac \
+                        --enable-libass \
+                        --enable-libwebp \
+                        --enable-librtmp \
+                        --enable-postproc \
+                        --enable-avresample \
+                        --enable-libfreetype \
+                        --enable-openssl \
+                        --disable-debug \
+                        --prefix=/opt/ffmpeg
+
+make -j8
+make install
+
+echo "Copy CEF"
+
+cd ../
+wget http://opensource.spotify.com/cefbuilds/cef_binary_3.3239.1723.g071d1c1_linux64_minimal.tar.bz2 -O cef.tar.bz2
+
+tar -jxvf cef.tar.bz2
+mkdir /opt/cef
+mv cef_binary_*/* /opt/cef
+
+cd ..
+mkdir build
+cd build
+
+echo "Build CasparCG"
+export BOOST_ROOT=/opt/boost
+export PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+cmake ../src
+make -j8
+
+cd ..
+# Find a better way to copy deps
+ln -s build/staging staging
+src/shell/copy_deps.sh build/shell/casparcg staging/lib
+echo "DONE - See staging/ for app"


### PR DESCRIPTION
All,

I've created 2 build scripts, for 16.04 and 17.10, this is to install all the required dependencies and compile boost/ffmpeg.

Be aware that on 16.04 - GCC 7.2 will be installed from backports required for building CCG.
This will become the default Compiler

Andy