### PR TITLE
feat(screen): Use shader for screen consumer, to allow gpu to perform key-only step

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -397,10 +397,8 @@ struct image_kernel::impl
                 GL(glVertexAttribPointer(vtx_loc, 2, GL_DOUBLE, GL_FALSE, stride, nullptr));
                 GL(glVertexAttribPointer(tex_loc, 4, GL_DOUBLE, GL_FALSE, stride, (GLvoid*)(2 * sizeof(GLdouble))));
 
-                for (int i = 0; i < coords_triangles.size(); i += 3) {
-                    GL(glDrawArrays(GL_TRIANGLES, i, 3));
-                    GL(glTextureBarrier());
-                }
+                GL(glDrawArrays(GL_TRIANGLES, 0, coords_triangles.size()));
+                GL(glTextureBarrier());
 
                 GL(glDisableVertexAttribArray(vtx_loc));
                 GL(glDisableVertexAttribArray(tex_loc));

--- a/src/accelerator/ogl/util/shader.h
+++ b/src/accelerator/ogl/util/shader.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <GL/glew.h>
 
 namespace caspar { namespace accelerator { namespace ogl {
 

--- a/src/modules/screen/CMakeLists.txt
+++ b/src/modules/screen/CMakeLists.txt
@@ -3,11 +3,13 @@ project (screen)
 
 set(SOURCES
 	consumer/screen_consumer.cpp
+	consumer/screen_shader.cpp
 
 	screen.cpp
 )
 set(HEADERS
 	consumer/screen_consumer.h
+	consumer/screen_shader.h
 
 	screen.h
 )
@@ -37,7 +39,7 @@ set_target_properties(screen PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)
 source_group(sources ./*)
 
-target_link_libraries(screen common core ffmpeg)
+target_link_libraries(screen common core accelerator ffmpeg)
 
 casparcg_add_include_statement("modules/screen/screen.h")
 casparcg_add_init_statement("screen::init" "screen")

--- a/src/modules/screen/consumer/screen_shader.cpp
+++ b/src/modules/screen/consumer/screen_shader.cpp
@@ -1,0 +1,69 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+*
+* This file is part of CasparCG (www.casparcg.com).
+*
+* CasparCG is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* CasparCG is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+*
+* Author: Julian Waller, git@julusian.co.uk
+*/
+
+#include "screen_shader.h"
+
+namespace caspar { namespace screen {
+
+std::string get_vertex()
+{
+    return R"shader(
+			#version 450
+            in vec4 TexCoordIn;
+            in vec2 Position;
+
+            out vec4 TexCoord;
+
+			void main()
+			{
+				TexCoord = TexCoordIn;
+				gl_Position = vec4(Position, 0, 1);
+			}
+	)shader";
+}
+
+std::string get_fragment()
+{
+    return R"shader(
+            #version 450
+            uniform sampler2D background;
+
+            in vec4 TexCoord;
+            out vec4 fragColor;
+
+			uniform bool key_only;
+
+            void main() {
+                vec4 color = texture(background, TexCoord.st);
+
+                if (key_only)
+                    color = vec4(color.aaa, 1);
+
+                fragColor = color;
+            }
+	)shader";
+}
+
+std::unique_ptr<accelerator::ogl::shader> get_shader() {
+    return std::make_unique<accelerator::ogl::shader>(get_vertex(), get_fragment());
+}
+
+}}

--- a/src/modules/screen/consumer/screen_shader.h
+++ b/src/modules/screen/consumer/screen_shader.h
@@ -1,0 +1,32 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+*
+* This file is part of CasparCG (www.casparcg.com).
+*
+* CasparCG is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* CasparCG is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+*
+* Author: Julian Waller, git@julusian.co.uk
+*/
+
+#pragma once
+
+#include <common/memory.h>
+
+#include <accelerator/ogl/util/shader.h>
+
+namespace caspar { namespace screen {
+
+std::unique_ptr<accelerator::ogl::shader> get_shader();
+
+}} // namespace caspar::screen


### PR DESCRIPTION
Primarily this avoids the aligned_memshfl() when set to key-only.

It also allows #805 and #1032 to be done more cleanly without any more work on the cpu