### PR TITLE
docs: Improve issue reports upon creation for easier handling

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,20 @@
+<!-- Please feel free to add or remove more information based on your context -->
+
+### Expected Behaviour
+<!-- If bug report, write short description of expected behaviour -->
+<!-- If feature/improvment, tell us how it should work -->
+
+### Current Behaviour
+<!-- If bug report, write short description of current behaviour -->
+<!-- If improvment, compare it to expected behavior -->
+
+<!-- If not bug report, remove everything below this line -->
+### Steps to Reproduce 
+
+### Environment
+* CasparCG Server version:
+* Operating system:
+<!-- Optional - Graphics driver: -->
+<!-- Optional - Decklink drivers: -->
+
+### Attachments


### PR DESCRIPTION
More and more issues are reported and sometimes crucial information is missing already from the begining of the issue. By adding this template and asking for information when creating an issue will increaee the quality of issues. It will also minimize the time to give feedback on a certain issue.