### PR TITLE
PR wip send background producer info via osc

### DIFF
--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -128,6 +128,7 @@ struct layer::impl
 
             state_.clear();
             state_["paused"] = is_paused_;
+            state_["background"] = background_->print();
             state_.insert_or_assign(foreground_->state());
 
             return frame;


### PR DESCRIPTION
This is all I've been able to figure out to get info about background producer.  The producer updates it's state in the ```receive()``` method which hasn't yet been called if it's in the background.  Currently this is a hack to call ```print()``` on the background producer and send it via osc.  @ronag can you give us some direction on this?

Related #941 