### PR TITLE
Cloud based builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 CasparCG Server
 ===============
 
+[![Build Status](https://dev.azure.com/julusian/casparcg/_apis/build/status/Julusian.CasparCG-Server?branchName=azure-pipelines)](https://dev.azure.com/julusian/casparcg/_build/latest?definitionId=1?branchName=azure-pipelines)
+
 Thank you for your interest in CasparCG Server, a professional software used to
 play out and record professional graphics, audio and video to multiple outputs.
 CasparCG Server has been in 24/7 broadcast production since 2006.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,69 @@
+jobs:
+- job: ubuntu_1804_docker
+  displayName: 'Ubuntu 18.04'
+  strategy:
+    matrix:
+      Default: {}
+      Clang:
+        CC: clang
+        CXX: clang++
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - checkout: self
+    clean: false
+    fetchDepth: 1
+    lfs: false
+  - bash: |
+      export PROC_COUNT=$(nproc)
+      ./tools/linux/ensure-base-images
+      ./tools/linux/build-in-docker
+    #   ./tools/linux/extract-from-docker
+    displayName: 'build in docker'
+#   - task: ArchiveFiles@2
+#     inputs:
+#       rootFolderOrFile: 'casparcg_server'
+#       archiveType: 'zip' # Options: zip, 7z, tar, wim
+#       archiveFile: 'artifacts/casparcg_server_linux.zip'
+#     displayName: 'make archive'
+# TODO - publish zip to ftp/similar
+
+- job: windows
+  displayName: 'Windows VS2017'
+  pool:
+    vmImage: 'vs2017-win2016'
+  steps:
+  - checkout: self
+    clean: false
+    fetchDepth: 1
+    lfs: false
+  - task: CMake@1
+    inputs:
+      workingDirectory: "$(Build.BinariesDirectory)"
+      cmakeArgs: "-A x64 $(Build.SourcesDirectory)/src"
+    displayName: 'prepare build'
+  - task: NuGetCommand@2
+    inputs:
+      command: 'restore'
+      restoreSolution: '$(Build.BinariesDirectory)/CasparCG Server.sln'
+    displayName: 'nuget restore'
+  - task: VSBuild@1
+    inputs:
+      solution: '$(Build.BinariesDirectory)/CasparCG Server.sln'
+      vsVersion: 15.0
+      configuration: Release
+      msbuildArchitecture: 'x64'
+    displayName: 'build'
+#   - script: |
+#       cd $(Build.BinariesDirectory)
+#       set SERVER_FOLDER=CasparCG Server
+
+#       $(Build.SourcesDirectory)\tools\windows\package.bat $(Build.SourcesDirectory)
+#     displayName: 'prepare archive'
+#   - task: ArchiveFiles@2
+#     inputs:
+#       rootFolderOrFile: '$(Build.BinariesDirectory)\CasparCG Server'
+#       archiveType: 'zip' # Options: zip, 7z, tar, wim
+#       archiveFile: 'artifacts/casparcg_server_windows.zip'
+#     displayName: 'make archive'
+# TODO - publish zip to ftp/similar

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -106,7 +106,7 @@ add_custom_command(TARGET casparcg_copy_dependencies POST_BUILD COMMAND ${CMAKE_
 
 if (MSVC)
 	foreach(FILE_TO_COPY ${CASPARCG_RUNTIME_DEPENDENCIES})
-		if(IS_DIRECTORY ${FILE_TO_COPY})
+		if(IS_DIRECTORY ${FILE_TO_COPY}) # TODO - this check isnt working reliably.
 			get_filename_component(FOLDER_NAME "${FILE_TO_COPY}" NAME)
 			add_custom_command(TARGET casparcg_copy_dependencies POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory \"${FILE_TO_COPY}\" \"${OUTPUT_FOLDER}/${FOLDER_NAME}\")
 			add_custom_command(TARGET casparcg_copy_dependencies POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory \"${FILE_TO_COPY}\" \"${CMAKE_CURRENT_BINARY_DIR}/${FOLDER_NAME}\")

--- a/tools/windows/build.bat
+++ b/tools/windows/build.bat
@@ -1,0 +1,42 @@
+@echo off
+
+set BUILD_ARCHIVE_NAME=casparcg_server
+set BUILD_VCVARSALL=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
+set BUILD_7ZIP=C:\Program Files\7-Zip\7z.exe
+set CEF_VERSION=cef.redist.x64.3.3239.1723
+
+:: Clean and enter shadow build folder
+echo Cleaning...
+if exist dist rmdir dist /s /q || goto :error
+mkdir dist || goto :error
+
+:: Setup VC++ environment
+echo Setting up VC++...
+call "%BUILD_VCVARSALL%" amd64 || goto :error
+
+:: Run cmake
+cd dist || goto :error
+cmake -G "Visual Studio 15 2017" -A x64 ..\src || goto :error
+
+:: Restore dependencies
+echo Restore dependencies...
+nuget restore || goto :error
+
+:: Build with MSBuild
+echo Building...
+msbuild "CasparCG Server.sln" /t:Clean /p:Configuration=RelWithDebInfo || goto :error
+msbuild "CasparCG Server.sln" /p:Configuration=RelWithDebInfo /m:%NUMBER_OF_PROCESSORS% || goto :error
+
+:: Create server folder to later zip
+set SERVER_FOLDER=casparcg_server
+package.bat ..
+
+:: Create zip file
+echo Creating zip...
+"%BUILD_7ZIP%" a "%BUILD_ARCHIVE_NAME%.zip" "%SERVER_FOLDER%" || goto :error
+
+:: Skip exiting with failure
+goto :EOF
+
+:error
+exit /b %errorlevel%

--- a/tools/windows/package.bat
+++ b/tools/windows/package.bat
@@ -1,0 +1,23 @@
+if exist "%SERVER_FOLDER%" rmdir "%SERVER_FOLDER%" /s /q
+mkdir "%SERVER_FOLDER%"
+
+del shell\*_debug.dll
+del shell\*-d-2.dll
+
+copy shell\*.dll "%SERVER_FOLDER%\server"
+copy shell\Release\casparcg.exe "%SERVER_FOLDER%\server"
+copy shell\casparcg.config "%SERVER_FOLDER%\server"
+copy shell\*.ttf "%SERVER_FOLDER%\server"
+copy shell\*.pak "%SERVER_FOLDER%\server"
+copy shell\*.bin "%SERVER_FOLDER%\server"
+copy shell\*.dat "%SERVER_FOLDER%\server"
+xcopy shell\locales "%SERVER_FOLDER%\server\locales" /E /I /Y
+xcopy shell\swiftshader "%SERVER_FOLDER%\server\swiftshader" /E /I /Y
+
+copy %1\src\shell\casparcg_auto_restart.bat "%SERVER_FOLDER%\server"
+xcopy %1\resources\windows\flash-template-host-files "%SERVER_FOLDER%" /E /I /Y
+
+echo Copying documentation...
+copy %1\CHANGELOG.md "%SERVER_FOLDER%"
+copy %1\LICENSE.md "%SERVER_FOLDER%"
+copy %1\README.md "%SERVER_FOLDER%"


### PR DESCRIPTION
This is something that will want discussion, I think was back when 2.2 was being started, but I am finding the current build process to be a bit limiting. Primarily, it is very hard to notice build issues caused by a commit or PR without someone trying to build it or @dotarmin noticing the SVT build server threw an error.
This PR is something I was spent a couple of hours playing with the other day. I don't mind if it is decided to stick with the current Jenkins process, but thought it worth review. 

One solution for this is to use a cloud based ci provider for the building.
This PR is largly some linux script refactoring to make the version numbers be defined in one place, the actual build scripts for both platforms are pretty simple, and are also good for using locally to produce a build zip file.

The only free cloud ci I am aware of that supports windows is appveyor, so I have been playing with that. The total build time ends up being 20-25mins (~10mins per platform, free tier won't run concurrent)

Another benefit of doing builds like this is that it will add some status badges to commits, which makes it easy to see if a commit builds, and does the same for PRs too. (Example: https://github.com/Julusian/CasparCG-Server/pull/2 https://github.com/Julusian/CasparCG-Server/commits/appveyor)

Each build is also producing a zip file for each platform (eg https://ci.appveyor.com/project/Julusian/casparcg-server/build/2.2.15-appveyor2/job/o58acv3ribggwjkr/artifacts and https://ci.appveyor.com/project/Julusian/casparcg-server/build/2.2.15-appveyor2/job/o4a3hhf7t2h8shh8/artifacts) These can also easily be pushed to builds.casparcg.com via whatever method SVT prefer, without adding that to the repo (it can be defined in the appveyor ui)

On linux, there is also a step which is rebuilding the docker base images if they do not yet exist, and I will make it push the new images to dockerhub, and so will also remove the current manual step to rebuild those when the versions are bumped.

And continuing further, users will be able to easily enable this whole process for their own repos with no additional work, which I would really like to have for any experimental/testing branches I have

What do people think about using this? I think it will be a good step to being more open and make the build process more transparent.

A later step (which I shall do as another PR) I would also like to do is to add a step which will mark the commit/PR as failed if clang-format detects anything wrong with a source file, to enforce the common styling across the project and reduce churn caused by formatting being corrected in later commits