### PR TITLE
fix: Clear sync time if using consumer as sync clock

### DIFF
--- a/src/core/consumer/output.cpp
+++ b/src/core/consumer/output.cpp
@@ -156,6 +156,8 @@ struct output::impl
                 std::this_thread::sleep_until(*time);
             }
             time_ = *time + std::chrono::microseconds(static_cast<int>(1e6 / format_desc_.fps));
+        } else {
+            time_.reset();
         }
     }
 


### PR DESCRIPTION
Running `REMOVE 1 DECKLINK` was causing the channel to render as fast as possible as time_ was set to when the channel last had no sync clock (probably when it was created)