### PR TITLE
fix(mixer) tweens dont run on uninitialized layers

### DIFF
--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -314,10 +314,9 @@ frame_transform tweened_transform::fetch()
                      static_cast<double>(time_), source_, dest_, static_cast<double>(duration_), tweener_);
 }
 
-frame_transform tweened_transform::fetch_and_tick(int num)
+void tweened_transform::tick(int num)
 {
     time_ = std::min(time_ + num, duration_);
-    return fetch();
 }
 
 boost::optional<chroma::legacy_type> get_chroma_mode(const std::wstring& str)

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -166,7 +166,7 @@ class tweened_transform
     const frame_transform& dest() const;
 
     frame_transform fetch();
-    frame_transform fetch_and_tick(int num);
+    void tick(int num);
 };
 
 boost::optional<chroma::legacy_type> get_chroma_mode(const std::wstring& str);

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -69,11 +69,14 @@ struct stage::impl : public std::enable_shared_from_this<impl>
             std::map<int, draw_frame> frames;
 
             try {
+                for (auto& t: tweens_)
+                    t.second.tick();
+
                 // TODO (perf) parallel_for
                 for (auto& p : layers_) {
                     auto& layer     = p.second;
                     auto& tween     = tweens_[p.first];
-                    frames[p.first] = draw_frame::push(layer.receive(format_desc, nb_samples), tween.fetch_and_tick(1));
+                    frames[p.first] = draw_frame::push(layer.receive(format_desc, nb_samples), tween.fetch());
                 }
 
                 state_.clear();
@@ -106,8 +109,8 @@ struct stage::impl : public std::enable_shared_from_this<impl>
                 auto& tween = tweens_[std::get<0>(transform)];
                 auto  src   = tween.fetch();
                 auto  dst   = std::get<1>(transform)(tween.dest());
-                tweens_[std::get<0>(transform)] =
-                    tweened_transform(src, dst, std::get<2>(transform), std::get<3>(transform));
+                auto  index = std::get<0>(transform);
+                tweens_[index] = tweened_transform(src, dst, std::get<2>(transform), std::get<3>(transform));
             }
         });
     }


### PR DESCRIPTION
Fixes #879 

Tested with FILL and OPACITY after CLEAR 1 and at startup.

I'm not 100% certain this is the best solution, but I think this is the better of the two solutions I came up with.