### PR TITLE
feat(screen): Optionally specify absolute coordinates and size of windows

### DIFF
--- a/src/modules/screen/CMakeLists.txt
+++ b/src/modules/screen/CMakeLists.txt
@@ -12,7 +12,17 @@ set(HEADERS
 	screen.h
 )
 
-add_library(screen ${SOURCES} ${HEADERS})
+if (MSVC)
+else ()
+	set(OS_SPECIFIC_HEADERS
+			util/x11_util.h
+			)
+	set(OS_SPECIFIC_SOURCES
+			util/x11_util.cpp
+			)
+endif ()
+
+add_library(screen ${SOURCES} ${OS_SPECIFIC_SOURCES} ${HEADERS} ${OS_SPECIFIC_HEADERS})
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
 
 include_directories(..)

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -184,10 +184,10 @@ struct screen_consumer : boost::noncopyable
         }
 #endif
 
-        screen_x_ += config.screen_x;
-        screen_y_ += config.screen_y;
-
         if (config.windowed) {
+            screen_x_ += config.screen_x;
+            screen_y_ += config.screen_y;
+
             if (config.screen_width > 0 && config.screen_height > 0) {
                 screen_width_ = config.screen_width;
                 screen_height_ = config.screen_height;

--- a/src/modules/screen/util/x11_util.cpp
+++ b/src/modules/screen/util/x11_util.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, git@julusian.co.uk
+ */
+
+#include "x11_util.h"
+
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+
+bool window_always_on_top(const sf::Window& window)
+{
+    Display* disp = XOpenDisplay(NULL);
+    if (!disp)
+        return false;
+
+    Window win = window.getSystemHandle();
+
+    Atom wm_state, wm_state_above;
+    XEvent event;
+
+    if ((wm_state = XInternAtom(disp, "_NET_WM_STATE", False)) != None)
+    {
+        if ((wm_state_above = XInternAtom(disp, "_NET_WM_STATE_ABOVE", False))
+            != None)
+        {
+            event.xclient.type = ClientMessage;
+            event.xclient.serial = 0;
+            event.xclient.send_event = True;
+            event.xclient.display = disp;
+            event.xclient.window = win;
+            event.xclient.message_type = wm_state;
+            event.xclient.format = 32;
+            event.xclient.data.l[0] = 1;
+            event.xclient.data.l[1] = wm_state_above;
+            event.xclient.data.l[2] = 0;
+            event.xclient.data.l[3] = 0;
+            event.xclient.data.l[4] = 0;
+
+            XSendEvent(disp, DefaultRootWindow(disp), False,
+                       SubstructureRedirectMask | SubstructureNotifyMask, &event);
+        }
+    }
+
+    XCloseDisplay(disp);
+    return true;
+}

--- a/src/modules/screen/util/x11_util.h
+++ b/src/modules/screen/util/x11_util.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, git@julusian.co.uk
+ */
+
+#pragma once
+
+#include <SFML/Window.hpp>
+
+bool window_always_on_top(const sf::Window& window);

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -83,6 +83,10 @@
                 <vsync>false [true|false]</vsync>
                 <borderless>false [true|false]</borderless>
                 <interactive>true [true|false]</interactive>
+                <x>0</x>
+                <y>0</y>
+                <width>0 (0=not set)</width>
+                <height>0 (0=not set)</height>
             </screen>
             <newtek-ivga></newtek-ivga>
             <ffmpeg>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -83,6 +83,7 @@
                 <vsync>false [true|false]</vsync>
                 <borderless>false [true|false]</borderless>
                 <interactive>true [true|false]</interactive>
+                <always-on-top>false [true|false]<</always-on-top>
                 <x>0</x>
                 <y>0</y>
                 <width>0 (0=not set)</width>


### PR DESCRIPTION
fixes #115 #487 #995

This allows specifying x,y,width,height and always-on-top for a screen consumer.

x and y are an offset relative to the screen selected via screen-index
width and height override the channel format if set. If only one of them is set then the aspect_ratio property is respected to calculate the window size.
These coordinates and dimensions only have effect when the consumer is windowed

Additionally, the aspect_ratio and stretch properties were broken by #966 and now work again.

Some linux window managers were always maximising any screen consumer windows due to them being created at screen size, then the size changed to be correct. It is now set correct when created 

Tested on debian 10 (gnome 3) with intel gpu and on windows 10 with intel gpu

One quirks that I shall document on the wiki once this is accepted is that when the consumer is fullscreen and always-on-top, the taskbar, startmenu and alt-tab overlay will still draw on top.