### PR TITLE
fix(opengl) #989 #999 Fix transform, rotate and distort

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -378,11 +378,13 @@ struct image_kernel::impl
 
         // Draw
         switch (params.geometry.type()) {
-            case core::frame_geometry::geometry_type::triangles: {
+            case core::frame_geometry::geometry_type::quad: {
                 GL(glBindVertexArray(vao_));
                 GL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
 
-                GL(glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizei>(sizeof(core::frame_geometry::coord)) * coords.size(), coords.data(), GL_STATIC_DRAW));
+                std::vector<core::frame_geometry::coord> coords_triangles { coords[0], coords[1], coords[2], coords[0], coords[2], coords[3] };
+
+                GL(glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizei>(sizeof(core::frame_geometry::coord)) * coords_triangles.size(), coords_triangles.data(), GL_STATIC_DRAW));
 
                 auto stride = static_cast<GLsizei>(sizeof(core::frame_geometry::coord));
 
@@ -393,9 +395,9 @@ struct image_kernel::impl
                 GL(glEnableVertexAttribArray(tex_loc));
 
                 GL(glVertexAttribPointer(vtx_loc, 2, GL_DOUBLE, GL_FALSE, stride, nullptr));
-                GL(glVertexAttribPointer(tex_loc, 4, GL_DOUBLE, GL_FALSE, stride, nullptr));
+                GL(glVertexAttribPointer(tex_loc, 4, GL_DOUBLE, GL_FALSE, stride, (GLvoid*)(2 * sizeof(GLdouble))));
 
-                for (int i = 0; i < coords.size(); i += 3) {
+                for (int i = 0; i < coords_triangles.size(); i += 3) {
                     GL(glDrawArrays(GL_TRIANGLES, i, 3));
                     GL(glTextureBarrier());
                 }

--- a/src/accelerator/ogl/image/image_shader.cpp
+++ b/src/accelerator/ogl/image/image_shader.cpp
@@ -272,39 +272,39 @@ std::string get_fragment()
 				switch(pixel_format)
 				{
 				case 0:		//gray
-					return vec4(get_sample(plane[0], TexCoord.st).rrr, 1.0);
+					return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rrr, 1.0);
 				case 1:		//bgra,
-					return get_sample(plane[0], TexCoord.st).bgra;
+					return get_sample(plane[0], TexCoord.st / TexCoord.q).bgra;
 				case 2:		//rgba,
-					return get_sample(plane[0], TexCoord.st).rgba;
+					return get_sample(plane[0], TexCoord.st / TexCoord.q).rgba;
 				case 3:		//argb,
-					return get_sample(plane[0], TexCoord.st).argb;
+					return get_sample(plane[0], TexCoord.st / TexCoord.q).argb;
 				case 4:		//abgr,
-					return get_sample(plane[0], TexCoord.st).gbar;
+					return get_sample(plane[0], TexCoord.st / TexCoord.q).gbar;
 				case 5:		//ycbcr,
 					{
-						float y  = get_sample(plane[0], TexCoord.st).r;
-						float cb = get_sample(plane[1], TexCoord.st).r;
-						float cr = get_sample(plane[2], TexCoord.st).r;
+						float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r;
+						float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r;
+						float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r;
 						return ycbcra_to_rgba(y, cb, cr, 1.0);
 					}
 				case 6:		//ycbcra
 					{
-						float y  = get_sample(plane[0], TexCoord.st).r;
-						float cb = get_sample(plane[1], TexCoord.st).r;
-						float cr = get_sample(plane[2], TexCoord.st).r;
-						float a  = get_sample(plane[3], TexCoord.st).r;
+						float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r;
+						float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r;
+						float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r;
+						float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r;
 						return ycbcra_to_rgba(y, cb, cr, a);
 					}
 				case 7:		//luma
 					{
-						vec3 y3 = get_sample(plane[0], TexCoord.st).rrr;
+						vec3 y3 = get_sample(plane[0], TexCoord.st / TexCoord.q).rrr;
 						return vec4((y3-0.065)/0.859, 1.0);
 					}
 				case 8:		//bgr,
-					return vec4(get_sample(plane[0], TexCoord.st).bgr, 1.0);
+					return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).bgr, 1.0);
 				case 9:		//rgb,
-					return vec4(get_sample(plane[0], TexCoord.st).rgb, 1.0);
+					return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rgb, 1.0);
 				}
 				return vec4(0.0, 0.0, 0.0, 0.0);
 			}

--- a/src/core/frame/geometry.cpp
+++ b/src/core/frame/geometry.cpp
@@ -43,11 +43,8 @@ struct frame_geometry::impl
     impl(frame_geometry::geometry_type type, std::vector<coord> data)
         : type_(type)
     {
-        if (type == geometry_type::triangles) {
-            if (data.size() % 3 != 0)
-                CASPAR_THROW_EXCEPTION(invalid_argument()
-                                       << msg_info("The number of coordinates needs to be a multiple of 3"));
-        }
+        if (type == geometry_type::quad && data.size() != 4)
+            CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("The number of coordinates needs to be 4"));
 
         data_ = std::move(data);
     }
@@ -71,11 +68,9 @@ const frame_geometry& frame_geometry::get_default()
         {0.0, 0.0, 0.0, 0.0}, // upper left
         {1.0, 0.0, 1.0, 0.0}, // upper right
         {1.0, 1.0, 1.0, 1.0}, // lower right
-        {0.0, 0.0, 0.0, 0.0}, // upper left
-        {1.0, 1.0, 1.0, 1.0}, // lower right
         {0.0, 1.0, 0.0, 1.0}  // lower left
     };
-    static const frame_geometry g(frame_geometry::geometry_type::triangles, data);
+    static const frame_geometry g(frame_geometry::geometry_type::quad, data);
 
     return g;
 }

--- a/src/core/frame/geometry.h
+++ b/src/core/frame/geometry.h
@@ -32,7 +32,7 @@ class frame_geometry
   public:
     enum class geometry_type
     {
-        triangles
+        quad
     };
 
     struct coord


### PR DESCRIPTION
Fixes #989 & fixes #999 

The key issue was no offset being passed in for the texture buffer data, so it was using the same coordinates as the vertex.

I have tested each of FILL, ROTATE and DISTORT individually and combined and in my testing they now behave the same as 2.1