### PR TITLE
fix(amcp) Command queue overflow guard has no effect

### DIFF
--- a/src/protocol/amcp/AMCPCommandQueue.cpp
+++ b/src/protocol/amcp/AMCPCommandQueue.cpp
@@ -72,11 +72,12 @@ void AMCPCommandQueue::AddCommand(AMCPCommand::ptr_type pCurrentCommand)
         try {
             CASPAR_LOG(error) << "AMCP Command Queue Overflow.";
             CASPAR_LOG(error) << "Failed to execute command:" << pCurrentCommand->print();
-            pCurrentCommand->SetReplyString(L"500 FAILED\r\n");
+            pCurrentCommand->SetReplyString(L"504 QUEUE OVERFLOW\r\n");
             pCurrentCommand->SendReply();
         } catch (...) {
             CASPAR_LOG_CURRENT_EXCEPTION();
         }
+        return;
     }
 
     executor_.begin_invoke([=] {

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -89,10 +89,11 @@
 403 [command] ERROR		invalid parameter
 404 [command] ERROR		file not found
 
-500 FAILED				internal error
-501 [command] FAILED	internal error
-502 [command] FAILED	could not read file
-503 [command] FAILED	access denied
+500 FAILED						internal error
+501 [command] FAILED			internal error
+502 [command] FAILED			could not read file
+503 [command] FAILED			access denied
+504 [command] QUEUE OVERFLOW	command queue overflow
 
 600 [command] FAILED	[command] not implemented
 */


### PR DESCRIPTION
When `AMCP Command Queue Overflow. Failed to execute command:` was logged, the command was still being queued and eventually executed.

At one point I ended up with over 70000 commands in the queue.

Also the error message sent to the client has been changed to indicate the cause of the failure, which will allow the client to try executing at another time