### PR TITLE
fix(decklink_producer): build on linux

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -97,7 +97,7 @@ struct Filter
     AVFilterContext*               video_source = nullptr;
     AVFilterContext*               audio_source = nullptr;
 
-    Filter(std::string filter_spec, AVMediaType type, const core::video_format_desc& format_desc, IDeckLinkDisplayMode* dm)
+    Filter(std::string filter_spec, AVMediaType type, const core::video_format_desc& format_desc, com_ptr<IDeckLinkDisplayMode> dm)
     {
         if (type == AVMEDIA_TYPE_VIDEO) {
             if (filter_spec.empty()) {


### PR DESCRIPTION
Current versions did not compile on linux due to a type mismatch. I don't have a windows installation so I haven't checked compilaton there, but I can't imagine it would go wrong.