### PR TITLE
feat: Sting transition #1008

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -280,6 +280,7 @@ struct image_kernel::impl
         shader_->set("keyer", params.keyer);
 
         // Setup image-adjustements
+        shader_->set("invert", params.transform.invert);
 
         if (params.transform.levels.min_input > epsilon || params.transform.levels.max_input < 1.0 - epsilon ||
             params.transform.levels.min_output > epsilon || params.transform.levels.max_output < 1.0 - epsilon ||

--- a/src/accelerator/ogl/image/image_shader.cpp
+++ b/src/accelerator/ogl/image/image_shader.cpp
@@ -159,6 +159,7 @@ std::string get_fragment()
 			uniform int			keyer;
 			uniform int			pixel_format;
 
+            uniform bool        invert;
 			uniform float		opacity;
 			uniform bool		levels;
 			uniform float		min_input;
@@ -283,6 +284,8 @@ std::string get_fragment()
 					if(has_layer_key)
 						color *= texture(layer_key, TexCoord2.st).r;
 					color *= opacity;
+                    if (invert)
+                        color = 1.0 - color;
                     if (blend_mode >= 0)
 					    color = blend(color);
 					fragColor = color.bgra;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
 		producer/color/color_producer.cpp
 		producer/separated/separated_producer.cpp
 		producer/transition/transition_producer.cpp
+		producer/transition/sting_producer.cpp
 		producer/route/route_producer.cpp
 
 		producer/cg_proxy.cpp
@@ -58,6 +59,7 @@ set(HEADERS
 		producer/color/color_producer.h
 		producer/separated/separated_producer.h
 		producer/transition/transition_producer.h
+		producer/transition/sting_producer.h
 		producer/route/route_producer.h
 
 		producer/cg_proxy.h

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -97,6 +97,7 @@ image_transform& image_transform::operator*=(const image_transform& other)
     chroma.spill_suppress_saturation =
         std::min(other.chroma.spill_suppress_saturation, chroma.spill_suppress_saturation);
     is_key |= other.is_key;
+    invert |= other.invert;
     is_mix |= other.is_mix;
     blend_mode = std::max(blend_mode, other.blend_mode);
     layer_depth += other.layer_depth;
@@ -185,6 +186,7 @@ image_transform image_transform::tween(double                 time,
     result.chroma.enable    = dest.chroma.enable;
     result.chroma.show_mask = dest.chroma.show_mask;
     result.is_key           = source.is_key | dest.is_key;
+    result.is_key           = source.invert | dest.invert;
     result.is_mix           = source.is_mix | dest.is_mix;
     result.blend_mode       = std::max(source.blend_mode, dest.blend_mode);
     result.layer_depth      = dest.layer_depth;
@@ -216,7 +218,7 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
            boost::range::equal(lhs.fill_scale, rhs.fill_scale, eq) &&
            boost::range::equal(lhs.clip_translation, rhs.clip_translation, eq) &&
            boost::range::equal(lhs.clip_scale, rhs.clip_scale, eq) && eq(lhs.angle, rhs.angle) &&
-           lhs.is_key == rhs.is_key && lhs.is_mix == rhs.is_mix && lhs.blend_mode == rhs.blend_mode &&
+           lhs.is_key == rhs.is_key && lhs.invert == rhs.invert && lhs.is_mix == rhs.is_mix && lhs.blend_mode == rhs.blend_mode &&
            lhs.layer_depth == rhs.layer_depth && lhs.chroma.enable == rhs.chroma.enable &&
            lhs.chroma.show_mask == rhs.chroma.show_mask && eq(lhs.chroma.target_hue, rhs.chroma.target_hue) &&
            eq(lhs.chroma.hue_width, rhs.chroma.hue_width) && eq(lhs.chroma.min_saturation, rhs.chroma.min_saturation) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -218,10 +218,11 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
            boost::range::equal(lhs.fill_scale, rhs.fill_scale, eq) &&
            boost::range::equal(lhs.clip_translation, rhs.clip_translation, eq) &&
            boost::range::equal(lhs.clip_scale, rhs.clip_scale, eq) && eq(lhs.angle, rhs.angle) &&
-           lhs.is_key == rhs.is_key && lhs.invert == rhs.invert && lhs.is_mix == rhs.is_mix && lhs.blend_mode == rhs.blend_mode &&
-           lhs.layer_depth == rhs.layer_depth && lhs.chroma.enable == rhs.chroma.enable &&
-           lhs.chroma.show_mask == rhs.chroma.show_mask && eq(lhs.chroma.target_hue, rhs.chroma.target_hue) &&
-           eq(lhs.chroma.hue_width, rhs.chroma.hue_width) && eq(lhs.chroma.min_saturation, rhs.chroma.min_saturation) &&
+           lhs.is_key == rhs.is_key && lhs.invert == rhs.invert && lhs.is_mix == rhs.is_mix &&
+           lhs.blend_mode == rhs.blend_mode && lhs.layer_depth == rhs.layer_depth &&
+           lhs.chroma.enable == rhs.chroma.enable && lhs.chroma.show_mask == rhs.chroma.show_mask &&
+           eq(lhs.chroma.target_hue, rhs.chroma.target_hue) && eq(lhs.chroma.hue_width, rhs.chroma.hue_width) &&
+           eq(lhs.chroma.min_saturation, rhs.chroma.min_saturation) &&
            eq(lhs.chroma.min_brightness, rhs.chroma.min_brightness) && eq(lhs.chroma.softness, rhs.chroma.softness) &&
            eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
            eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -95,6 +95,7 @@ struct image_transform final
     core::chroma          chroma;
 
     bool             is_key      = false;
+    bool             invert      = false;
     bool             is_mix      = false;
     core::blend_mode blend_mode  = blend_mode::normal;
     int              layer_depth = 0;

--- a/src/core/producer/color/color_producer.cpp
+++ b/src/core/producer/color/color_producer.cpp
@@ -113,6 +113,9 @@ class color_producer : public frame_producer
 
 std::wstring get_hex_color(const std::wstring& str)
 {
+    if (str.size() == 0)
+        return str;
+
     if (str.at(0) == '#')
         return str.length() == 7 ? L"#FF" + str.substr(1) : str;
 
@@ -185,8 +188,12 @@ spl::shared_ptr<frame_producer> create_color_producer(const spl::shared_ptr<fram
     std::vector<std::wstring> colors;
 
     for (auto& param : params) {
-        if (try_get_color(param, value))
+        if (try_get_color(param, value)) {
             colors.push_back(param);
+        } else {
+            // Stop after something not a colour, as that probably means the transition definition
+            break;
+        }
     }
 
     return spl::make_shared<color_producer>(frame_factory, colors);

--- a/src/core/producer/frame_producer.h
+++ b/src/core/producer/frame_producer.h
@@ -31,6 +31,7 @@
 #include <core/video_format.h>
 
 #include <boost/noncopyable.hpp>
+#include <boost/optional.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -95,6 +96,7 @@ class frame_producer
     }
     virtual void                            leading_producer(const spl::shared_ptr<frame_producer>&) {}
     virtual spl::shared_ptr<frame_producer> following_producer() const { return core::frame_producer::empty(); }
+    virtual boost::optional<int64_t>        auto_play_delta() const { return boost::none; }
 };
 
 class frame_producer_registry;

--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -86,7 +86,7 @@ struct layer::impl
     void stop()
     {
         foreground_ = frame_producer::empty();
-        auto_play_ = false;
+        auto_play_  = false;
     }
 
     draw_frame receive(const video_format_desc& format_desc, int nb_samples)
@@ -99,8 +99,8 @@ struct layer::impl
             if (auto_play_) {
                 auto auto_play_delta = background_->auto_play_delta();
                 if (auto_play_delta) {
-                    auto time = static_cast<std::int64_t>(foreground_->frame_number());
-                    auto duration = static_cast<std::int64_t>(foreground_->nb_frames());
+                    auto time        = static_cast<std::int64_t>(foreground_->frame_number());
+                    auto duration    = static_cast<std::int64_t>(foreground_->nb_frames());
                     auto frames_left = duration - time - *auto_play_delta;
                     if (frames_left < 1) {
                         play();
@@ -144,9 +144,7 @@ layer& layer::operator=(layer&& other)
     return *this;
 }
 void layer::swap(layer& other) { impl_.swap(other.impl_); }
-void layer::load(spl::shared_ptr<frame_producer> frame_producer,
-                 bool                            preview,
-                 bool                            auto_play)
+void layer::load(spl::shared_ptr<frame_producer> frame_producer, bool preview, bool auto_play)
 {
     return impl_->load(std::move(frame_producer), preview, auto_play);
 }

--- a/src/core/producer/layer.h
+++ b/src/core/producer/layer.h
@@ -29,8 +29,6 @@
 #include <common/forward.h>
 #include <common/memory.h>
 
-#include <boost/optional.hpp>
-
 #include <string>
 
 namespace caspar { namespace core {
@@ -50,7 +48,7 @@ class layer final
 
     void load(spl::shared_ptr<frame_producer> producer,
               bool                            preview,
-              const boost::optional<int32_t>& auto_play_delta = boost::optional<int32_t>());
+              bool                            auto_play = false);
     void play();
     void pause();
     void resume();

--- a/src/core/producer/layer.h
+++ b/src/core/producer/layer.h
@@ -46,9 +46,7 @@ class layer final
 
     void swap(layer& other);
 
-    void load(spl::shared_ptr<frame_producer> producer,
-              bool                            preview,
-              bool                            auto_play = false);
+    void load(spl::shared_ptr<frame_producer> producer, bool preview, bool auto_play = false);
     void play();
     void pause();
     void resume();

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -145,9 +145,9 @@ struct stage::impl : public std::enable_shared_from_this<impl>
     std::future<void> load(int                                    index,
                            const spl::shared_ptr<frame_producer>& producer,
                            bool                                   preview,
-                           const boost::optional<int32_t>&        auto_play_delta)
+                           bool                                   auto_play)
     {
-        return executor_.begin_invoke([=] { get_layer(index).load(producer, preview, auto_play_delta); });
+        return executor_.begin_invoke([=] { get_layer(index).load(producer, preview, auto_play); });
     }
 
     std::future<void> pause(int index)
@@ -289,9 +289,9 @@ std::future<frame_transform> stage::get_current_transform(int index) { return im
 std::future<void>            stage::load(int                                    index,
                               const spl::shared_ptr<frame_producer>& producer,
                               bool                                   preview,
-                              const boost::optional<int32_t>&        auto_play_delta)
+                              bool                                   auto_play)
 {
-    return impl_->load(index, producer, preview, auto_play_delta);
+    return impl_->load(index, producer, preview, auto_play);
 }
 std::future<void> stage::pause(int index) { return impl_->pause(index); }
 std::future<void> stage::resume(int index) { return impl_->resume(index); }

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -142,10 +142,7 @@ struct stage::impl : public std::enable_shared_from_this<impl>
         return executor_.begin_invoke([=] { return tweens_[index].fetch(); });
     }
 
-    std::future<void> load(int                                    index,
-                           const spl::shared_ptr<frame_producer>& producer,
-                           bool                                   preview,
-                           bool                                   auto_play)
+    std::future<void> load(int index, const spl::shared_ptr<frame_producer>& producer, bool preview, bool auto_play)
     {
         return executor_.begin_invoke([=] { get_layer(index).load(producer, preview, auto_play); });
     }
@@ -286,10 +283,7 @@ std::future<void> stage::apply_transform(int                                    
 std::future<void>            stage::clear_transforms(int index) { return impl_->clear_transforms(index); }
 std::future<void>            stage::clear_transforms() { return impl_->clear_transforms(); }
 std::future<frame_transform> stage::get_current_transform(int index) { return impl_->get_current_transform(index); }
-std::future<void>            stage::load(int                                    index,
-                              const spl::shared_ptr<frame_producer>& producer,
-                              bool                                   preview,
-                              bool                                   auto_play)
+std::future<void> stage::load(int index, const spl::shared_ptr<frame_producer>& producer, bool preview, bool auto_play)
 {
     return impl_->load(index, producer, preview, auto_play);
 }

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -57,20 +57,18 @@ class stage final
     std::future<void>            clear_transforms(int index);
     std::future<void>            clear_transforms();
     std::future<frame_transform> get_current_transform(int index);
-    std::future<void>            load(int                                    index,
-                                      const spl::shared_ptr<frame_producer>& producer,
-                                      bool                                   preview   = false,
-                                      bool                                   auto_play = false);
-    std::future<void>            pause(int index);
-    std::future<void>            resume(int index);
-    std::future<void>            play(int index);
-    std::future<void>            stop(int index);
-    std::future<std::wstring>    call(int index, const std::vector<std::wstring>& params);
-    std::future<void>            clear(int index);
-    std::future<void>            clear();
-    std::future<void>            swap_layers(stage& other, bool swap_transforms);
-    std::future<void>            swap_layer(int index, int other_index, bool swap_transforms);
-    std::future<void>            swap_layer(int index, int other_index, stage& other, bool swap_transforms);
+    std::future<void>
+                              load(int index, const spl::shared_ptr<frame_producer>& producer, bool preview = false, bool auto_play = false);
+    std::future<void>         pause(int index);
+    std::future<void>         resume(int index);
+    std::future<void>         play(int index);
+    std::future<void>         stop(int index);
+    std::future<std::wstring> call(int index, const std::vector<std::wstring>& params);
+    std::future<void>         clear(int index);
+    std::future<void>         clear();
+    std::future<void>         swap_layers(stage& other, bool swap_transforms);
+    std::future<void>         swap_layer(int index, int other_index, bool swap_transforms);
+    std::future<void>         swap_layer(int index, int other_index, stage& other, bool swap_transforms);
 
     core::monitor::state state() const;
 

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -28,8 +28,6 @@
 #include <common/memory.h>
 #include <common/tweener.h>
 
-#include <boost/optional.hpp>
-
 #include <functional>
 #include <future>
 #include <map>
@@ -61,8 +59,8 @@ class stage final
     std::future<frame_transform> get_current_transform(int index);
     std::future<void>            load(int                                    index,
                                       const spl::shared_ptr<frame_producer>& producer,
-                                      bool                                   preview         = false,
-                                      const boost::optional<int32_t>&        auto_play_delta = boost::optional<int32_t>());
+                                      bool                                   preview   = false,
+                                      bool                                   auto_play = false);
     std::future<void>            pause(int index);
     std::future<void>            resume(int index);
     std::future<void>            play(int index);

--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -75,7 +75,8 @@ class sting_producer : public frame_producer
         return duration && current_frame_ >= *duration ? dst_producer_ : core::frame_producer::empty();
     }
 
-    boost::optional<int64_t> auto_play_delta() const override {
+    boost::optional<int64_t> auto_play_delta() const override
+    {
         auto duration = static_cast<int64_t>(mask_producer_->nb_frames());
         // ffmpeg will return -1 when media is still loading, so we need to cast duration first
         if (duration > -1) {
@@ -90,11 +91,11 @@ class sting_producer : public frame_producer
 
         CASPAR_SCOPE_EXIT
         {
-            state_                     = dst_producer_->state();
-            state_["transition/type"]  = std::string("sting");
+            state_                    = dst_producer_->state();
+            state_["transition/type"] = std::string("sting");
 
             if (duration)
-                state_["transition/frame"] = { static_cast<int>(current_frame_), static_cast<int>(*duration) };
+                state_["transition/frame"] = {static_cast<int>(current_frame_), static_cast<int>(*duration)};
         };
 
         if (duration && current_frame_ >= *duration) {
@@ -117,7 +118,7 @@ class sting_producer : public frame_producer
 
             if (!dst_) { // Not ready yet
                 auto res = src_;
-                src_ = draw_frame{};
+                src_     = draw_frame{};
                 return res;
             }
         }
@@ -134,16 +135,16 @@ class sting_producer : public frame_producer
         bool mask_and_overlay_valid = mask_ && (!expecting_overlay || overlay_);
         if (current_frame_ == 0 && !mask_and_overlay_valid) {
             auto res = src_;
-            src_ = draw_frame{};
+            src_     = draw_frame{};
             return res;
         }
 
         // Ensure mask and overlay are in perfect sync
-        auto mask = mask_;
+        auto mask    = mask_;
         auto overlay = overlay_;
         if (!mask_and_overlay_valid) {
             // If one is behind, then fetch the last_frame of both
-            mask = mask_producer_->last_frame();
+            mask    = mask_producer_->last_frame();
             overlay = overlay_producer_->last_frame();
         }
 
@@ -153,7 +154,7 @@ class sting_producer : public frame_producer
         src_ = draw_frame{};
 
         if (mask_and_overlay_valid) {
-            mask_ = draw_frame{};
+            mask_    = draw_frame{};
             overlay_ = draw_frame{};
 
             current_frame_ += 1;
@@ -181,8 +182,8 @@ class sting_producer : public frame_producer
     draw_frame
     compose(draw_frame dst_frame, draw_frame src_frame, draw_frame mask_frame, draw_frame overlay_frame) const
     {
-        const auto duration = auto_play_delta();
-        const double delta = duration ? audio_tweener_(current_frame_, 0.0, 1.0, static_cast<double>(*duration)) : 0;
+        const auto   duration = auto_play_delta();
+        const double delta    = duration ? audio_tweener_(current_frame_, 0.0, 1.0, static_cast<double>(*duration)) : 0;
 
         src_frame.transform().audio_transform.volume = 1.0 - delta;
         dst_frame.transform().audio_transform.volume = delta;

--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018 Norsk rikskringkasting AS
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "../../StdAfx.h"
+
+#include "sting_producer.h"
+
+#include "../../frame/draw_frame.h"
+#include "../../frame/frame_transform.h"
+#include "../../monitor/monitor.h"
+#include "../frame_producer.h"
+
+#include <common/param.h>
+#include <common/scope_exit.h>
+
+#include <tbb/parallel_invoke.h>
+
+#include <future>
+
+namespace caspar { namespace core {
+
+class sting_producer : public frame_producer_base
+{
+    monitor::state  state_;
+    uint32_t        current_frame_ = 0;
+    caspar::tweener audio_tweener_{L"linear"};
+
+    core::draw_frame dst_;
+    core::draw_frame src_;
+    core::draw_frame mask_;
+    core::draw_frame overlay_;
+
+    const sting_info info_;
+
+    spl::shared_ptr<frame_producer> dst_producer_     = frame_producer::empty();
+    spl::shared_ptr<frame_producer> src_producer_     = frame_producer::empty();
+    spl::shared_ptr<frame_producer> mask_producer_    = frame_producer::empty();
+    spl::shared_ptr<frame_producer> overlay_producer_ = frame_producer::empty();
+
+  public:
+    sting_producer(const spl::shared_ptr<frame_producer>& dest,
+                   const sting_info&                      info,
+                   const spl::shared_ptr<frame_producer>& mask,
+                   const spl::shared_ptr<frame_producer>& overlay)
+        : info_(info)
+        , dst_producer_(dest)
+        , mask_producer_(mask)
+        , overlay_producer_(overlay)
+    {
+    }
+
+    // frame_producer
+
+    void leading_producer(const spl::shared_ptr<frame_producer>& producer) override { src_producer_ = producer; }
+
+    spl::shared_ptr<frame_producer> following_producer() const override
+    {
+        return dst_ && current_frame_ >= info_.duration ? dst_producer_ : core::frame_producer::empty();
+    }
+
+    draw_frame receive_impl(int nb_samples) override
+    {
+        CASPAR_SCOPE_EXIT
+        {
+            state_                     = dst_producer_->state();
+            state_["transition/frame"] = {static_cast<int>(current_frame_), static_cast<int>(info_.duration)};
+            state_["transition/type"]  = L"sting";
+        };
+
+        bool started_dst = current_frame_ >= info_.trigger_point;
+
+        tbb::parallel_invoke(
+            [&] {
+                if (!started_dst)
+                    return;
+
+                dst_ = dst_producer_->receive(nb_samples);
+                if (!dst_) {
+                    dst_ = dst_producer_->last_frame();
+                }
+            },
+            [&] {
+                src_ = src_producer_->receive(nb_samples);
+                if (!src_) {
+                    src_ = src_producer_->last_frame();
+                }
+            },
+            [&] {
+                mask_ = mask_producer_->receive(nb_samples);
+                if (!mask_) {
+                    mask_ = mask_producer_->last_frame();
+                }
+            },
+            [&] {
+                overlay_ = overlay_producer_->receive(nb_samples);
+                if (!overlay_) {
+                    overlay_ = overlay_producer_->last_frame();
+                }
+            });
+
+        if (!mask_) {
+            return src_;
+        }
+
+        if (current_frame_ >= info_.duration) {
+            return dst_;
+        }
+
+        current_frame_ += 1;
+
+        return compose(dst_, src_, mask_, overlay_);
+    }
+
+    uint32_t nb_frames() const override { return dst_producer_->nb_frames(); }
+
+    uint32_t frame_number() const override { return dst_producer_->frame_number(); }
+
+    std::wstring print() const override
+    {
+        return L"transition[" + src_producer_->print() + L"=>" + dst_producer_->print() + L"]";
+    }
+
+    std::wstring name() const override { return L"transition"; }
+
+    std::future<std::wstring> call(const std::vector<std::wstring>& params) override
+    {
+        return dst_producer_->call(params);
+    }
+
+    draw_frame
+    compose(draw_frame dst_frame, draw_frame src_frame, draw_frame mask_frame, draw_frame overlay_frame) const
+    {
+        const double delta = audio_tweener_(current_frame_, 0.0, 1.0, static_cast<double>(info_.duration));
+
+        src_frame.transform().audio_transform.volume = 1.0 - delta;
+        dst_frame.transform().audio_transform.volume = delta;
+
+        draw_frame mask_frame2                         = mask_frame;
+        mask_frame.transform().image_transform.is_key  = true;
+        mask_frame2.transform().image_transform.is_key = true;
+        mask_frame2.transform().image_transform.invert = true;
+
+        std::vector<draw_frame> frames;
+        frames.push_back(std::move(mask_frame2));
+        frames.push_back(std::move(src_frame));
+        frames.push_back(std::move(mask_frame));
+        frames.push_back(std::move(dst_frame));
+        if (overlay_frame != draw_frame::empty())
+            frames.push_back(std::move(overlay_frame));
+
+        return draw_frame(std::move(frames));
+    }
+
+    const monitor::state& state() { return state_; }
+};
+
+spl::shared_ptr<frame_producer> create_sting_producer(const frame_producer_dependencies&     dependencies,
+                                                      const spl::shared_ptr<frame_producer>& destination,
+                                                      sting_info&                            info)
+{
+    // Any producer which exposes a fixed duration will work here, not just ffmpeg
+    auto mask_producer = dependencies.producer_registry->create_producer(dependencies, info.mask_filename);
+    info.duration      = mask_producer->nb_frames();
+
+    auto overlay_producer = frame_producer::empty();
+    if (info.overlay_filename != L"") {
+        // This could be any producer, no requirement for it to be of fixed length
+        overlay_producer = dependencies.producer_registry->create_producer(dependencies, info.overlay_filename);
+    }
+
+    return spl::make_shared<sting_producer>(destination, info, mask_producer, overlay_producer);
+}
+
+bool try_match_sting(const std::vector<std::wstring>& params, sting_info& stingInfo)
+{
+    auto match = std::find_if(params.begin(), params.end(), param_comparer(L"STING"));
+    if (match == params.end())
+        return false;
+
+    auto start_ind = static_cast<int>(match - params.begin());
+
+    if (params.size() <= start_ind + 1) {
+        // No mask filename
+        return false;
+    }
+
+    stingInfo.mask_filename = params.at(start_ind + 1);
+
+    if (params.size() > start_ind + 2) {
+        stingInfo.trigger_point = boost::lexical_cast<int>(params.at(start_ind + 2));
+    }
+
+    if (params.size() > start_ind + 3) {
+        stingInfo.overlay_filename = params.at(start_ind + 3);
+    }
+
+    return true;
+}
+
+}} // namespace caspar::core

--- a/src/core/producer/transition/sting_producer.h
+++ b/src/core/producer/transition/sting_producer.h
@@ -36,9 +36,6 @@ struct sting_info
     std::wstring mask_filename    = L"";
     std::wstring overlay_filename = L"";
     uint32_t     trigger_point    = 0;
-
-    // out parameter
-    uint32_t duration = 0;
 };
 
 bool try_match_sting(const std::vector<std::wstring>& params, sting_info& stingInfo);

--- a/src/core/producer/transition/sting_producer.h
+++ b/src/core/producer/transition/sting_producer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ * Copyright (c) 2018 Norsk rikskringkasting AS
  *
  * This file is part of CasparCG (www.casparcg.com).
  *
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
  *
- * Author: Robert Nagy, ronag89@gmail.com
+ * Author: Julian Waller, julian@superfly.tv
  */
 
 #pragma once
@@ -31,34 +31,20 @@
 
 namespace caspar { namespace core {
 
-enum class transition_type
+struct sting_info
 {
-    cut,
-    mix,
-    push,
-    slide,
-    wipe,
-    count
+    std::wstring mask_filename    = L"";
+    std::wstring overlay_filename = L"";
+    uint32_t     trigger_point    = 0;
+
+    // out parameter
+    uint32_t duration = 0;
 };
 
-enum class transition_direction
-{
-    from_left,
-    from_right,
-    count
-};
+bool try_match_sting(const std::vector<std::wstring>& params, sting_info& stingInfo);
 
-struct transition_info
-{
-    int                  duration  = 0;
-    transition_direction direction = transition_direction::from_left;
-    transition_type      type      = transition_type::cut;
-    caspar::tweener      tweener{L"linear"};
-};
-
-bool try_match_transition(const std::wstring& message, transition_info& transitionInfo);
-
-spl::shared_ptr<frame_producer> create_transition_producer(const spl::shared_ptr<frame_producer>& destination,
-                                                           const transition_info&                 info);
+spl::shared_ptr<frame_producer> create_sting_producer(const frame_producer_dependencies&     dependencies,
+                                                      const spl::shared_ptr<frame_producer>& destination,
+                                                      sting_info&                            info);
 
 }} // namespace caspar::core

--- a/src/core/producer/transition/transition_producer.cpp
+++ b/src/core/producer/transition/transition_producer.cpp
@@ -74,6 +74,8 @@ class transition_producer : public frame_producer
         return dst_ && current_frame_ >= info_.duration ? dst_producer_ : core::frame_producer::empty();
     }
 
+    boost::optional<int64_t> auto_play_delta() const override { return info_.duration; }
+
     void update_state()
     {
         state_                     = dst_producer_->state();

--- a/src/core/producer/transition/transition_producer.cpp
+++ b/src/core/producer/transition/transition_producer.cpp
@@ -178,4 +178,42 @@ spl::shared_ptr<frame_producer> create_transition_producer(const spl::shared_ptr
     return spl::make_shared<transition_producer>(destination, info);
 }
 
+bool try_match_transition(const std::wstring& message, transition_info& transitionInfo)
+{
+    static const boost::wregex expr(
+        LR"(.*(?<TRANSITION>CUT|PUSH|SLIDE|WIPE|MIX)\s*(?<DURATION>\d+)\s*(?<TWEEN>(LINEAR)|(EASE[^\s]*))?\s*(?<DIRECTION>FROMLEFT|FROMRIGHT|LEFT|RIGHT)?.*)");
+    boost::wsmatch what;
+    if (!boost::regex_match(message, what, expr)) {
+        return false;
+    }
+
+    auto transition         = what["TRANSITION"].str();
+    transitionInfo.duration = boost::lexical_cast<int>(what["DURATION"].str());
+    auto direction          = what["DIRECTION"].matched ? what["DIRECTION"].str() : L"";
+    auto tween              = what["TWEEN"].matched ? what["TWEEN"].str() : L"";
+    transitionInfo.tweener  = tween;
+
+    if (transition == L"CUT")
+        transitionInfo.type = transition_type::cut;
+    else if (transition == L"MIX")
+        transitionInfo.type = transition_type::mix;
+    else if (transition == L"PUSH")
+        transitionInfo.type = transition_type::push;
+    else if (transition == L"SLIDE")
+        transitionInfo.type = transition_type::slide;
+    else if (transition == L"WIPE")
+        transitionInfo.type = transition_type::wipe;
+
+    if (direction == L"FROMLEFT")
+        transitionInfo.direction = transition_direction::from_left;
+    else if (direction == L"FROMRIGHT")
+        transitionInfo.direction = transition_direction::from_right;
+    else if (direction == L"LEFT")
+        transitionInfo.direction = transition_direction::from_right;
+    else if (direction == L"RIGHT")
+        transitionInfo.direction = transition_direction::from_left;
+
+    return true;
+}
+
 }} // namespace caspar::core

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -753,12 +753,12 @@ std::wstring mixer_invert_command(command_context& ctx)
     transforms_applier transforms(ctx);
     bool               value = boost::lexical_cast<int>(ctx.parameters.at(0));
     transforms.add(stage::transform_tuple_t(ctx.layer_index(),
-        [=](frame_transform transform) -> frame_transform {
-        transform.image_transform.invert = value;
-        return transform;
-    },
-        0,
-        tweener(L"linear")));
+                                            [=](frame_transform transform) -> frame_transform {
+                                                transform.image_transform.invert = value;
+                                                return transform;
+                                            },
+                                            0,
+                                            tweener(L"linear")));
     transforms.apply();
 
     return L"202 MIXER OK\r\n";

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -237,11 +237,9 @@ std::wstring loadbg_command(command_context& ctx)
     spl::shared_ptr<frame_producer> transition_producer = frame_producer::empty();
     transition_info                 transitionInfo;
     sting_info                      stingInfo;
-    int                             duration;
 
     if (try_match_sting(ctx.parameters, stingInfo)) {
         transition_producer = create_sting_producer(get_producer_dependencies(channel, ctx), pFP, stingInfo);
-        duration = stingInfo.duration;
     } else {
         std::wstring message;
         for (size_t n = 0; n < ctx.parameters.size(); ++n)
@@ -250,13 +248,9 @@ std::wstring loadbg_command(command_context& ctx)
         // Always fallback to transition
         try_match_transition(message, transitionInfo);
         transition_producer = create_transition_producer(pFP, transitionInfo);
-        duration            = transitionInfo.duration;
     }
 
-    if (auto_play)
-        channel->stage().load(ctx.layer_index(), transition_producer, false, duration); // TODO: LOOP
-    else
-        channel->stage().load(ctx.layer_index(), transition_producer, false); // TODO: LOOP
+    channel->stage().load(ctx.layer_index(), transition_producer, false, auto_play); // TODO: LOOP
 
     return L"202 LOADBG OK\r\n";
 }

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -48,6 +48,7 @@
 #include <core/producer/frame_producer.h>
 #include <core/producer/layer.h>
 #include <core/producer/stage.h>
+#include <core/producer/transition/sting_producer.h>
 #include <core/producer/transition/transition_producer.h>
 #include <core/video_format.h>
 
@@ -220,45 +221,6 @@ core::frame_producer_dependencies get_producer_dependencies(const std::shared_pt
 
 std::wstring loadbg_command(command_context& ctx)
 {
-    transition_info transitionInfo;
-
-    // TRANSITION
-
-    std::wstring message;
-    for (size_t n = 0; n < ctx.parameters.size(); ++n)
-        message += boost::to_upper_copy(ctx.parameters[n]) + L" ";
-
-    static const boost::wregex expr(
-        LR"(.*(?<TRANSITION>CUT|PUSH|SLIDE|WIPE|MIX)\s*(?<DURATION>\d+)\s*(?<TWEEN>(LINEAR)|(EASE[^\s]*))?\s*(?<DIRECTION>FROMLEFT|FROMRIGHT|LEFT|RIGHT)?.*)");
-    boost::wsmatch what;
-    if (boost::regex_match(message, what, expr)) {
-        auto transition         = what["TRANSITION"].str();
-        transitionInfo.duration = boost::lexical_cast<size_t>(what["DURATION"].str());
-        auto direction          = what["DIRECTION"].matched ? what["DIRECTION"].str() : L"";
-        auto tween              = what["TWEEN"].matched ? what["TWEEN"].str() : L"";
-        transitionInfo.tweener  = tween;
-
-        if (transition == L"CUT")
-            transitionInfo.type = transition_type::cut;
-        else if (transition == L"MIX")
-            transitionInfo.type = transition_type::mix;
-        else if (transition == L"PUSH")
-            transitionInfo.type = transition_type::push;
-        else if (transition == L"SLIDE")
-            transitionInfo.type = transition_type::slide;
-        else if (transition == L"WIPE")
-            transitionInfo.type = transition_type::wipe;
-
-        if (direction == L"FROMLEFT")
-            transitionInfo.direction = transition_direction::from_left;
-        else if (direction == L"FROMRIGHT")
-            transitionInfo.direction = transition_direction::from_right;
-        else if (direction == L"LEFT")
-            transitionInfo.direction = transition_direction::from_right;
-        else if (direction == L"RIGHT")
-            transitionInfo.direction = transition_direction::from_left;
-    }
-
     // Perform loading of the clip
     core::diagnostics::scoped_call_context save;
     core::diagnostics::call_context::for_thread().video_channel = ctx.channel_index + 1;
@@ -272,11 +234,29 @@ std::wstring loadbg_command(command_context& ctx)
 
     bool auto_play = contains_param(L"AUTO", ctx.parameters);
 
-    auto pFP2 = create_transition_producer(pFP, transitionInfo);
+    spl::shared_ptr<frame_producer> transition_producer = frame_producer::empty();
+    transition_info                 transitionInfo;
+    sting_info                      stingInfo;
+    int                             duration;
+
+    if (try_match_sting(ctx.parameters, stingInfo)) {
+        transition_producer = create_sting_producer(get_producer_dependencies(channel, ctx), pFP, stingInfo);
+        duration = stingInfo.duration;
+    } else {
+        std::wstring message;
+        for (size_t n = 0; n < ctx.parameters.size(); ++n)
+            message += boost::to_upper_copy(ctx.parameters[n]) + L" ";
+
+        // Always fallback to transition
+        try_match_transition(message, transitionInfo);
+        transition_producer = create_transition_producer(pFP, transitionInfo);
+        duration            = transitionInfo.duration;
+    }
+
     if (auto_play)
-        channel->stage().load(ctx.layer_index(), pFP2, false, transitionInfo.duration); // TODO: LOOP
+        channel->stage().load(ctx.layer_index(), transition_producer, false, duration); // TODO: LOOP
     else
-        channel->stage().load(ctx.layer_index(), pFP2, false); // TODO: LOOP
+        channel->stage().load(ctx.layer_index(), transition_producer, false); // TODO: LOOP
 
     return L"202 LOADBG OK\r\n";
 }

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -771,6 +771,25 @@ std::wstring mixer_keyer_command(command_context& ctx)
     return L"202 MIXER OK\r\n";
 }
 
+std::wstring mixer_invert_command(command_context& ctx)
+{
+    if (ctx.parameters.empty())
+        return reply_value(ctx, [](const frame_transform& t) { return t.image_transform.invert ? 1 : 0; });
+
+    transforms_applier transforms(ctx);
+    bool               value = boost::lexical_cast<int>(ctx.parameters.at(0));
+    transforms.add(stage::transform_tuple_t(ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+        transform.image_transform.invert = value;
+        return transform;
+    },
+        0,
+        tweener(L"linear")));
+    transforms.apply();
+
+    return L"202 MIXER OK\r\n";
+}
+
 std::wstring ANIMATION_SYNTAX = L" {[duration:int] {[tween:string]|linear}|0 linear}}";
 
 std::wstring mixer_chroma_command(command_context& ctx)
@@ -1467,6 +1486,7 @@ void register_commands(amcp_command_repository& repo)
     repo.register_channel_command(L"Template Commands", L"CG INVOKE", cg_invoke_command, 2);
 
     repo.register_channel_command(L"Mixer Commands", L"MIXER KEYER", mixer_keyer_command, 0);
+    repo.register_channel_command(L"Mixer Commands", L"MIXER INVERT", mixer_invert_command, 0);
     repo.register_channel_command(L"Mixer Commands", L"MIXER CHROMA", mixer_chroma_command, 0);
     repo.register_channel_command(L"Mixer Commands", L"MIXER BLEND", mixer_blend_command, 0);
     repo.register_channel_command(L"Mixer Commands", L"MIXER OPACITY", mixer_opacity_command, 0);


### PR DESCRIPTION
This allows for doing more complex transitions than are currently supported.
It uses a video file as the mask (it will work with other producers if they report a length)
And another optional video file (or any producer) as the overlay artwork.

The length is dictated by the mask file, if the overlay is longer it will get cut off.
There is an optional parameter to delay the start of the destination producer. 

Example usage:
```
PLAY 1-10 AMB STING wipe_mask 0 wipe_overlay

explanation: 
STING (mask_filename) (dest_start_delay) (overlay_filename)
```

Here is not great looking demo of it in action, along with the source assets. Hopefully this will help others understand how it all fits together when used.

Demo: https://drive.google.com/open?id=1XDuZXug2kepzFLK9MGWdAeNsEKTTv6pM
Assets: https://drive.google.com/open?id=1cGvX8CfUwg89AbQ9PvU7iLW-g-YPp1wr