### PR TITLE
Don't let ffmpeg handle .html files

### DIFF
--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -320,10 +320,15 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
     auto vfilter = boost::to_lower_copy(get_param(L"VF", params, filter_str));
     auto afilter = boost::to_lower_copy(get_param(L"AF", params, get_param(L"FILTER", params, L"")));
 
-    auto producer = spl::make_shared<ffmpeg_producer>(
-        dependencies.frame_factory, dependencies.format_desc, name, path, vfilter, afilter, start, duration, loop);
-
-    return core::create_destroy_proxy(std::move(producer));
+    try {
+        auto producer = spl::make_shared<ffmpeg_producer>(
+            dependencies.frame_factory, dependencies.format_desc, name, path, vfilter, afilter, start, duration, loop);
+        return core::create_destroy_proxy(std::move(producer));
+    }
+    catch (...) {
+        CASPAR_LOG_CURRENT_EXCEPTION();
+    }
+    return core::frame_producer::empty();
 }
 
 }} // namespace caspar::ffmpeg

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -274,6 +274,10 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
     auto name = params.at(0);
     auto path = name;
 
+    if (boost::contains(path, L".html")) {
+        return core::frame_producer::empty();
+    }
+
     if (!boost::contains(path, L"://")) {
         path = boost::filesystem::path(probe_stem(env::media_folder() + L"/" + path)).generic_wstring();
         name += boost::filesystem::path(path).extension().wstring();

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -447,21 +447,7 @@ spl::shared_ptr<core::frame_producer> create_cg_producer(const core::frame_produ
 spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies,
                                                       const std::vector<std::wstring>&         params)
 {
-    const auto filename       = env::template_folder() + params.at(0) + L".html";
-    const auto found_filename = find_case_insensitive(filename);
-    const auto html_prefix    = boost::iequals(params.at(0), L"[HTML]");
-
-    if (!found_filename && !html_prefix)
-        return core::frame_producer::empty();
-
-    const auto url = found_filename ? L"file://" + *found_filename : params.at(1);
-
-    if (!html_prefix && (!boost::algorithm::contains(url, ".") || boost::algorithm::ends_with(url, "_A") ||
-                         boost::algorithm::ends_with(url, "_ALPHA")))
-        return core::frame_producer::empty();
-
-    return core::create_destroy_proxy(
-        spl::make_shared<html_producer>(dependencies.frame_factory, dependencies.format_desc, url));
+    return create_cg_producer(dependencies, params);
 }
 
 }} // namespace caspar::html

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -430,15 +430,16 @@ class html_producer : public core::frame_producer_base
 spl::shared_ptr<core::frame_producer> create_cg_producer(const core::frame_producer_dependencies& dependencies,
                                                          const std::vector<std::wstring>&         params)
 {
-    const auto filename       = env::template_folder() + params.at(0) + L".html";
+    const auto param_url      = boost::iequals(params.at(0), L"[HTML]") ? params.at(1) : params.at(0);
+    const auto filename       = env::template_folder() + param_url + L".html";
     const auto found_filename = find_case_insensitive(filename);
-    const auto http_prefix    = boost::algorithm::istarts_with(params.at(0), L"http:") ||
-                             boost::algorithm::istarts_with(params.at(0), L"https:");
+    const auto http_prefix    = boost::algorithm::istarts_with(param_url, L"http:") ||
+                             boost::algorithm::istarts_with(param_url, L"https:");
 
     if (!found_filename && !http_prefix)
         return core::frame_producer::empty();
 
-    const auto url = found_filename ? L"file://" + *found_filename : params.at(0);
+    const auto url = found_filename ? L"file://" + *found_filename : param_url;
 
     return core::create_destroy_proxy(
         spl::make_shared<html_producer>(dependencies.frame_factory, dependencies.format_desc, url));


### PR DESCRIPTION
This PR does a few things:

* Checks if the filename contains '.html' in the ffmpeg producer. And if so, returns an empty frame producer.
* Checks if the ffmpeg producer could be created and if not, returns an empty frame producer (currently it will swallow the request and if it fails, it stops. This gives other producers no change to handle the files)
* Removes the [HTML] prefix from the HTML producer. The HTML producer tries to handle input after the ffmpeg producer, so all HLS/DASH and other HTTP-like streams will be handled by ffmpeg in the first place. Because of the previous point, all other items that ffmpeg can't handle will then be passed to subsequent producers (including the HTML producer) and thus, the [HTML] prefix is unneccesary.


What I've tested:
* Normal file (PLAY 1-1 AMB)
* HLS stream (PLAY 1-1 https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8)
* HTML template (PLAY 1-1 graphics, graphics.html in template directory)
* PLAY explicit HTML file (PLAY 1-1 https://google.com/index.html)
* PLAY regular URL (PLAY 1-1 http://google.com)

About the last point: When ffmpeg does try to play the html page (e.g. http://google.com), it will log an error (just as now), but then the HTML producer will pick it up and it will play succesfully.