### PR TITLE
Fix osc total-time when paused #945

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -784,7 +784,7 @@ struct AVProducer::Impl
         CASPAR_SCOPE_EXIT
         {
             graph_->set_text(u16(print()));
-            state_["file/time"] = {time() / format_desc_.fps, input_.duration().value_or(0) / format_desc_.fps};
+            state_["file/time"] = {time() / format_desc_.fps, duration().value_or(0) / format_desc_.fps};
         };
 
         {


### PR DESCRIPTION
I haven't tested it, but this makes the prev_frame code be consistent with next_frame so I am confident it will fix the issue.
