### PR TITLE
fix(amcp): log level validation. add missing get command

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -202,7 +202,9 @@ void add_cout_sink()
     logging::core::get()->add_sink(stream_sink);
 }
 
-void set_log_level(const std::wstring& lvl)
+std::wstring current_log_level;
+
+bool set_log_level(const std::wstring& lvl)
 {
     if (boost::iequals(lvl, L"trace"))
         logging::core::get()->set_filter(logging::trivial::severity >= boost::log::trivial::trace);
@@ -216,6 +218,16 @@ void set_log_level(const std::wstring& lvl)
         logging::core::get()->set_filter(logging::trivial::severity >= boost::log::trivial::error);
     else if (boost::iequals(lvl, L"fatal"))
         logging::core::get()->set_filter(logging::trivial::severity >= boost::log::trivial::fatal);
+    else
+        return false;
+
+    current_log_level = lvl;
+    return true;
+}
+
+std::wstring& get_log_level()
+{
+    return current_log_level;
 }
 
 }} // namespace caspar::log

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -64,7 +64,8 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_DEFAULT(logger, caspar_logger)
 
 void add_file_sink(const std::wstring& file);
 void add_cout_sink();
-void set_log_level(const std::wstring& lvl);
+bool set_log_level(const std::wstring& lvl);
+std::wstring& get_log_level();
 
 inline std::wstring get_stack_trace()
 {

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -410,7 +410,17 @@ std::wstring print_command(command_context& ctx)
 
 std::wstring log_level_command(command_context& ctx)
 {
-    log::set_log_level(ctx.parameters.at(0));
+    if (ctx.parameters.size() == 0) {
+        std::wstringstream replyString;
+        replyString << L"201 LOG OK\r\n"
+                    << boost::to_upper_copy(log::get_log_level()) << L"\r\n";
+
+        return replyString.str();
+    }
+
+    if (!log::set_log_level(ctx.parameters.at(0))) {
+        return L"403 LOG FAILED\r\n";
+    }
 
     return L"202 LOG OK\r\n";
 }
@@ -1384,7 +1394,7 @@ void register_commands(amcp_command_repository& repo)
     repo.register_channel_command(L"Basic Commands", L"ADD", add_command, 1);
     repo.register_channel_command(L"Basic Commands", L"REMOVE", remove_command, 0);
     repo.register_channel_command(L"Basic Commands", L"PRINT", print_command, 0);
-    repo.register_command(L"Basic Commands", L"LOG LEVEL", log_level_command, 1);
+    repo.register_command(L"Basic Commands", L"LOG LEVEL", log_level_command, 0);
     repo.register_channel_command(L"Basic Commands", L"SET", set_command, 2);
     repo.register_command(L"Basic Commands", L"LOCK", lock_command, 2);
 

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
     // Set debug mode.
     auto debugging_environment = setup_debugging_environment();
 
-    // Increase process priotity.
+    // Increase process priority.
     increase_process_priority();
 
     tbb::task_scheduler_init init;
@@ -215,14 +215,20 @@ int main(int argc, char** argv)
         log::add_cout_sink();
         env::configure(config_file_name);
 
-        log::set_log_level(env::properties().get(L"configuration.log-level", L"info"));
+        {
+            std::wstring target_level = env::properties().get(L"configuration.log-level", L"info");
+            if (!log::set_log_level(target_level)) {
+                log::set_log_level(L"info");
+                std::wcout << L"Failed to set log level [" << target_level << L"]" << std::endl;
+            }
+        }
 
         if (env::properties().get(L"configuration.debugging.remote", false))
             wait_for_remote_debugging();
 
         // Start logging to file.
         log::add_file_sink(env::log_folder() + L"caspar");
-        std::wcout << L"Logging [info] or higher severity to " << env::log_folder() << std::endl << std::endl;
+        std::wcout << L"Logging [" <<  log::get_log_level() << L"] or higher severity to " << env::log_folder() << std::endl << std::endl;
 
         // Once logging to file, log configuration warnings.
         env::log_configuration_warnings();


### PR DESCRIPTION
fixes #1031 

Also ensures log-level is set to info if the value specified in the config is invalid, and reports that the invalid value was rejected