### PR TITLE
Fix some opengl logging

### DIFF
--- a/src/accelerator/ogl/util/device.cpp
+++ b/src/accelerator/ogl/util/device.cpp
@@ -89,10 +89,10 @@ struct device::impl : public std::enable_shared_from_this<impl>
                                                "since it does not support OpenGL 4.5 or higher."));
         }
 
-        CASPAR_LOG(info) << L"Successfully initialized OpenGL " << version();
-
         version_ = u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VERSION)))) + L" " +
                    u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VENDOR))));
+
+        CASPAR_LOG(info) << L"Successfully initialized OpenGL " << version();
 
         GL(glCreateFramebuffers(1, &fbo_));
         GL(glBindFramebuffer(GL_FRAMEBUFFER, fbo_));

--- a/src/common/gl/gl_check.cpp
+++ b/src/common/gl/gl_check.cpp
@@ -36,7 +36,8 @@ void SMFL_GLCheckError(const std::string&, const char* func, const char* file, u
     GLenum LastErrorCode = GL_NO_ERROR;
 
     for (GLenum ErrorCode = glGetError(); ErrorCode != GL_NO_ERROR; ErrorCode = glGetError()) {
-        CASPAR_LOG(error) << "OpenGL Error: " << ErrorCode << L" " << glewGetErrorString(ErrorCode);
+        std::string str(reinterpret_cast< const char* >(glewGetErrorString(ErrorCode)));
+        CASPAR_LOG(error) << "OpenGL Error: " << ErrorCode << L" " << str;
         LastErrorCode = ErrorCode;
     }
 


### PR DESCRIPTION
The version number string had not been built before it was being written to the log.

When an OpenGL exception was thrown, the error code was being turned into a string with the memory address being printed instead of the string