### PR TITLE
fix: Building from zip on Windows

### DIFF
--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -3,7 +3,7 @@ find_package(Git)
 set(CONFIG_VERSION_GIT_REV "0")
 set(CONFIG_VERSION_GIT_HASH "N/A")
 
-if (GIT_FOUND)
+if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/../.git")
 	exec_program("${GIT_EXECUTABLE}" "${PROJECT_SOURCE_DIR}"
 			ARGS rev-list --all --count
 			OUTPUT_VARIABLE CONFIG_VERSION_GIT_REV)


### PR DESCRIPTION
Solves the issue with invalid CASPAR_REV and CASPAR_HASH fields in version.h when building from zip (no .git folder present)

With this I can now build from zip following the instructions in BUILDING.md, skipping just the git clone step.

#828