### PR TITLE
fix(media-scanner): don't print stack trace if connection fails

### DIFF
--- a/src/protocol/amcp/AMCPCommandQueue.cpp
+++ b/src/protocol/amcp/AMCPCommandQueue.cpp
@@ -110,7 +110,7 @@ void AMCPCommandQueue::AddCommand(AMCPCommand::ptr_type pCurrentCommand)
                 pCurrentCommand->SetReplyString(L"403 " + pCurrentCommand->print() + L" FAILED\r\n");
             } catch (...) {
                 CASPAR_LOG_CURRENT_EXCEPTION();
-                CASPAR_LOG(error) << "Failed to execute command:" << pCurrentCommand->print();
+                CASPAR_LOG(error) << "Failed to execute command: " << pCurrentCommand->print();
                 pCurrentCommand->SetReplyString(L"501 " + pCurrentCommand->print() + L" FAILED\r\n");
             }
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1240,56 +1240,57 @@ std::wstring channel_grid_command(command_context& ctx)
 
 // Thumbnail Commands
 
+std::wstring make_request(command_context& ctx, const std::string path, const std::wstring default_response)
+{
+    auto res = http::request(ctx.proxy_host, ctx.proxy_port, path);
+    if (res.status_code >= 500 || res.body.size() == 0) {
+        CASPAR_LOG(error) << "Failed to connect to media-scanner. Is it running? \nReason: " << res.status_message;
+        return default_response;
+    }
+    return u16(res.body);
+}
+
 std::wstring thumbnail_list_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/thumbnail");
-    return u16(res.body);
+    return make_request(ctx, "/thumbnail", L"501 THUMBNAIL LIST FAILED\r\n");
 }
 
 std::wstring thumbnail_retrieve_command(command_context& ctx)
 {
-    auto res =
-        http::request(ctx.proxy_host, ctx.proxy_port, "/thumbnail/" + http::url_encode(u8(ctx.parameters.at(0))));
-    return u16(res.body);
+    return make_request(ctx, "/thumbnail/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL RETRIEVE FAILED\r\n");
 }
 
 std::wstring thumbnail_generate_command(command_context& ctx)
 {
-    auto res = http::request(
-        ctx.proxy_host, ctx.proxy_port, "/thumbnail/generate/" + http::url_encode(u8(ctx.parameters.at(0))));
-    return u16(res.body);
+    return make_request(
+        ctx, "/thumbnail/generate/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL GENERATE FAILED\r\n");
 }
 
 std::wstring thumbnail_generateall_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/thumbnail/generate");
-    return u16(res.body);
+    return make_request(ctx, "/thumbnail/generate", L"501 THUMBNAIL GENERATE_ALL FAILED\r\n");
 }
 
 // Query Commands
 
 std::wstring cinf_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/cinf/" + http::url_encode(u8(ctx.parameters.at(0))));
-    return u16(res.body);
+    return make_request(ctx, "/cinf/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 CINF FAILED\r\n");
 }
 
 std::wstring cls_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/cls");
-    return u16(res.body);
+    return make_request(ctx, "/cls", L"501 CLS FAILED\r\n");
 }
 
 std::wstring fls_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/fls");
-    return u16(res.body);
+    return make_request(ctx, "/fls", L"501 FLS FAILED\r\n");
 }
 
 std::wstring tls_command(command_context& ctx)
 {
-    auto res = http::request(ctx.proxy_host, ctx.proxy_port, "/tls");
-    return u16(res.body);
+    return make_request(ctx, "/tls", L"501 TLS FAILED\r\n");
 }
 
 std::wstring version_command(command_context& ctx) { return L"201 VERSION OK\r\n" + env::version() + L"\r\n"; }


### PR DESCRIPTION
This cleans up the log when the media-scanner is not running and the relevant commands are used. It should now be more obvious to end users what is happening and hopefully reduce the number of issues and forum topics raised.

```
[2018-06-05 19:25:47.332] [info]    Received message from 127.0.0.1: CLS\r\n
[2018-06-05 19:25:49.353] [error]   Failed to connect to media-scanner. Is it running?
[2018-06-05 19:25:49.353] [error]   Reason: No connection could be made because the target machine actively refused it
[2018-06-05 19:25:49.358] [error]   Failed to execute command: CLS. Turn on log level debug for stacktrace.
[2018-06-05 19:25:49.358] [info]    Sent message to 127.0.0.1:501 CLS FAILED\r\n
```

The full stacktrace is still printed under trace logging.