### PR TITLE
Explicitly check if filename starts with http or https before setting related flags

### DIFF
--- a/src/modules/ffmpeg/producer/av_input.cpp
+++ b/src/modules/ffmpeg/producer/av_input.cpp
@@ -109,10 +109,11 @@ void Input::reset()
     AVDictionary* options = nullptr;
     CASPAR_SCOPE_EXIT{ av_dict_free(&options); };
 
-    // TODO (fix) check if filename is http
-    FF(av_dict_set(&options, "http_persistent", "0", 0));  // NOTE https://trac.ffmpeg.org/ticket/7034#comment:3
-    FF(av_dict_set(&options, "http_multiple", "0", 0));    // NOTE https://trac.ffmpeg.org/ticket/7034#comment:3
-    FF(av_dict_set(&options, "reconnect", "1", 0));        // HTTP reconnect
+    if (filename_.find("http://") == 0 || filename_.find("https://") == 0) {
+        FF(av_dict_set(&options, "http_persistent", "0", 0));  // NOTE https://trac.ffmpeg.org/ticket/7034#comment:3
+        FF(av_dict_set(&options, "http_multiple", "0", 0));    // NOTE https://trac.ffmpeg.org/ticket/7034#comment:3
+        FF(av_dict_set(&options, "reconnect", "1", 0));        // HTTP reconnect
+    }
                                                            // TODO (fix) timeout?
     FF(av_dict_set(&options, "rw_timeout", "5000000", 0)); // 5 second IO timeout
 


### PR DESCRIPTION
This fixes #887 