### PR TITLE
fix: #963 LOADBG with AUTO not working after seeking forward

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -916,6 +916,10 @@ struct AVProducer::Impl
 
     boost::optional<int64_t> duration() const
     {
+        if (duration_ != AV_NOPTS_VALUE) {
+            return av_rescale_q(duration_, TIME_BASE_Q, format_tb_);
+        }
+
         if (!input_.duration()) {
             return boost::none;
         }

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -107,13 +107,13 @@ struct ffmpeg_producer : public core::frame_producer_base
 
     std::uint32_t frame_number() const override
     {
-        return static_cast<std::uint32_t>(producer_->time() * format_desc_.fps);
+        return static_cast<std::uint32_t>(producer_->time());
     }
 
     std::uint32_t nb_frames() const override
     {
         return producer_->loop() ? std::numeric_limits<std::uint32_t>::max()
-                                 : static_cast<std::uint32_t>(producer_->duration() * format_desc_.fps);
+                                 : static_cast<std::uint32_t>(producer_->duration());
     }
 
     std::future<std::wstring> call(const std::vector<std::wstring>& params) override


### PR DESCRIPTION
Fixes #963 

This fixes both cases raised in #963. Transition to the background layer now triggers on the correct frame at the end of the clip, at the end after a seek and with the clip length shortened