### PR TITLE
Make clang-format work with Visual Studio

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,7 +31,7 @@ BraceWrapping:
   AfterObjCDeclaration: false
   AfterStruct: true
   AfterUnion: true
-  AfterExternBlock: true
+  #AfterExternBlock: true
   BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
@@ -69,7 +69,7 @@ IncludeCategories:
     Priority: 1
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
-IndentPPDirectives: None
+#IndentPPDirectives: None
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
@@ -85,10 +85,10 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-RawStringFormats: 
-  - Delimiter: pb
-    Language: TextProto
-    BasedOnStyle: google
+#RawStringFormats: 
+#  - Delimiter: pb
+#    Language: TextProto
+#    BasedOnStyle: google
 ReflowComments: true
 SortIncludes: true
 SortUsingDeclarations: true


### PR DESCRIPTION
Fixes #822 

> Specifically, we ship version 5.0 of the clang-format.exe.

I had to comment out these lines for it to be accepted due to the version of clang-format being used, but then it just works.

The one requirement I found was that the VS solution has to be located inside the git tree, which it will be if following BUILDING.md