### PR TITLE
Add support for bluefish producer

### DIFF
--- a/src/modules/bluefish/CMakeLists.txt
+++ b/src/modules/bluefish/CMakeLists.txt
@@ -3,12 +3,14 @@ project (bluefish)
 
 set(SOURCES
 		consumer/bluefish_consumer.cpp
+        producer/bluefish_producer.cpp
 		util/blue_velvet.cpp
 		bluefish.cpp
 		StdAfx.cpp
 )
 set(HEADERS
 		consumer/bluefish_consumer.h
+         producer/bluefish_producer.h
         interop/BlueVelvetC.h
         interop/BlueVelvetCUtils.h
         util/blue_velvet.h
@@ -30,6 +32,7 @@ include_directories(${FFMPEG_INCLUDE_PATH})
 set_target_properties(bluefish PROPERTIES FOLDER modules)
 source_group(sources ./*)
 source_group(sources\\consumer consumer/*)
+source_group(sources\\producer producer/*)
 source_group(sources\\util util/*)
 source_group(sources\\interop interop/*)
 

--- a/src/modules/bluefish/bluefish.cpp
+++ b/src/modules/bluefish/bluefish.cpp
@@ -25,6 +25,7 @@
 #include "bluefish.h"
 
 #include "consumer/bluefish_consumer.h"
+#include "producer/bluefish_producer.h"
 
 #include "util/blue_velvet.h"
 
@@ -85,6 +86,7 @@ void init(core::module_dependencies dependencies)
 
 	dependencies.consumer_registry->register_consumer_factory(L"Bluefish Consumer", create_consumer);
 	dependencies.consumer_registry->register_preconfigured_consumer_factory(L"bluefish", create_preconfigured_consumer);
+    dependencies.producer_registry->register_producer_factory(L"Bluefish Producer", create_producer);
 }
 
 }}

--- a/src/modules/bluefish/producer/bluefish_producer.cpp
+++ b/src/modules/bluefish/producer/bluefish_producer.cpp
@@ -1,0 +1,596 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+*
+* This file is part of CasparCG (www.casparcg.com).
+*
+* CasparCG is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* CasparCG is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+*
+* Author:Robert Nagy, ronag89@gmail.com
+*		 satchit puthenveetil
+*        James Wise, james.wise@bluefish444.com
+*/
+
+
+#include "../StdAfx.h" 
+
+#include "bluefish_producer.h"
+
+#include "../util/blue_velvet.h"
+#include "../util/memory.h"
+
+#include <common/executor.h>
+#include <common/diagnostics/graph.h>
+#include <common/except.h>
+#include <common/log.h>
+#include <common/param.h>
+#include <common/timer.h>
+#include <common/scope_exit.h>
+
+#include <ffmpeg/util/av_assert.h>
+#include <ffmpeg/util/av_util.h>
+
+#include <core/frame/frame.h>
+#include <core/frame/draw_frame.h>
+#include <core/frame/frame_transform.h>
+#include <core/frame/frame_factory.h>
+#include <core/producer/frame_producer.h>
+#include <core/monitor/monitor.h>
+#include <core/diagnostics/call_context.h>
+#include <core/mixer/audio/audio_mixer.h>
+
+#include <tbb/concurrent_queue.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+
+#include <boost/circular_buffer.hpp>
+#include <boost/timer.hpp>
+#include <boost/range/algorithm.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/format.hpp>
+
+#include <functional>
+#include <mutex>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+extern "C"
+{
+  #include <libavcodec/avcodec.h>
+  #include <libavfilter/avfilter.h>
+  #include <libavfilter/buffersink.h>
+  #include <libavfilter/buffersrc.h>
+  #include <libavformat/avformat.h>
+  #include <libavutil/opt.h>
+  #include <libavutil/pixfmt.h>
+  #include <libavutil/samplefmt.h>
+  #include <libavutil/timecode.h>
+}
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+
+using namespace caspar::ffmpeg;
+
+namespace caspar { namespace bluefish {
+
+static const size_t MAX_DECODED_AUDIO_BUFFER_SIZE = 2002*16;  // max 2002 samples, 16 channels.
+
+template <typename T>
+std::wstring to_string(const T& cadence)
+{
+	return boost::join(cadence | boost::adaptors::transformed([](size_t i) { return boost::lexical_cast<std::wstring>(i); }), L", ");
+}
+
+unsigned int get_bluesdk_input_videochannel_from_streamid(int stream_id)
+{
+    /*This function would return the corresponding EBlueVideoChannel from them stream_id argument */
+    switch (stream_id)
+    {
+        case 1:	return BLUE_VIDEO_INPUT_CHANNEL_A;
+        case 2:	return BLUE_VIDEO_INPUT_CHANNEL_B;
+        case 3:	return BLUE_VIDEO_INPUT_CHANNEL_C;
+        case 4:	return BLUE_VIDEO_INPUT_CHANNEL_D;
+        default: return BLUE_VIDEO_INPUT_CHANNEL_A;
+    }
+}
+
+unsigned int extract_pcm_data_from_hanc(bvc_wrapper& blue, struct hanc_decode_struct* decode_struct, unsigned int card_type, unsigned int* src_hanc_buffer, unsigned int* pcm_audio_buffer, int audio_channels_to_extract)
+{
+    decode_struct->audio_pcm_data_ptr = pcm_audio_buffer;
+    decode_struct->type_of_sample_required = 0;                 // No flags indicates default of 32bit samples.
+    decode_struct->max_expected_audio_sample_count = 2002;
+
+    if (audio_channels_to_extract == 2)
+        decode_struct->audio_ch_required_mask = MONO_CHANNEL_1 | MONO_CHANNEL_2;
+    else if (audio_channels_to_extract == 8)
+        decode_struct->audio_ch_required_mask = MONO_CHANNEL_1 | MONO_CHANNEL_2 | MONO_CHANNEL_3 | MONO_CHANNEL_4 | MONO_CHANNEL_5 | MONO_CHANNEL_6 | MONO_CHANNEL_7 | MONO_CHANNEL_8;
+    else if (audio_channels_to_extract == 16)
+        decode_struct->audio_ch_required_mask = MONO_CHANNEL_1 | MONO_CHANNEL_2 | MONO_CHANNEL_3 | MONO_CHANNEL_4 | MONO_CHANNEL_5 | MONO_CHANNEL_6 | MONO_CHANNEL_7 | MONO_CHANNEL_8 | MONO_CHANNEL_11 | MONO_CHANNEL_12 | MONO_CHANNEL_13 | MONO_CHANNEL_14 | MONO_CHANNEL_15 | MONO_CHANNEL_16 | MONO_CHANNEL_17 | MONO_CHANNEL_18;
+
+    blue.decode_hanc_frame(card_type, src_hanc_buffer, decode_struct);
+
+    return decode_struct->no_audio_samples;
+}
+
+struct bluefish_producer : boost::noncopyable
+{
+	const int							    device_index_;
+    const int                               stream_index_;
+	spl::shared_ptr<bvc_wrapper>		    blue_;
+
+    core::monitor::state                    state_;
+    spl::shared_ptr<diagnostics::graph>     graph_;
+	caspar::timer							tick_timer_;
+    caspar::timer							processing_benchmark_timer_;
+
+    std::vector<int>                        audio_cadence_;
+    const std::wstring						model_name_ = std::wstring(L"bluefish");
+
+    std::atomic_bool						process_capture_ = true;
+    std::shared_ptr<std::thread>            capture_thread_;
+    std::array<blue_dma_buffer_ptr, 4>	    reserved_frames_;
+
+	core::video_format_desc				    format_desc_;
+    unsigned int                            mode_;
+
+	spl::shared_ptr<core::frame_factory>	frame_factory_;
+
+	tbb::concurrent_bounded_queue<core::draw_frame>	frame_buffer_;
+	std::exception_ptr					    exception_;
+
+	ULONG									schedule_capture_frame_id_ = 0;
+	ULONG									capturing_frame_id_ = std::numeric_limits<ULONG>::max();
+	ULONG									dma_ready_captured_frame_id_ = std::numeric_limits<ULONG>::max();
+	
+	struct hanc_decode_struct				hanc_decode_struct_;
+    std::vector<uint32_t>                   decoded_audio_bytes_;
+    unsigned int							memory_format_on_card_;
+    int                                     frames_captured = 0;
+    uint64_t                                capture_ts = 0;
+
+public:
+	bluefish_producer(const core::video_format_desc&              format_desc,
+		              int                                         device_index,
+                      int                                         stream_index,
+		              const spl::shared_ptr<core::frame_factory>& frame_factory)
+	: blue_(create_blue(device_index))
+	, device_index_(device_index)
+    , stream_index_(stream_index)                                 
+	, frame_factory_(frame_factory)
+	, model_name_(get_card_desc(*blue_, device_index))
+	, memory_format_on_card_(MEM_FMT_RGB) 
+    {
+        mode_ = static_cast<unsigned int>(VID_FMT_INVALID);
+		frame_buffer_.set_capacity(2);
+        unsigned int invalid_video_mode_flag = VID_FMT_INVALID;
+
+		graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
+		graph_->set_color("late-frame", diagnostics::color(0.6f, 0.3f, 0.3f));
+		graph_->set_color("frame-time", diagnostics::color(1.0f, 0.0f, 0.0f));
+		graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
+		graph_->set_color("output-buffer", diagnostics::color(0.0f, 1.0f, 0.0f));
+		graph_->set_text(print());
+		diagnostics::register_graph(graph_);
+
+	    memset(&hanc_decode_struct_, 0, sizeof(hanc_decode_struct_));
+		hanc_decode_struct_.audio_input_source = AUDIO_INPUT_SOURCE_EMB;
+
+        decoded_audio_bytes_.resize(MAX_DECODED_AUDIO_BUFFER_SIZE);
+
+    // Configure input connector and routing
+        unsigned int bf_channel = get_bluesdk_input_videochannel_from_streamid(stream_index);
+        if (BLUE_FAIL(blue_->set_card_property32(DEFAULT_VIDEO_INPUT_CHANNEL, (bf_channel))))
+            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to set input channel."));
+
+        if (BLUE_FAIL(configure_input_routing(bf_channel, true)))       // to do: tofix pass rgba vs use actual dual link!!
+          CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to set input routing."));
+
+		//Select Update Mode for input
+		if (BLUE_FAIL(blue_->set_card_property32(VIDEO_INPUT_UPDATE_TYPE, UPD_FMT_FRAME)))
+			CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to set input update type."));
+
+		//Select input memory format
+		if (BLUE_FAIL(blue_->set_card_property32(VIDEO_INPUT_MEMORY_FORMAT, memory_format_on_card_)))
+			CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to set input memory format."));
+
+		//Select image orientation
+		if (BLUE_FAIL(blue_->set_card_property32(VIDEO_INPUTFRAMESTORE_IMAGE_ORIENTATION, ImageOrientation_Normal)))
+			CASPAR_LOG(warning) << print() << L" Failed to set image orientation to normal.";
+
+		// Select data range
+		if (BLUE_FAIL(blue_->set_card_property32(EPOCH_VIDEO_INPUT_RGB_DATA_RANGE, CGR_RANGE)))     // todo: confirm if we want to pass CGR or SMPTe range to caspar!!!!
+			CASPAR_LOG(warning) << print() << L" Failed to set RGB data range to CGR.";
+
+		blue_->get_card_property32(VIDEO_INPUT_SIGNAL_VIDEO_MODE, mode_);  
+        blue_->get_card_property32(INVALID_VIDEO_MODE_FLAG, invalid_video_mode_flag);
+        if (mode_ < invalid_video_mode_flag)
+        {
+
+            format_desc_ = get_format_desc(*blue_, static_cast<EVideoMode>(mode_), static_cast<EMemoryFormat>(memory_format_on_card_));
+            audio_cadence_ = format_desc_.audio_cadence;
+
+        // Generate dma buffers
+		    int n = 0;
+		    boost::range::generate(reserved_frames_, [&] {return std::make_shared<blue_dma_buffer>(static_cast<int>(format_desc_.size), n++); });
+
+            // Set Video Engine
+		    if (BLUE_FAIL(blue_->set_card_property32(VIDEO_INPUT_ENGINE, VIDEO_ENGINE_FRAMESTORE)))
+			    CASPAR_LOG(warning) << print() << TEXT(" Failed to set video engine.");
+
+            capture_thread_ = std::make_shared<std::thread>([this]
+            {
+			   capture_thread_actual();
+		    });
+        }
+	}
+
+    int configure_input_routing(const unsigned int bf_channel, bool dual_link)
+    {
+    unsigned int routing_value = 0;
+    unsigned int routing_value_b = 0;
+
+    /*This function would return the corresponding EBlueVideoChannel from the device output channel*/
+    switch (bf_channel)
+    {
+        case BLUE_VIDEO_INPUT_CHANNEL_A:
+            if (dual_link)
+            {
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_A, EPOCH_DEST_INPUT_MEM_INTERFACE_CHA, BLUE_CONNECTOR_PROP_DUALLINK_LINK_1);
+                routing_value_b = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_B, EPOCH_DEST_INPUT_MEM_INTERFACE_CHA, BLUE_CONNECTOR_PROP_DUALLINK_LINK_2);
+            }
+            else
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_A, EPOCH_DEST_INPUT_MEM_INTERFACE_CHA, BLUE_CONNECTOR_PROP_SINGLE_LINK);
+            break;
+        case BLUE_VIDEO_INPUT_CHANNEL_B:
+            if (dual_link)
+            {
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_B, EPOCH_DEST_INPUT_MEM_INTERFACE_CHB, BLUE_CONNECTOR_PROP_DUALLINK_LINK_1);
+                routing_value_b = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_C, EPOCH_DEST_INPUT_MEM_INTERFACE_CHB, BLUE_CONNECTOR_PROP_DUALLINK_LINK_2);
+            }
+            else
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_B, EPOCH_DEST_INPUT_MEM_INTERFACE_CHB, BLUE_CONNECTOR_PROP_SINGLE_LINK);
+            break;
+        case BLUE_VIDEO_INPUT_CHANNEL_C:
+            if (dual_link)
+            {
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_C, EPOCH_DEST_INPUT_MEM_INTERFACE_CHC, BLUE_CONNECTOR_PROP_DUALLINK_LINK_1);
+                routing_value_b = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_D, EPOCH_DEST_INPUT_MEM_INTERFACE_CHC, BLUE_CONNECTOR_PROP_DUALLINK_LINK_2);
+            }
+            else
+                routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_C, EPOCH_DEST_INPUT_MEM_INTERFACE_CHC, BLUE_CONNECTOR_PROP_SINGLE_LINK);
+            break;
+        case BLUE_VIDEO_INPUT_CHANNEL_D:
+            routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_D, EPOCH_DEST_INPUT_MEM_INTERFACE_CHD, BLUE_CONNECTOR_PROP_SINGLE_LINK);
+            break;
+        default:
+            routing_value = EPOCH_SET_ROUTING(EPOCH_SRC_SDI_INPUT_A, EPOCH_DEST_INPUT_MEM_INTERFACE_CHA, BLUE_CONNECTOR_PROP_SINGLE_LINK);
+            break;
+    }
+
+    if (dual_link)
+    {
+        blue_->set_card_property32(MR2_ROUTING, routing_value);
+        return blue_->set_card_property32(MR2_ROUTING, routing_value_b);
+    }
+    else
+        return blue_->set_card_property32(MR2_ROUTING, routing_value);
+    }
+
+    void schedule_capture()
+    {
+	    blue_->render_buffer_capture(BlueBuffer_Image_HANC(schedule_capture_frame_id_));
+        dma_ready_captured_frame_id_ = capturing_frame_id_;
+        capturing_frame_id_ = schedule_capture_frame_id_;
+        schedule_capture_frame_id_ = (++schedule_capture_frame_id_ % 4);
+    }
+
+    void get_capture_time()
+    {
+        blue_->get_card_property64(BTC_TIMER, capture_ts);
+    }
+
+    HRESULT process_data()
+    {
+        caspar::timer frame_timer;     
+
+        // Get info for source video mode
+        unsigned int width = 0;
+        unsigned int height = 0;
+        unsigned int rate = 0;
+        unsigned int is_1001 = 0;
+        unsigned int is_progressive = 0;
+        unsigned int image_size = 0;
+        blue_->get_frame_info_for_video_mode(mode_, width, height, rate, is_1001, is_progressive);
+        blue_->get_bytes_per_frame(static_cast<EVideoMode>(mode_), static_cast<EMemoryFormat>(memory_format_on_card_), UPD_FMT_FRAME, image_size);
+        double fps = rate;
+        if (is_1001)
+          fps = (rate * 1000) / 1001;
+
+        CASPAR_SCOPE_EXIT
+        {
+            state_["file/name"] = model_name_;
+            state_["file/path"] = device_index_;
+            state_["file/video/width"] = static_cast<long>(width);
+            state_["file/video/height"] = static_cast<long>(height);
+            state_["file/audio/sample-rate"] = format_desc_.audio_sample_rate;
+            state_["file/audio/channels"] = format_desc_.audio_channels;
+            state_["file/fps"] = static_cast<double>(fps);
+            state_["profiler/time"] = { frame_timer.elapsed(), fps };
+            state_["buffer"] = { frame_buffer_.size(), frame_buffer_.capacity() };
+
+            graph_->set_value("frame-time", frame_timer.elapsed() * fps / format_desc_.field_count * 0.5);      
+            graph_->set_value("output-buffer", static_cast<float>(frame_buffer_.size()) / static_cast<float>(frame_buffer_.capacity()));
+        };
+
+        try
+        {
+            graph_->set_value("tick-time", tick_timer_.elapsed() * fps * 0.5);
+            tick_timer_.restart();
+            {
+                auto src_video = alloc_frame();
+                auto src_audio = alloc_frame();
+
+                // video
+                src_video->format = AV_PIX_FMT_RGB24; 
+                src_video->width = width;
+                src_video->height = height;
+                src_video->interlaced_frame = !is_progressive;
+                src_video->top_field_first = (height != 486);
+                src_video->key_frame = 1;
+                src_video->display_picture_number = frames_captured; 
+                src_video->pts = capture_ts;
+
+                void* video_bytes = nullptr;
+                video_bytes = reserved_frames_.front()->image_data();
+                if (reserved_frames_.front() && video_bytes)
+                {
+                    src_video->data[0] = reinterpret_cast<uint8_t*>(reserved_frames_.front()->image_data());
+                    src_video->linesize[0] = static_cast<int>(image_size / height);
+                }
+
+                // Audio
+                src_audio->format = AV_SAMPLE_FMT_S32;
+                src_audio->channels = format_desc_.audio_channels;   
+                src_audio->sample_rate = format_desc_.audio_sample_rate;
+
+                void* audio_bytes = nullptr;
+                auto hanc_buffer = reinterpret_cast<uint8_t*>(reserved_frames_.front()->hanc_data());
+                if (hanc_buffer)
+                {
+                    int card_type = CRD_INVALID;
+                    blue_->query_card_type(card_type, device_index_);
+                    auto no_extracted_pcm_samples = extract_pcm_data_from_hanc(*blue_, &hanc_decode_struct_,
+                                                                                card_type,
+                                                                                reinterpret_cast<unsigned int*>(hanc_buffer),
+                                                                                reinterpret_cast<unsigned int*>(&decoded_audio_bytes_[0]), src_audio->channels);
+
+                    audio_bytes = reinterpret_cast<int32_t*>(&decoded_audio_bytes_[0]);
+
+                    src_audio->nb_samples = no_extracted_pcm_samples / src_audio->channels;
+                    src_audio->data[0] = reinterpret_cast<uint8_t*>(audio_bytes);
+                    src_audio->linesize[0] = src_audio->nb_samples * src_audio->channels * av_get_bytes_per_sample(static_cast<AVSampleFormat>(src_audio->format));
+                    src_audio->pts = capture_ts;
+                }
+
+                // pass to caspar
+                auto frame = core::draw_frame(make_frame(this, *frame_factory_, src_video, src_audio));
+                if (!frame_buffer_.try_push(frame))
+                {
+                    core::draw_frame dummy;
+                    frame_buffer_.try_pop(dummy);
+                    frame_buffer_.try_push(frame);
+                    graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+                }
+            }
+            boost::range::rotate(audio_cadence_, std::end(audio_cadence_) - 1);
+        }
+        catch (...)
+        {
+          exception_ = std::current_exception();
+          return E_FAIL;
+        }
+
+    return S_OK;
+  }
+
+	void grab_frame_from_bluefishcard()
+	{
+		try
+		{
+            if (reserved_frames_.front()->image_data())
+            {
+		        blue_->system_buffer_read(const_cast<uint8_t*>(reserved_frames_.front()->image_data()),
+			        static_cast<unsigned long>(reserved_frames_.front()->image_size()),
+			        BlueImage_DMABuffer(dma_ready_captured_frame_id_, BLUE_DATA_IMAGE),
+			        0);
+            }
+            
+            if (reserved_frames_.front()->hanc_data())
+            {
+			    blue_->system_buffer_read(const_cast<uint8_t*>(reserved_frames_.front()->hanc_data()),
+				    static_cast<unsigned long>(reserved_frames_.front()->hanc_size()),
+				    BlueImage_DMABuffer(dma_ready_captured_frame_id_, BLUE_DATA_HANC),
+				    0);
+            }
+            
+		}
+		catch (...)
+		{
+			exception_ = std::current_exception();
+			return ;
+		}
+	}
+
+    void capture_thread_actual()
+    {
+        ULONG current_field_count = 0;
+        ULONG last_field_count = 0;
+        ULONG start_field_count = 0;
+        unsigned int invalid_video_mode_flag = VID_FMT_INVALID;
+        unsigned int current_input_video_signal = VID_FMT_INVALID;
+        blue_->get_card_property32(INVALID_VIDEO_MODE_FLAG, invalid_video_mode_flag);
+
+        last_field_count = current_field_count;
+        start_field_count = current_field_count;
+
+        while (process_capture_)
+        {
+            //tell the card to capture another frame at the next interrupt
+            schedule_capture();
+
+            blue_->wait_video_input_sync(UPD_FMT_FRAME, current_field_count);
+            get_capture_time();
+
+            if (last_field_count + 3 < current_field_count)
+                CASPAR_LOG(warning) << L"Error: dropped " << ((current_field_count - last_field_count - 2) / 2) << L" frames" << L"Current " << current_field_count << L"  Old " << last_field_count;
+
+            last_field_count = current_field_count;
+            blue_->get_card_property32(VIDEO_INPUT_SIGNAL_VIDEO_MODE, current_input_video_signal);
+            if (current_input_video_signal < invalid_video_mode_flag && dma_ready_captured_frame_id_ != std::numeric_limits<ULONG>::max())
+            {
+                //DoneID is now what ScheduleID was at the last iteration when we called render_buffer_capture(ScheduleID)
+                //we just checked if the video signal for the buffer “DoneID” was valid while it was capturing so we can DMA the buffer
+                //DMA the frame from the card to our buffer
+                grab_frame_from_bluefishcard();
+                process_data();
+                processing_benchmark_timer_.restart();
+                boost::range::rotate(reserved_frames_, std::begin(reserved_frames_) + 1);
+
+                frames_captured++;
+            }
+        }
+    }
+
+	~bluefish_producer()
+	{
+      try
+      {
+          process_capture_ = false;
+          if (capture_thread_)
+          {
+            Sleep(41);
+            capture_thread_->join();
+          }
+
+          blue_->detach();
+      }
+      catch (...)
+      {
+          CASPAR_LOG_CURRENT_EXCEPTION();
+      }
+	}
+
+	core::draw_frame get_frame()
+	{
+		if(exception_ != nullptr)
+			std::rethrow_exception(exception_);
+		
+		core::draw_frame frame;
+		if(!frame_buffer_.try_pop(frame))
+        {
+			graph_->set_tag(diagnostics::tag_severity::WARNING, "late-frame");
+        }
+		return frame;
+	}
+	
+	std::wstring print() const
+	{
+		return model_name_ + L" [" + boost::lexical_cast<std::wstring>(device_index_) + L"|" + format_desc_.name + L"]";
+	}
+
+    const core::monitor::state& state() { return state_; }
+
+    boost::rational<int> get_out_framerate() const { return format_desc_.framerate; }
+};
+
+class bluefish_producer_proxy : public core::frame_producer_base
+{
+	std::unique_ptr<bluefish_producer>	producer_;
+	const uint32_t						length_;
+	executor							executor_;
+
+public:
+	explicit bluefish_producer_proxy(
+        const core::video_format_desc&              format_desc,
+	    const spl::shared_ptr<core::frame_factory>& frame_factory,
+		int                                         device_index,
+        int                                         stream_index,
+		uint32_t                                    length)
+	: executor_(L"bluefish_producer[" + boost::lexical_cast<std::wstring>(device_index) + L"]")
+	, length_(length)
+	{
+        auto ctx = core::diagnostics::call_context::for_thread();
+		executor_.invoke([=]
+		{
+            core::diagnostics::call_context::for_thread() = ctx;
+			producer_.reset(new bluefish_producer(format_desc, device_index, stream_index, frame_factory));
+		});
+	}
+
+	~bluefish_producer_proxy()
+	{		
+		executor_.invoke([=]
+		{
+			producer_.reset();
+		});
+	}
+
+  const core::monitor::state& state() const { return producer_->state(); }
+
+  // frame_producer
+
+  core::draw_frame receive_impl(int nb_samples) override { return producer_->get_frame(); }
+
+  uint32_t nb_frames() const override { return length_; }
+
+  std::wstring print() const override { return producer_->print(); }
+
+  std::wstring name() const override { return L"bluefish"; }
+
+  boost::rational<int> get_out_framerate() const { return producer_->get_out_framerate(); }
+};
+
+spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params)
+{
+    if(params.empty() || !boost::iequals(params.at(0), "bluefish"))
+	    return core::frame_producer::empty();
+
+	auto device_index	= get_param(L"DEVICE", params, -1);
+	if(device_index == -1)
+		device_index = boost::lexical_cast<int>(params.at(1));
+
+    auto stream_index = get_param(L"SDI-STREAM", params, -1);
+    if (stream_index == -1)
+        stream_index = 1;             
+
+	auto length = get_param(L"LENGTH", params, std::numeric_limits<uint32_t>::max()); 	
+	auto in_format_desc = core::video_format_desc(get_param(L"FORMAT", params, L"INVALID"));
+	
+    auto producer = spl::make_shared<bluefish_producer_proxy>(
+        dependencies.format_desc,
+		dependencies.frame_factory,
+		device_index,
+        stream_index,
+		length);
+
+  return create_destroy_proxy(producer);
+}
+
+}} // namespace bluefish

--- a/src/modules/bluefish/producer/bluefish_producer.h
+++ b/src/modules/bluefish/producer/bluefish_producer.h
@@ -1,0 +1,35 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+*
+* This file is part of CasparCG (www.casparcg.com).
+*
+* CasparCG is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* CasparCG is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+*
+* Author: Robert Nagy, ronag89@gmail.com
+*		  satchit puthenveetil
+*         James Wise, james.wise@bluefish444.com
+*/
+
+#pragma once
+
+#include <core/fwd.h>
+
+#include <string>
+#include <vector>
+
+namespace caspar { namespace bluefish {
+
+spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies, const std::vector<std::wstring>& params);
+
+}}

--- a/src/modules/bluefish/util/blue_velvet.cpp
+++ b/src/modules/bluefish/util/blue_velvet.cpp
@@ -154,6 +154,16 @@ namespace caspar { namespace bluefish {
 		return bfcSetCardProperty32(bvc_.get(), iProperty, nValue);
 	}
 
+    BLUE_UINT32 bvc_wrapper::get_card_property64(const int iProperty, unsigned long long& nValue)
+    {
+        return (BLUE_UINT32)bfcQueryCardProperty64(bvc_.get(), iProperty, nValue);
+    }
+
+    BLUE_UINT32 bvc_wrapper::set_card_property64(const int iProperty, const unsigned long long nValue)
+    {
+        return bfcSetCardProperty64(bvc_.get(), iProperty, nValue);
+    }
+
 	BLUE_UINT32 bvc_wrapper::enumerate(int & iDevices)
 	{
 		return bfcEnumerate(bvc_.get(), iDevices);
@@ -233,13 +243,66 @@ namespace caspar { namespace bluefish {
 
 	BLUE_UINT32 bvc_wrapper::get_bytes_per_frame(EVideoMode nVideoMode, EMemoryFormat nMemoryFormat, EUpdateMethod nUpdateMethod, unsigned int& nBytesPerFrame)
 	{
-		return bfcGetBytesPerFrame(nVideoMode, nMemoryFormat, nUpdateMethod, nBytesPerFrame);
+        return bfcGetGoldenValue(nVideoMode, nMemoryFormat, nUpdateMethod, nBytesPerFrame);
 	}
 
-  std::string bvc_wrapper::get_string_for_card_type(unsigned int nCardType)
-  {
-    return bfcUtilsGetStringForCardType(nCardType);
-  }
+    std::string bvc_wrapper::get_string_for_card_type(unsigned int nCardType)
+    {
+        return bfcUtilsGetStringForCardType(nCardType);
+    }
+
+    std::wstring bvc_wrapper::get_wstring_for_video_mode(unsigned int nVideoMode)
+    {
+        std::wstring mode_desc;
+        switch (nVideoMode)
+        {
+        case  VID_FMT_PAL:	        mode_desc = L"pal";
+            break;
+        case  VID_FMT_NTSC:     	mode_desc = L"ntsc";
+            break;
+        case  VID_FMT_720P_2398:	mode_desc = L"720p23";
+            break;
+        case  VID_FMT_720P_2400:	mode_desc = L"720p24";
+            break;
+        case  VID_FMT_720P_2500:	mode_desc = L"720p25";
+            break;
+        case  VID_FMT_720P_5000:	mode_desc = L"720p50";
+            break;
+        case  VID_FMT_720P_2997:	mode_desc = L"720p29";
+            break;
+        case  VID_FMT_720P_5994:	mode_desc = L"720p59";
+            break;
+        case  VID_FMT_720P_3000:	mode_desc = L"720p30";
+            break;
+        case  VID_FMT_720P_6000:	mode_desc = L"720p60";
+            break;
+        case  VID_FMT_1080P_2397:	mode_desc = L"1080p23";
+            break;
+        case  VID_FMT_1080P_2400:	mode_desc = L"1080p24";
+            break;
+        case  VID_FMT_1080I_5000:	mode_desc = L"1080i50";
+            break;
+        case  VID_FMT_1080I_5994:	mode_desc = L"1080i59";
+            break;
+        case  VID_FMT_1080I_6000:	mode_desc = L"1080i60";
+            break;
+        case  VID_FMT_1080P_2500:	mode_desc = L"1080p25";
+            break;
+        case  VID_FMT_1080P_2997:	mode_desc = L"1080p29";
+            break;
+        case  VID_FMT_1080P_3000:	mode_desc = L"1080p30";
+            break;
+        case  VID_FMT_1080P_5000:	mode_desc = L"1080p50";
+            break;
+        case  VID_FMT_1080P_5994:	mode_desc = L"1080p59";
+            break;
+        case  VID_FMT_1080P_6000:	mode_desc = L"1080p60";
+            break;
+        default:					mode_desc = L"invalid";
+            break;
+        }
+        return mode_desc;
+    }
 
   int  bvc_wrapper::get_num_audio_samples_for_frame(const BLUE_UINT32 nVideoMode, const BLUE_UINT32 nFrameNo)
   {
@@ -324,36 +387,40 @@ bool is_epoch_neutron_3o_card(bvc_wrapper& blue)
 		return false;
 }
 
-// also fix this damn confusion between the 2 funcs !! 
 std::wstring get_card_desc(bvc_wrapper blue, int device_id)
 {
-  // TODO: 1. can we use bfcUtils here?
-  // TODO: 2. - should we make it return name and Fw typoe ie... "Neutron 2i2o"
   std::wstring card_desc;
-
   int card_type = 0;
   blue.query_card_type(card_type, device_id);
 
   switch (card_type)
   {
-  case CRD_BLUE_EPOCH_2K_CORE:		  card_desc = L"Blue Epoch 2K Core";
-  case CRD_BLUE_EPOCH_2K_ULTRA:		  card_desc = L"Blue Epoch 2K Ultra";
-  case CRD_BLUE_EPOCH_HORIZON:		  card_desc = L"Blue Epoch Horizon";
-  case CRD_BLUE_EPOCH_CORE:			    card_desc = L"Blue Epoch Core";
-  case CRD_BLUE_EPOCH_ULTRA:			  card_desc = L"Blue Epoch Ultra";
-  case CRD_BLUE_CREATE_HD:			    card_desc = L"Blue Create HD";
-  case CRD_BLUE_CREATE_2K:			    card_desc = L"Blue Create 2K";
-  case CRD_BLUE_CREATE_2K_ULTRA:		card_desc = L"Blue Create 2K Ultra";
-  case CRD_BLUE_SUPER_NOVA:			    card_desc = L"Blue SuperNova";
-  case CRD_BLUE_SUPER_NOVA_S_PLUS:	card_desc = L"Blue SuperNova s+";
-  case CRD_BLUE_NEUTRON:				    card_desc = L"Blue Neutron 4k";
-  case CRD_BLUE_EPOCH_CG:				    card_desc = L"Blue Epopch CG";
-  default:							            card_desc = L"Unknown";
+  case CRD_BLUE_EPOCH_2K_CORE:		    card_desc = L"Bluefish Epoch 2K Core";
+      break;
+  case CRD_BLUE_EPOCH_2K_ULTRA:		    card_desc = L"Bluefish Epoch 2K Ultra";
+      break;
+  case CRD_BLUE_EPOCH_HORIZON:		    card_desc = L"Bluefish Epoch Horizon";
+      break;
+  case CRD_BLUE_EPOCH_CORE:			    card_desc = L"Blufishe Epoch Core";
+      break;
+  case CRD_BLUE_EPOCH_ULTRA:			card_desc = L"Bluefish Epoch Ultra";
+      break;
+  case CRD_BLUE_CREATE_HD:			    card_desc = L"Bluefish Create HD";
+      break;
+  case CRD_BLUE_CREATE_2K:			    card_desc = L"Bluefish Create 2K";
+      break;
+  case CRD_BLUE_CREATE_2K_ULTRA:		card_desc = L"Bluefish Create 2K Ultra";
+      break;
+  case CRD_BLUE_SUPER_NOVA:			    card_desc = L"Bluefish SuperNova";
+      break;
+  case CRD_BLUE_SUPER_NOVA_S_PLUS:	    card_desc = L"Bluefish SuperNova s+";
+      break;
+  case CRD_BLUE_NEUTRON:				card_desc = L"Bluefish Neutron 4k";
+      break;
+  case CRD_BLUE_EPOCH_CG:				card_desc = L"Bluefish Epoch CG";
+      break;
+  default:							    card_desc = L"Unknown";
   }
-
-  // refine the card name by adding xixo  to infomr the specific variant.  eg "Blue Neutron 4k 3o"
-
-  // TODO: do this!!!!
   return card_desc;
 }
 
@@ -396,9 +463,7 @@ core::video_format_desc get_format_desc(bvc_wrapper& blue, EVideoMode vid_fmt, E
 	core::video_format_desc fmt;
 	unsigned int width, height, duration = 0, time_scale = 0, rate = 0, bIs1001 = 0, is_progressive = 0, size = 0;
 	std::vector<int>	audio_cadence;
-  int field_count = 1;
-
-	//core::field_mode video_field_mode = core::field_mode::progressive;
+    int field_count = 1;
 
 	blue.get_frame_info_for_video_mode(vid_fmt, width, height, rate, bIs1001, is_progressive);
 	blue.get_bytes_per_frame(vid_fmt, mem_fmt, UPD_FMT_FRAME, size);
@@ -410,7 +475,6 @@ core::video_format_desc get_format_desc(bvc_wrapper& blue, EVideoMode vid_fmt, E
 		duration = 30000;
 		time_scale = 1001;
 		audio_cadence = { 1601,1602,1601,1602,1602 };
-	//	video_field_mode = core::field_mode::upper;
 		break;
 	case VID_FMT_2048_1080P_2500:
 	case VID_FMT_2048_1080PSF_2500:
@@ -490,12 +554,15 @@ core::video_format_desc get_format_desc(bvc_wrapper& blue, EVideoMode vid_fmt, E
 		break;
 	}
 
-  if (!is_progressive)
-    field_count = 2;
+    if (!is_progressive)
+        field_count = 2;
 
-  fmt.field_count = 2;
-  fmt = get_caspar_video_format(vid_fmt);
-  fmt.size = size;
+    fmt.field_count = field_count;
+    fmt = get_caspar_video_format(vid_fmt);
+    fmt.size = size;
+    fmt.audio_cadence = audio_cadence;
+    fmt.name = blue.get_wstring_for_video_mode(vid_fmt);
+
 	return fmt;
 }
 

--- a/src/modules/bluefish/util/blue_velvet.h
+++ b/src/modules/bluefish/util/blue_velvet.h
@@ -118,6 +118,9 @@ public:
 
 	BLUE_UINT32 get_card_property32(const int iProperty, unsigned int& nValue);
 	BLUE_UINT32 set_card_property32(const int iProperty, const unsigned int nValue);
+
+    BLUE_UINT32 get_card_property64(const int iProperty, unsigned long long& nValue);
+    BLUE_UINT32 set_card_property64(const int iProperty, const unsigned long long nValue);
 	
 	BLUE_UINT32 system_buffer_write(unsigned char* pPixels, unsigned long ulSize, unsigned long ulBufferID, unsigned long ulOffset);
 	BLUE_UINT32 system_buffer_read(unsigned char* pPixels, unsigned long ulSize, unsigned long ulBufferID, unsigned long ulOffset);
@@ -139,9 +142,10 @@ public:
 	BLUE_UINT32 get_frame_info_for_video_mode(const unsigned int nVideoMode, unsigned int&  nWidth, unsigned int& nHeight, unsigned int& nRate, unsigned int& bIs1001, unsigned int& bIsProgressive);
 	BLUE_UINT32 get_bytes_per_frame(EVideoMode nVideoMode, EMemoryFormat nMemoryFormat, EUpdateMethod nUpdateMethod, unsigned int& nBytesPerFrame);
 
-  std::string get_string_for_card_type(unsigned int nCardType);
+    std::string get_string_for_card_type(unsigned int nCardType);
+    std::wstring get_wstring_for_video_mode(unsigned int nVideoMode);
 
-  int         get_num_audio_samples_for_frame(const BLUE_UINT32 nVideoMode, const BLUE_UINT32 nFrameNo);
+    int         get_num_audio_samples_for_frame(const BLUE_UINT32 nVideoMode, const BLUE_UINT32 nFrameNo);
 
 private:
 	bool					init_function_pointers();

--- a/src/modules/bluefish/util/memory.h
+++ b/src/modules/bluefish/util/memory.h
@@ -17,14 +17,13 @@
 * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
 *
 * Author: Robert Nagy, ronag89@gmail.com
+          James Wise, james.wise@bluefish444.com
 */
 
 #pragma once
 
 #include <Windows.h>
-
-#include <tbb/scalable_allocator.h>
-
+#include <boost/align.hpp>
 #include <vector>
 
 namespace caspar { namespace bluefish {
@@ -54,8 +53,8 @@ private:
 	int id_;
 	size_t image_size_;
 	size_t hanc_size_;
-	std::vector<BYTE> image_buffer_;
-	std::vector<BYTE> hanc_buffer_;
+    std::vector<BYTE, boost::alignment::aligned_allocator<BYTE, 64> > image_buffer_;
+    std::vector<BYTE, boost::alignment::aligned_allocator<BYTE, 64> > hanc_buffer_;
 };
 typedef std::shared_ptr<blue_dma_buffer> blue_dma_buffer_ptr;
 


### PR DESCRIPTION
- add support for bluefish consumer, including new files
	producer\
		bluefish_producer.h
		bluefish_producer.cpp
- add alignment to the way we allocate memory for bluefish DMA objects (memory.h)
- new helper functions in bvc_wrapper class.
- fixed some minor bugs in bvc_wrapper