### PR TITLE
fix(html): Dont report late-frame from html producer to log

### DIFF
--- a/src/common/diagnostics/graph.h
+++ b/src/common/diagnostics/graph.h
@@ -37,7 +37,8 @@ std::tuple<float, float, float, float> color(int code);
 enum class tag_severity
 {
     WARNING,
-    INFO
+    INFO,
+    SILENT,
 };
 
 class graph : boost::noncopyable

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -324,7 +324,7 @@ class html_client
             std::lock_guard<std::mutex> lock(last_frame_mutex_);
             last_frame_ = frame;
         } else {
-            graph_->set_tag(diagnostics::tag_severity::WARNING, "late-frame");
+            graph_->set_tag(diagnostics::tag_severity::SILENT, "late-frame");
         }
     }
 


### PR DESCRIPTION
Small improvement on #854, to avoid the late-frame reports being logged to the console or file, but remain in the diag window