### PR TITLE
Build freeimage against vs2015

### DIFF
--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -135,10 +135,11 @@ casparcg_add_runtime_dependency("${NUGET_PACKAGES_FOLDER}/sfml-system.redist.2.4
 casparcg_add_runtime_dependency("${NUGET_PACKAGES_FOLDER}/sfml-system.redist.2.4.2.0/build/native/bin/x64/v140/Release/dynamic/sfml-system-2.dll")
 
 # FREEIMAGE
-set(FREEIMAGE_INCLUDE_PATH "${NUGET_PACKAGES_FOLDER}/native.freeimage.3.17.0/build/native/include")
-set(FREEIMAGE_BIN_PATH "${NUGET_PACKAGES_FOLDER}/native.freeimage.redist.3.17.0/build/native/bin/x64/dynamic")
-link_directories("${NUGET_PACKAGES_FOLDER}/native.freeimage.3.17.0/build/native/lib/x64/dynamic")
+set(FREEIMAGE_INCLUDE_PATH "${NUGET_PACKAGES_FOLDER}/native.freeimage.vc140.3.17.0/build/native/include")
+set(FREEIMAGE_BIN_PATH "${NUGET_PACKAGES_FOLDER}/native.freeimage.vc140.redist.3.17.0/build/native/bin/x64/dynamic")
+link_directories("${NUGET_PACKAGES_FOLDER}/native.freeimage.vc140.3.17.0/build/native/lib/x64")
 casparcg_add_runtime_dependency("${FREEIMAGE_BIN_PATH}/FreeImage.dll")
+casparcg_add_runtime_dependency("${FREEIMAGE_BIN_PATH}/FreeImaged.dll")
 
 #ZLIB
 set(ZLIB_INCLUDE_PATH "${NUGET_PACKAGES_FOLDER}/zlib-msvc-x64.1.2.11.8900/build/native/include")

--- a/src/modules/image/CMakeLists.txt
+++ b/src/modules/image/CMakeLists.txt
@@ -45,7 +45,8 @@ if(MSVC)
 		common
 		core
 
-		FreeImage.lib
+		optimized FreeImage.lib
+		debug FreeImaged.lib
 	)
 else()
 	target_link_libraries(image

--- a/src/modules/image/packages.config
+++ b/src/modules/image/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.66.0.0" targetFramework="native" />
-  <package id="native.freeimage" version="3.17.0" targetFramework="native" />
-  <package id="native.freeimage.redist" version="3.17.0" targetFramework="native" />
+  <package id="native.freeimage.vc140" version="3.17.0" targetFramework="native" />
+  <package id="native.freeimage.vc140.redist" version="3.17.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Fixes #926 

I had to make my own nuget package for this.
Build scripts with instructions: https://github.com/Julusian/nuget-freeimage

@dotarmin do you want to transfer that repo to the caspar org?
If you create a casparcg nuget user, I can make you an owner of the nuget package too.

Alternatively, if it is too much work to maintain a nuget package, this could be put back into git as it is small enough and new versions arent released very often.