### PR TITLE
fix(html) #991 Make url/filename validation less strict when using [HTML] prefix on a play command

### DIFF
--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -430,13 +430,14 @@ class html_producer : public core::frame_producer_base
 spl::shared_ptr<core::frame_producer> create_cg_producer(const core::frame_producer_dependencies& dependencies,
                                                          const std::vector<std::wstring>&         params)
 {
-    const auto param_url      = boost::iequals(params.at(0), L"[HTML]") ? params.at(1) : params.at(0);
+    const auto html_prefix    = boost::iequals(params.at(0), L"[HTML]");
+    const auto param_url      = html_prefix ? params.at(1) : params.at(0);
     const auto filename       = env::template_folder() + param_url + L".html";
     const auto found_filename = find_case_insensitive(filename);
     const auto http_prefix    = boost::algorithm::istarts_with(param_url, L"http:") ||
                              boost::algorithm::istarts_with(param_url, L"https:");
 
-    if (!found_filename && !http_prefix)
+    if (!found_filename && !http_prefix && !html_prefix)
         return core::frame_producer::empty();
 
     const auto url = found_filename ? L"file://" + *found_filename : param_url;


### PR DESCRIPTION
fixes #991 
