### PR TITLE
fix(screen) ADD X-Y SCREEN BORDERLESS

### DIFF
--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -458,7 +458,10 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     configuration config;
 
     if (params.size() > 1) {
-        config.screen_index = boost::lexical_cast<int>(params.at(1));
+        try {
+            config.screen_index = boost::lexical_cast<int>(params.at(1));
+        } catch (...) {
+        }
     }
 
     config.windowed    = !contains_param(L"FULLSCREEN", params);


### PR DESCRIPTION
Fixes #626

It was expected that the first parameter to the consumer is always the screen index. 
2.0 did not make that assumption