### PR TITLE
Switch OpenGL code to use a Core 4.5 profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 build
 CMakeFiles
 casparcg_server
+
+src/cmake-build-*
+src/.idea

--- a/src/accelerator/ogl/util/device.cpp
+++ b/src/accelerator/ogl/util/device.cpp
@@ -74,6 +74,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
     impl()
         : work_(make_work_guard(service_))
+        , device_(sf::ContextSettings(0, 0, 0, 4, 5, sf::ContextSettings::Attribute::Core), 1, 1)
     {
         CASPAR_LOG(info) << L"Initializing OpenGL Device.";
 
@@ -83,16 +84,16 @@ struct device::impl : public std::enable_shared_from_this<impl>
             CASPAR_THROW_EXCEPTION(gl::ogl_exception() << msg_info("Failed to initialize GLEW."));
         }
 
-        if (!GLEW_VERSION_4_5) {
+        version_ = u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VERSION)))) + L" " +
+                   u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VENDOR))));
+
+        CASPAR_LOG(info) << L"Initialized OpenGL " << version();
+
+        if (!GLEW_VERSION_4_5 && !glewIsSupported("GL_ARB_sync GL_ARB_shader_objects GL_ARB_multitexture GL_ARB_direct_state_access GL_ARB_texture_barrier")) {
             CASPAR_THROW_EXCEPTION(not_supported()
                                    << msg_info("Your graphics card does not meet the minimum hardware requirements "
                                                "since it does not support OpenGL 4.5 or higher."));
         }
-
-        version_ = u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VERSION)))) + L" " +
-                   u16(reinterpret_cast<const char*>(GL2(glGetString(GL_VENDOR))));
-
-        CASPAR_LOG(info) << L"Successfully initialized OpenGL " << version();
 
         GL(glCreateFramebuffers(1, &fbo_));
         GL(glBindFramebuffer(GL_FRAMEBUFFER, fbo_));

--- a/src/accelerator/ogl/util/shader.cpp
+++ b/src/accelerator/ogl/util/shader.cpp
@@ -31,7 +31,8 @@ namespace caspar { namespace accelerator { namespace ogl {
 struct shader::impl : boost::noncopyable
 {
     GLuint                                 program_;
-    std::unordered_map<std::string, GLint> locations_;
+    std::unordered_map<std::string, GLint> uniform_locations_;
+    std::unordered_map<std::string, GLint> attrib_locations_;
 
   public:
     impl(const std::string& vertex_source_str, const std::string& fragment_source_str)
@@ -97,28 +98,36 @@ struct shader::impl : boost::noncopyable
 
     ~impl() { glDeleteProgram(program_); }
 
-    GLint get_location(const char* name)
+    GLint get_uniform_location(const char* name)
     {
-        auto it = locations_.find(name);
-        if (it == locations_.end())
-            it = locations_.insert(std::make_pair(name, glGetUniformLocation(program_, name))).first;
+        auto it = uniform_locations_.find(name);
+        if (it == uniform_locations_.end())
+            it = uniform_locations_.insert(std::make_pair(name, glGetUniformLocation(program_, name))).first;
+        return it->second;
+    }
+
+    GLint get_attrib_location(const char* name)
+    {
+        auto it = attrib_locations_.find(name);
+        if (it == attrib_locations_.end())
+            it = attrib_locations_.insert(std::make_pair(name, glGetAttribLocation(program_, name))).first;
         return it->second;
     }
 
     void set(const std::string& name, bool value) { set(name, value ? 1 : 0); }
 
-    void set(const std::string& name, int value) { GL(glUniform1i(get_location(name.c_str()), value)); }
+    void set(const std::string& name, int value) { GL(glUniform1i(get_uniform_location(name.c_str()), value)); }
 
-    void set(const std::string& name, float value) { GL(glUniform1f(get_location(name.c_str()), value)); }
+    void set(const std::string& name, float value) { GL(glUniform1f(get_uniform_location(name.c_str()), value)); }
 
     void set(const std::string& name, double value0, double value1)
     {
-        GL(glUniform2f(get_location(name.c_str()), static_cast<float>(value0), static_cast<float>(value1)));
+        GL(glUniform2f(get_uniform_location(name.c_str()), static_cast<float>(value0), static_cast<float>(value1)));
     }
 
     void set(const std::string& name, double value)
     {
-        GL(glUniform1f(get_location(name.c_str()), static_cast<float>(value)));
+        GL(glUniform1f(get_uniform_location(name.c_str()), static_cast<float>(value)));
     }
 
     void use() { GL(glUseProgramObjectARB(program_)); }
@@ -134,6 +143,7 @@ void shader::set(const std::string& name, int value) { impl_->set(name, value); 
 void shader::set(const std::string& name, float value) { impl_->set(name, value); }
 void shader::set(const std::string& name, double value0, double value1) { impl_->set(name, value0, value1); }
 void shader::set(const std::string& name, double value) { impl_->set(name, value); }
+GLint shader::get_attrib_location(const char* name) { return impl_->get_attrib_location(name); }
 int  shader::id() const { return impl_->program_; }
 void shader::use() const { impl_->use(); }
 

--- a/src/accelerator/ogl/util/shader.h
+++ b/src/accelerator/ogl/util/shader.h
@@ -42,6 +42,8 @@ class shader final
     void set(const std::string& name, double value0, double value1);
     void set(const std::string& name, double value);
 
+    GLint get_attrib_location(const char* name);
+
     template <typename E>
     typename std::enable_if<std::is_enum<E>::value, void>::type set(const std::string& name, E value)
     {

--- a/src/core/frame/geometry.cpp
+++ b/src/core/frame/geometry.cpp
@@ -43,13 +43,10 @@ struct frame_geometry::impl
     impl(frame_geometry::geometry_type type, std::vector<coord> data)
         : type_(type)
     {
-        if (type == geometry_type::quad && data.size() != 4)
-            CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("The number of coordinates needs to be 4"));
-
-        if (type == geometry_type::quad_list) {
-            if (data.size() % 4 != 0)
+        if (type == geometry_type::triangles) {
+            if (data.size() % 3 != 0)
                 CASPAR_THROW_EXCEPTION(invalid_argument()
-                                       << msg_info("The number of coordinates needs to be a multiple of 4"));
+                                       << msg_info("The number of coordinates needs to be a multiple of 3"));
         }
 
         data_ = std::move(data);
@@ -74,9 +71,11 @@ const frame_geometry& frame_geometry::get_default()
         {0.0, 0.0, 0.0, 0.0}, // upper left
         {1.0, 0.0, 1.0, 0.0}, // upper right
         {1.0, 1.0, 1.0, 1.0}, // lower right
+        {0.0, 0.0, 0.0, 0.0}, // upper left
+        {1.0, 1.0, 1.0, 1.0}, // lower right
         {0.0, 1.0, 0.0, 1.0}  // lower left
     };
-    static const frame_geometry g(frame_geometry::geometry_type::quad, data);
+    static const frame_geometry g(frame_geometry::geometry_type::triangles, data);
 
     return g;
 }

--- a/src/core/frame/geometry.h
+++ b/src/core/frame/geometry.h
@@ -32,8 +32,7 @@ class frame_geometry
   public:
     enum class geometry_type
     {
-        quad,
-        quad_list
+        triangles
     };
 
     struct coord


### PR DESCRIPTION
Fixes #937 

The OpenGL code for the mixer and screen consumer has been updated to use a OpenGL 4.5 Core profile context. This has been tested on Debian 10 on an Intel HD5500. It should help on both windows and linux when the GPU claims to support OpenGL 4.5 but CasparCG doesn't detect that functionality.

Some of the code could do with review by someone who knows OpenGL. In particular I'm not sure what some of the bits I removed from the shader did, and it feels wrong to be creating buffers so often in the kernel during drawing, but I'm not sure where best to do so.

The diag window is still using a compatibility profile, but it is still runs even on linux.

I think this is best left to 2.3, as there is some risk of breaking things or decreased performance. Unless it gets sufficient testing before 2.2 is released

Windows: https://drive.google.com/open?id=1IXqVzTflx9-D1fsrCJ2ufl1XBMIqMUza
Ubuntu18: https://drive.google.com/open?id=1ialg921IzdVlWvpA0JZn6Tsh2SrS-JPd