### PR TITLE
Add producer for QtQuick

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,17 +19,19 @@ Development using Visual Studio
 
 2. Install CMake (http://www.cmake.org/download/).
 
-3. `git clone --single-branch --branch master https://github.com/CasparCG/server casparcg-server-master`
+3. Install Qt (https://www.qt.io/download-qt-installer).
 
-4. `cd casparcg-server-master`
+4. `git clone --single-branch --branch master https://github.com/CasparCG/server casparcg-server-master`
 
-5. `mkdir build`
+5. `cd casparcg-server-master`
 
-6. `cd build`
+6. `mkdir build`
 
-7. `cmake -G "Visual Studio 15 2017" -A x64 ../src`
+7. `cd build`
 
-8. Open `CasparCG Server.sln`
+8. `cmake -G "Visual Studio 15 2017" -A x64 -D CMAKE_PREFIX_PATH=C:/Qt/5.12.3/msvc2017_64 ../src`
+
+9. Open `CasparCG Server.sln`
 
 Linux
 =====

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -16,3 +16,4 @@ if (MSVC)
 endif()
 
 add_subdirectory(image)
+add_subdirectory(qtquick)

--- a/src/modules/qtquick/CMakeLists.txt
+++ b/src/modules/qtquick/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required (VERSION 2.6)
+project (qtquick)
+
+set(SOURCES
+		producer/qtquick_cg_proxy.cpp
+		producer/qtquick_producer.cpp
+
+		qtquick.cpp
+)
+set(HEADERS
+		producer/qtquick_cg_proxy.h
+		producer/qtquick_producer.h
+
+		qtquick.h
+)
+
+add_library(qtquick ${SOURCES} ${HEADERS})
+
+set_property(TARGET qtquick PROPERTY CXX_STANDARD 17)
+
+include_directories(..)
+include_directories(../..)
+include_directories(${BOOST_INCLUDE_PATH})
+
+find_package(Qt5Quick 5.10 REQUIRED)
+target_link_libraries(qtquick Qt5::Core Qt5::Quick)
+
+set_target_properties(qtquick PROPERTIES FOLDER modules)
+source_group(sources\\producer producer/*)
+source_group(sources ./*)
+
+target_link_libraries(qtquick
+  common
+  core
+)
+
+casparcg_add_include_statement("modules/qtquick/qtquick.h")
+casparcg_add_init_statement("qtquick::init" "qtquick")
+casparcg_add_uninit_statement("qtquick::uninit")
+casparcg_add_command_line_arg_interceptor("qtquick::intercept_command_line")
+casparcg_add_module_project("qtquick")

--- a/src/modules/qtquick/CMakeLists.txt
+++ b/src/modules/qtquick/CMakeLists.txt
@@ -21,6 +21,7 @@ set_property(TARGET qtquick PROPERTY CXX_STANDARD 17)
 include_directories(..)
 include_directories(../..)
 include_directories(${BOOST_INCLUDE_PATH})
+include_directories(${TBB_INCLUDE_PATH})
 
 find_package(Qt5Quick 5.10 REQUIRED)
 target_link_libraries(qtquick Qt5::Core Qt5::Quick)

--- a/src/modules/qtquick/producer/qtquick_cg_proxy.cpp
+++ b/src/modules/qtquick/producer/qtquick_cg_proxy.cpp
@@ -1,0 +1,36 @@
+#include "qtquick_cg_proxy.h"
+
+#include <future>
+
+namespace caspar { namespace qtquick {
+
+qtquick_cg_proxy::qtquick_cg_proxy(spl::shared_ptr<core::frame_producer> producer)
+    : producer_(producer)
+{
+}
+
+void qtquick_cg_proxy::add(int                 layer,
+                           const std::wstring& template_name,
+                           bool                play_on_load,
+                           const std::wstring& start_from_label,
+                           const std::wstring& data)
+{
+    update(layer, data);
+
+    if (play_on_load)
+        play(layer);
+}
+
+void qtquick_cg_proxy::remove(int layer) { producer_->call({L"_remove"}); }
+
+void qtquick_cg_proxy::play(int layer) { producer_->call({L"_play"}); }
+
+void qtquick_cg_proxy::stop(int layer, unsigned int mix_out_duration) { producer_->call({L"_stop"}); }
+
+void qtquick_cg_proxy::next(int layer) { producer_->call({L"_next"}); }
+
+void qtquick_cg_proxy::update(int layer, const std::wstring& data) { producer_->call({L"_update", data}); }
+
+std::wstring qtquick_cg_proxy::invoke(int layer, const std::wstring& label) { return producer_->call({label}).get(); }
+
+}} // namespace caspar::qtquick

--- a/src/modules/qtquick/producer/qtquick_cg_proxy.cpp
+++ b/src/modules/qtquick/producer/qtquick_cg_proxy.cpp
@@ -25,7 +25,7 @@ void qtquick_cg_proxy::remove(int layer) { producer_->call({L"_remove"}); }
 
 void qtquick_cg_proxy::play(int layer) { producer_->call({L"_play"}); }
 
-void qtquick_cg_proxy::stop(int layer, unsigned int mix_out_duration) { producer_->call({L"_stop"}); }
+void qtquick_cg_proxy::stop(int layer) { producer_->call({L"_stop"}); }
 
 void qtquick_cg_proxy::next(int layer) { producer_->call({L"_next"}); }
 

--- a/src/modules/qtquick/producer/qtquick_cg_proxy.h
+++ b/src/modules/qtquick/producer/qtquick_cg_proxy.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <common/memory.h>
+
+#include <core/producer/cg_proxy.h>
+
+namespace caspar { namespace qtquick {
+
+class qtquick_cg_proxy : public core::cg_proxy
+{
+  public:
+    qtquick_cg_proxy(spl::shared_ptr<core::frame_producer> producer);
+
+    void         add(int                 layer,
+                     const std::wstring& template_name,
+                     bool                play_on_load,
+                     const std::wstring& start_from_label,
+                     const std::wstring& data) override;
+    void         remove(int layer) override;
+    void         play(int layer) override;
+    void         stop(int layer, unsigned int mix_out_duration) override;
+    void         next(int layer) override;
+    void         update(int layer, const std::wstring& data) override;
+    std::wstring invoke(int layer, const std::wstring& label) override;
+
+  private:
+    spl::shared_ptr<core::frame_producer> producer_;
+};
+
+}} // namespace caspar::qtquick

--- a/src/modules/qtquick/producer/qtquick_cg_proxy.h
+++ b/src/modules/qtquick/producer/qtquick_cg_proxy.h
@@ -18,7 +18,7 @@ class qtquick_cg_proxy : public core::cg_proxy
                      const std::wstring& data) override;
     void         remove(int layer) override;
     void         play(int layer) override;
-    void         stop(int layer, unsigned int mix_out_duration) override;
+    void         stop(int layer) override;
     void         next(int layer) override;
     void         update(int layer, const std::wstring& data) override;
     std::wstring invoke(int layer, const std::wstring& label) override;

--- a/src/modules/qtquick/producer/qtquick_producer.cpp
+++ b/src/modules/qtquick/producer/qtquick_producer.cpp
@@ -1,0 +1,351 @@
+#include "qtquick_producer.h"
+
+#include <core/video_format.h>
+
+#include <core/frame/draw_frame.h>
+#include <core/frame/frame.h>
+#include <core/frame/frame_factory.h>
+#include <core/frame/pixel_format.h>
+#include <core/monitor/monitor.h>
+#include <core/producer/frame_producer.h>
+
+#include <common/assert.h>
+#include <common/diagnostics/graph.h>
+#include <common/env.h>
+#include <common/future.h>
+#include <common/log.h>
+#include <common/os/filesystem.h>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/timer.hpp>
+
+#include <tbb/atomic.h>
+#include <tbb/concurrent_queue.h>
+
+#include <QGuiApplication>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QOpenGLFunctions>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickRenderControl>
+#include <QQuickWindow>
+#include <QThread>
+#include <QTimer>
+#include <QUrl>
+
+namespace caspar { namespace qtquick {
+
+class qt_renderer
+{
+    using loaded_callback_t = std::function<void()>;
+
+    const loaded_callback_t                    loaded_callback_;
+    const core::video_format_desc              format_desc_;
+    const spl::shared_ptr<core::frame_factory> frame_factory_;
+
+    QQuickRenderControl                       control_;
+    QOpenGLContext                            context_;
+    QOffscreenSurface                         surface_;
+    std::unique_ptr<QOpenGLFramebufferObject> fbo_;
+    QQmlEngine                                engine_;
+    QQuickWindow                              window_;
+    std::unique_ptr<QQmlComponent>            qmlComponent_;
+
+    spl::shared_ptr<diagnostics::graph> graph_;
+
+    QTimer                      updateTimer_;
+    std::unique_ptr<QQuickItem> rootItem_;
+
+    mutable std::mutex frame_mutex_;
+    core::draw_frame   frame_;
+
+    void createFbo()
+    {
+        fbo_ = std::unique_ptr<QOpenGLFramebufferObject>(new QOpenGLFramebufferObject(
+            QSize(format_desc_.width, format_desc_.height), QOpenGLFramebufferObject::CombinedDepthStencil));
+        window_.setRenderTarget(fbo_.get());
+    }
+
+    void destroyFbo() { fbo_.reset(nullptr); }
+
+    void requestUpdate()
+    {
+        if (!updateTimer_.isActive())
+            updateTimer_.start();
+    }
+
+    void render()
+    {
+        boost::timer timer;
+        timer.restart();
+
+        if (!context_.makeCurrent(&surface_))
+            return;
+
+        // Polish, synchronize and render the next frame (into our fbo).  In this example
+        // everything happens on the same thread and therefore all three steps are performed
+        // in succession from here. In a threaded setup the render() call would happen on a
+        // separate thread.
+        control_.polishItems();
+        control_.sync();
+        control_.render();
+
+        window_.resetOpenGLState();
+        QOpenGLFramebufferObject::bindDefault();
+
+        context_.functions()->glFlush();
+
+        QImage image  = fbo_->toImage();
+        int    width  = image.width();
+        int    height = image.height();
+
+        core::pixel_format_desc pixel_desc;
+        pixel_desc.format = core::pixel_format::bgra;
+        pixel_desc.planes.push_back(core::pixel_format_desc::plane(width, height, 4));
+
+        auto                 frame  = frame_factory_->create_frame(this, pixel_desc);
+        const unsigned char* buffer = image.bits();
+        std::memcpy(frame.image_data(0).begin(), buffer, width * height * 4);
+        {
+            std::lock_guard<std::mutex> lock(frame_mutex_);
+            frame_ = core::draw_frame(std::move(frame));
+        }
+
+        graph_->set_value("render-time", timer.elapsed() * format_desc_.fps);
+    }
+
+    void run()
+    {
+        if (qmlComponent_->isError()) {
+            const QList<QQmlError> errorList = qmlComponent_->errors();
+            for (const QQmlError& error : errorList)
+                qWarning() << error.url() << error.line() << error;
+            return;
+        }
+
+        QObject* rootObject = qmlComponent_->create();
+        if (qmlComponent_->isError()) {
+            const QList<QQmlError> errorList = qmlComponent_->errors();
+            for (const QQmlError& error : errorList)
+                qWarning() << error.url() << error.line() << error;
+            return;
+        }
+
+        rootItem_.reset(qobject_cast<QQuickItem*>(rootObject));
+        if (!rootItem_) {
+            qWarning("run: Not a QQuickItem");
+            delete rootObject;
+            return;
+        }
+
+        // The root item is ready. Associate it with the window.
+        rootItem_->setParentItem(window_.contentItem());
+
+        // Update item and rendering related geometries.
+        updateSizes();
+
+        // Initialize the render control and our OpenGL resources.
+        context_.makeCurrent(&surface_);
+        control_.initialize(&context_);
+
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [this]() { requestUpdate(); });
+        loaded_callback_();
+    }
+
+    void updateSizes()
+    {
+        // Behave like SizeRootObjectToView.
+        rootItem_->setWidth(format_desc_.width);
+        rootItem_->setHeight(format_desc_.height);
+
+        window_.setGeometry(0, 0, format_desc_.width, format_desc_.height);
+    }
+
+  public:
+    qt_renderer(const spl::shared_ptr<core::frame_factory>& frame_factory,
+                const loaded_callback_t&                    loaded_callback,
+                core::video_format_desc                     format_desc)
+        : loaded_callback_(loaded_callback)
+        , format_desc_(format_desc)
+        , frame_factory_(frame_factory)
+        , window_(&control_)
+        , frame_(core::draw_frame{})
+    {
+        graph_->set_color("render-time", diagnostics::color(0.1f, 1.0f, 0.1f));
+        graph_->set_text(L"test");
+        diagnostics::register_graph(graph_);
+
+        // All of Qt must be initialized from Qt's main thread to work.
+        assert(QThread::currentThread() == QGuiApplication::instance()->thread());
+
+        QSurfaceFormat format;
+        // Qt Quick may need a depth and stencil buffer. Always make sure these are available.
+        format.setDepthBufferSize(16);
+        format.setStencilBufferSize(8);
+
+        context_.setFormat(format);
+        context_.create();
+
+        surface_.setFormat(format);
+        surface_.create();
+
+        window_.setColor(Qt::transparent);
+
+        if (!engine_.incubationController())
+            engine_.setIncubationController(window_.incubationController());
+
+        updateTimer_.setSingleShot(true);
+        updateTimer_.setInterval(5);
+
+        QObject::connect(&updateTimer_, &QTimer::timeout, [this]() { render(); });
+
+        QObject::connect(&window_, &QQuickWindow::sceneGraphInitialized, [this]() { createFbo(); });
+
+        QObject::connect(&window_, &QQuickWindow::sceneGraphInvalidated, [this]() { destroyFbo(); });
+    }
+
+    ~qt_renderer()
+    {
+        context_.makeCurrent(&surface_);
+        control_.invalidate();
+    }
+
+    void startQuick(const QString& filename)
+    {
+        qmlComponent_ = std::unique_ptr<QQmlComponent>(new QQmlComponent(&engine_, QUrl(filename)));
+
+        if (qmlComponent_->isLoading()) {
+            auto conn = std::make_shared<QMetaObject::Connection>();
+            *conn     = QObject::connect(qmlComponent_.get(), &QQmlComponent::statusChanged, [this, conn]() {
+                QObject::disconnect(*conn);
+                run();
+            });
+        } else {
+            run();
+        }
+    }
+
+    void execute_javascript(const std::vector<std::wstring>& params)
+    {
+        assert(rootItem_);
+        if (params.size() == 1)
+            QMetaObject::invokeMethod(rootItem_.get(), u8(params.at(0)).c_str());
+        else
+            QMetaObject::invokeMethod(
+                rootItem_.get(), u8(params.at(0)).c_str(), Q_ARG(QVariant, QString::fromStdWString(params.at(1))));
+    }
+
+    core::draw_frame receive_frame()
+    {
+        core::draw_frame frame;
+
+        {
+            std::lock_guard<std::mutex> lock(frame_mutex_);
+            frame = frame_;
+        }
+
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [this]() { requestUpdate(); });
+
+        return frame;
+    }
+};
+
+class qtquick_producer : public core::frame_producer
+{
+    const std::wstring url_;
+
+    std::unique_ptr<qt_renderer> renderer_;
+
+    tbb::concurrent_queue<std::vector<std::wstring>> javascript_before_load_;
+    tbb::atomic<bool>                                loaded_;
+
+  public:
+    qtquick_producer(const spl::shared_ptr<core::frame_factory>& frame_factory,
+                     const core::video_format_desc&              format_desc,
+                     const std::wstring&                         url)
+        : url_(url)
+    {
+        loaded_ = false;
+
+        QMetaObject::invokeMethod(QCoreApplication::instance(),
+                                  [this, url, frame_factory, format_desc]() {
+                                      auto loaded_callback = [this]() { renderer_loaded(); };
+                                      renderer_ =
+                                          std::make_unique<qt_renderer>(frame_factory, loaded_callback, format_desc);
+                                      renderer_->startQuick(QString::fromStdWString(url));
+                                  },
+                                  Qt::QueuedConnection);
+    }
+
+    ~qtquick_producer()
+    {
+        qt_renderer* renderer = renderer_.release();
+        QMetaObject::invokeMethod(
+            QCoreApplication::instance(), [renderer]() { delete renderer; }, Qt::QueuedConnection);
+    }
+
+    void renderer_loaded()
+    {
+        loaded_ = true;
+        execute_queued_javascript();
+    }
+
+    std::wstring name() const override { return L"qtquick"; }
+
+    core::draw_frame receive_impl(int nb_samples) override
+    {
+        if (renderer_) {
+            return renderer_->receive_frame();
+        }
+
+        return core::draw_frame{};
+    }
+
+    std::future<std::wstring> call(const std::vector<std::wstring>& params) override
+    {
+        if (!loaded_) {
+            javascript_before_load_.push(params);
+        } else {
+            execute_queued_javascript();
+            renderer_->execute_javascript(params);
+        }
+
+        return make_ready_future(std::wstring(L""));
+    }
+
+    void execute_queued_javascript()
+    {
+        std::vector<std::wstring> params;
+
+        while (javascript_before_load_.try_pop(params))
+            renderer_->execute_javascript(params);
+    }
+
+    std::wstring print() const override { return L"qtquick[" + url_ + L"]"; }
+};
+
+spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies,
+                                                      const std::vector<std::wstring>&         params)
+{
+    const auto filename       = env::template_folder() + params.at(0) + L".qml";
+    const auto found_filename = find_case_insensitive(filename);
+    const auto url_prefix     = boost::iequals(params.at(0), L"[URL]");
+
+    if (!found_filename && !url_prefix)
+        return core::frame_producer::empty();
+
+    const auto url = found_filename ? L"file://" + *found_filename : params.at(1);
+
+    if (!url_prefix && (!boost::algorithm::contains(url, ".") || boost::algorithm::ends_with(url, "_A") ||
+                        boost::algorithm::ends_with(url, "_ALPHA")))
+        return core::frame_producer::empty();
+
+    return core::create_destroy_proxy(
+        spl::make_shared<qtquick_producer>(dependencies.frame_factory, dependencies.format_desc, url));
+}
+
+}} // namespace caspar::qtquick

--- a/src/modules/qtquick/producer/qtquick_producer.cpp
+++ b/src/modules/qtquick/producer/qtquick_producer.cpp
@@ -338,7 +338,7 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
     if (!found_filename && !url_prefix)
         return core::frame_producer::empty();
 
-    const auto url = found_filename ? L"file://" + *found_filename : params.at(1);
+    const auto url = found_filename ? QUrl::fromLocalFile(QString::fromStdWString(*found_filename)).toString().toStdWString() : params.at(1);
 
     if (!url_prefix && (!boost::algorithm::contains(url, ".") || boost::algorithm::ends_with(url, "_A") ||
                         boost::algorithm::ends_with(url, "_ALPHA")))

--- a/src/modules/qtquick/producer/qtquick_producer.h
+++ b/src/modules/qtquick/producer/qtquick_producer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <common/memory.h>
+
+#include <core/fwd.h>
+
+#include <string>
+#include <vector>
+
+namespace caspar { namespace qtquick {
+
+spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer_dependencies& dependencies,
+                                                      const std::vector<std::wstring>&         params);
+
+}} // namespace caspar::qtquick

--- a/src/modules/qtquick/qtquick.cpp
+++ b/src/modules/qtquick/qtquick.cpp
@@ -77,7 +77,6 @@ void init(core::module_dependencies dependencies)
     dependencies.cg_registry->register_cg_producer(
         L"qtquick",
         {L".qml"},
-        [](const std::wstring& filename) { return ""; },
         [](const spl::shared_ptr<core::frame_producer>& producer) {
             return spl::make_shared<qtquick_cg_proxy>(producer);
         },

--- a/src/modules/qtquick/qtquick.cpp
+++ b/src/modules/qtquick/qtquick.cpp
@@ -1,0 +1,96 @@
+#include "qtquick.h"
+
+#include "producer/qtquick_cg_proxy.h"
+#include "producer/qtquick_producer.h"
+
+#include <core/producer/cg_proxy.h>
+
+#include <boost/property_tree/ptree.hpp>
+
+#include <common/log.h>
+
+#include <QGuiApplication>
+#include <QThread>
+#include <QtGlobal>
+
+#include <memory>
+
+// workaround to give QGuiApplication a valid reference for argc
+// see https://stackoverflow.com/questions/43825082/qcoreapplication-on-the-heap/43825083#43825083
+struct ApplicationHolder
+{
+    ApplicationHolder(int argc, char* argv[])
+    {
+        m_argc = new int(argc);
+        m_app  = new QGuiApplication(*m_argc, argv);
+    }
+    ~ApplicationHolder()
+    {
+        delete m_app;
+        delete m_argc;
+    }
+
+    int*             m_argc;
+    QGuiApplication* m_app;
+};
+
+namespace {
+// Use a single Qt application event loop for all producers.
+std::unique_ptr<ApplicationHolder> application;
+std::thread                        thread;
+
+std::mutex              application_started_mutex;
+bool                    application_started = false;
+std::condition_variable application_started_condition;
+} // namespace
+
+namespace caspar { namespace qtquick {
+
+bool intercept_command_line(int argc, char** argv)
+{
+    thread = std::thread([argc, argv]() {
+        application = std::make_unique<ApplicationHolder>(argc, argv);
+        QMetaObject::invokeMethod(application->m_app,
+                                  []() {
+                                      application_started = true;
+                                      application_started_condition.notify_all();
+                                  },
+                                  Qt::QueuedConnection);
+        int exit_code = application->m_app->exec();
+
+        CASPAR_LOG(debug) << std::string("Qt application loop exited with code ") << std::to_string(exit_code);
+    });
+
+    {
+        // Wait for application event loop to be running.
+        std::unique_lock<std::mutex> lock(application_started_mutex);
+        application_started_condition.wait(lock, []() { return application_started; });
+    }
+
+    return false;
+}
+
+void init(core::module_dependencies dependencies)
+{
+    dependencies.producer_registry->register_producer_factory(L"QtQuick Producer", qtquick::create_producer);
+
+    dependencies.cg_registry->register_cg_producer(
+        L"qtquick",
+        {L".qml"},
+        [](const std::wstring& filename) { return ""; },
+        [](const spl::shared_ptr<core::frame_producer>& producer) {
+            return spl::make_shared<qtquick_cg_proxy>(producer);
+        },
+        [](const core::frame_producer_dependencies& dependencies, const std::wstring& filename) {
+            return qtquick::create_producer(dependencies, {filename});
+        },
+        false);
+}
+
+void uninit()
+{
+    application->m_app->exit(0);
+    application.reset();
+}
+
+}} // namespace caspar::qtquick

--- a/src/modules/qtquick/qtquick.h
+++ b/src/modules/qtquick/qtquick.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <functional>
+#include <future>
+#include <string>
+
+#include <core/module_dependencies.h>
+
+namespace caspar { namespace qtquick {
+
+bool intercept_command_line(int argc, char** argv);
+void init(core::module_dependencies dependencies);
+void uninit();
+
+}} // namespace caspar::qtquick

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -15,6 +15,10 @@ FROM ${IMAGE_BASE} as build-casparcg
 
     ARG PROC_COUNT=8
 
+	RUN wget http://download.qt.io/official_releases/qt/5.10/5.10.0/qt-opensource-linux-x64-5.10.0.run
+	COPY ./tools/linux/qt-installer.js /qt-installer.js
+	RUN chmod +x qt-opensource-linux-x64-5.10.0.run && ./qt-opensource-linux-x64-5.10.0.run --platform minimal --script /qt-installer.js
+
 	RUN mkdir /source && mkdir /build && mkdir /install
 
 	COPY ./src /source
@@ -23,6 +27,7 @@ FROM ${IMAGE_BASE} as build-casparcg
 
 	ENV BOOST_ROOT=/opt/boost
 	ENV PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
+	ENV Qt5Quick_DIR=/opt/Qt/5.10.0/gcc_64/lib/cmake/
 
     ARG CC
     ARG CXX

--- a/tools/linux/qt-installer.js
+++ b/tools/linux/qt-installer.js
@@ -1,0 +1,64 @@
+function Controller() {
+    installer.autoRejectMessageBoxes();
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    })
+}
+
+Controller.prototype.LicenseCheckPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+// WELCOME -> NEXT
+Controller.prototype.WelcomePageCallback = function() {
+    // Hope the license check is faster than 3 seconds.
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+// LOGIN -> SKIP
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+// SETUP -> NEXT
+Controller.prototype.IntroductionPageCallback = function() {
+    gui.clickButton(buttons.NextButton);
+}
+
+// INSTALLATION FOLDER -> NEXT
+Controller.prototype.TargetDirectoryPageCallback = function()
+{
+    var targetDir = gui.findChild(gui.currentPageWidget(), "TargetDirectoryLineEdit");
+    targetDir.text = "/opt/Qt";
+    gui.clickButton(buttons.NextButton);
+}
+
+
+// SELECT COMPONENTS -> NEXT
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    widget.deselectAll();
+
+    widget.selectComponent("qt.qt5.5100.gcc_64");
+
+    gui.clickButton(buttons.NextButton);
+}
+
+// LICENSE AGREE -> RADIO IAGREE -> NEXT
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    gui.currentPageWidget().AcceptLicenseRadioButton.setChecked(true);
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var checkBoxForm = gui.currentPageWidget().LaunchQtCreatorCheckBoxForm;
+    if (checkBoxForm && checkBoxForm.launchQtCreatorCheckBox) {
+        checkBoxForm.launchQtCreatorCheckBox.checked = false;
+    }
+    gui.clickButton(buttons.FinishButton);
+}


### PR DESCRIPTION
I've used QtQuick for several productions now. Its language (QML) is easier to write and more expressive than HTML. A lot of features, like animations, are easily accessible. After doing one event with CasparCG and HTML I missed the convenience of QtQuick so much that I had to try adding it to CasparCG. The result is this pull request.

The code is based on the HTML producer from 2.1.0 and [Qt's QQuickRenderControl example](http://doc.qt.io/qt-5/qtquick-rendercontrol-example.html). Unfortunately I'm not very knowledgeable in graphics programming which is why the code might not be that good. Very much looking forward to any comments on it.

~Please note that the code requires Qt 5.10 which might need to be installed manually. For cmake to pick it up set `CMAKE_PREFIX_PATH=/home/user/qt/5.10.0/gcc_64/lib/cmake/`.~ Qt is installed during the Docker build and instructions for Windows were added.