### PR TITLE
fix: #917 Initialize cout logger before loading config file

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -212,6 +212,7 @@ int main(int argc, char** argv)
         if (argc >= 2)
             config_file_name = caspar::u16(argv[1]);
 
+        log::add_cout_sink();
         env::configure(config_file_name);
 
         log::set_log_level(env::properties().get(L"configuration.log-level", L"info"));
@@ -220,7 +221,6 @@ int main(int argc, char** argv)
             wait_for_remote_debugging();
 
         // Start logging to file.
-        log::add_cout_sink();
         log::add_file_sink(env::log_folder() + L"caspar");
         std::wcout << L"Logging [info] or higher severity to " << env::log_folder() << std::endl << std::endl;
 


### PR DESCRIPTION
With this I now get the following on linux when the config file doesn't exist
```
/home/julus/Projects/ccg22/src/cmake-build-debug/staging/bin/casparcg ../casparcg.config
Type "q" to close application.
[2018-04-14 01:02:31.263] [error]    ### Invalid configuration file. ###
[2018-04-14 01:02:31.263] [fatal]   At ../casparcg.config:0: read error. Please check the configuration file (../casparcg.config) for errors.

Process finished with exit code 0
```