### PR TITLE
#1007 feat(route) route first frame of layer background producer

### DIFF
--- a/src/core/mixer/mixer.cpp
+++ b/src/core/mixer/mixer.cpp
@@ -69,12 +69,12 @@ struct mixer::impl : boost::noncopyable
     {
     }
 
-    const_frame operator()(std::map<int, draw_frame> frames, const video_format_desc& format_desc, int nb_samples)
+    const_frame operator()(std::vector<draw_frame> frames, const video_format_desc& format_desc, int nb_samples)
     {
         for (auto& frame : frames) {
-            frame.second.accept(audio_mixer_);
-            frame.second.transform().image_transform.layer_depth = 1;
-            frame.second.accept(*image_mixer_);
+            frame.accept(audio_mixer_);
+            frame.transform().image_transform.layer_depth = 1;
+            frame.accept(*image_mixer_);
         }
 
         auto image = (*image_mixer_)(format_desc);
@@ -112,7 +112,7 @@ mixer::mixer(int channel_index, spl::shared_ptr<diagnostics::graph> graph, spl::
 }
 void        mixer::set_master_volume(float volume) { impl_->set_master_volume(volume); }
 float       mixer::get_master_volume() { return impl_->get_master_volume(); }
-const_frame mixer::operator()(std::map<int, draw_frame> frames, const video_format_desc& format_desc, int nb_samples)
+const_frame mixer::operator()(std::vector<draw_frame> frames, const video_format_desc& format_desc, int nb_samples)
 {
     return (*impl_)(std::move(frames), format_desc, nb_samples);
 }

--- a/src/core/mixer/mixer.h
+++ b/src/core/mixer/mixer.h
@@ -48,7 +48,7 @@ class mixer final
                    spl::shared_ptr<caspar::diagnostics::graph> graph,
                    spl::shared_ptr<image_mixer>                image_mixer);
 
-    const_frame operator()(std::map<int, draw_frame> frames, const video_format_desc& format_desc, int nb_samples);
+    const_frame operator()(std::vector<draw_frame> frames, const video_format_desc& format_desc, int nb_samples);
 
     void  set_master_volume(float volume);
     float get_master_volume();

--- a/src/core/producer/frame_producer.cpp
+++ b/src/core/producer/frame_producer.cpp
@@ -87,6 +87,7 @@ const spl::shared_ptr<frame_producer>& frame_producer::empty()
             return make_ready_future(std::wstring(L""));
         }
         draw_frame last_frame() { return draw_frame{}; }
+        draw_frame first_frame() { return draw_frame{}; }
     };
 
     static spl::shared_ptr<frame_producer> producer = spl::make_shared<empty_frame_producer>();
@@ -176,6 +177,7 @@ class destroy_producer_proxy : public frame_producer
     uint32_t             frame_number() const override { return producer_->frame_number(); }
     uint32_t             nb_frames() const override { return producer_->nb_frames(); }
     draw_frame           last_frame() override { return producer_->last_frame(); }
+    draw_frame           first_frame() override { return producer_->first_frame(); }
     core::monitor::state state() const override { return producer_->state(); }
 };
 

--- a/src/core/producer/frame_producer.h
+++ b/src/core/producer/frame_producer.h
@@ -48,13 +48,14 @@ class frame_producer
     frame_producer& operator=(const frame_producer&);
 
     uint32_t         frame_number_ = 0;
-    core::draw_frame frame_;
+    core::draw_frame last_frame_;
+    core::draw_frame first_frame_;
 
   public:
     static const spl::shared_ptr<frame_producer>& empty();
 
     frame_producer(core::draw_frame frame)
-        : frame_(std::move(frame))
+        : last_frame_(std::move(frame))
     {
     }
     frame_producer() {}
@@ -62,17 +63,27 @@ class frame_producer
 
     draw_frame receive(int nb_samples)
     {
+        if (frame_number_ == 0 && first_frame_) {
+            frame_number_ += 1;
+            return first_frame_;
+        }
+
         auto frame = receive_impl(nb_samples);
 
         if (frame) {
             frame_number_ += 1;
-            frame_ = frame;
+            last_frame_ = frame;
+        }
+
+        if (!first_frame_) {
+            first_frame_ = frame;
         }
 
         return frame;
     }
 
-    virtual draw_frame                receive_impl(int nb_samples) { return core::draw_frame{}; };
+    virtual draw_frame receive_impl(int nb_samples) { return core::draw_frame{}; }
+
     virtual std::future<std::wstring> call(const std::vector<std::wstring>& params)
     {
         CASPAR_THROW_EXCEPTION(not_implemented());
@@ -89,10 +100,17 @@ class frame_producer
     virtual uint32_t     nb_frames() const { return std::numeric_limits<uint32_t>::max(); }
     virtual draw_frame   last_frame()
     {
-        if (!frame_) {
-            frame_ = receive_impl(0);
+        if (!last_frame_) {
+            last_frame_ = receive_impl(0);
         }
-        return core::draw_frame::still(frame_);
+        return core::draw_frame::still(last_frame_);
+    }
+    virtual draw_frame first_frame()
+    {
+        if (!first_frame_) {
+            first_frame_ = receive_impl(0);
+        }
+        return core::draw_frame::still(first_frame_);
     }
     virtual void                            leading_producer(const spl::shared_ptr<frame_producer>&) {}
     virtual spl::shared_ptr<frame_producer> following_producer() const { return core::frame_producer::empty(); }

--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -43,9 +43,8 @@ struct layer::impl
     spl::shared_ptr<frame_producer> foreground_ = frame_producer::empty();
     spl::shared_ptr<frame_producer> background_ = frame_producer::empty();
 
-    bool auto_play_            = false;
-    bool paused_               = false;
-    bool background_previewed_ = false;
+    bool auto_play_ = false;
+    bool paused_    = false;
 
   public:
     void pause() { paused_ = true; }
@@ -54,9 +53,8 @@ struct layer::impl
 
     void load(spl::shared_ptr<frame_producer> producer, bool preview, bool auto_play)
     {
-        background_           = std::move(producer);
-        auto_play_            = auto_play;
-        background_previewed_ = false;
+        background_ = std::move(producer);
+        auto_play_  = auto_play;
 
         if (auto_play_ && foreground_ == frame_producer::empty()) {
             play();
@@ -134,14 +132,7 @@ struct layer::impl
     draw_frame receive_background(const video_format_desc& format_desc, int nb_samples)
     {
         try {
-            if (background_ == frame_producer::empty())
-                return core::draw_frame{};
-
-            if (background_previewed_)
-                return background_->last_frame();
-
-            background_previewed_ = true;
-            return background_->receive(nb_samples);
+            return background_->first_frame();
 
         } catch (...) {
             CASPAR_LOG_CURRENT_EXCEPTION();

--- a/src/core/producer/layer.h
+++ b/src/core/producer/layer.h
@@ -53,11 +53,13 @@ class layer final
     void stop();
 
     draw_frame receive(const video_format_desc& format_desc, int nb_samples);
+    draw_frame receive_background(const video_format_desc& format_desc, int nb_samples);
 
     core::monitor::state state() const;
 
     spl::shared_ptr<frame_producer> foreground() const;
     spl::shared_ptr<frame_producer> background() const;
+    bool                            has_background() const;
 
   private:
     struct impl;

--- a/src/core/producer/route/route_producer.cpp
+++ b/src/core/producer/route/route_producer.cpp
@@ -115,6 +115,14 @@ spl::shared_ptr<core::frame_producer> create_route_producer(const core::frame_pr
     auto channel = boost::lexical_cast<int>(what["CHANNEL"].str());
     auto layer   = what["LAYER"].matched ? boost::lexical_cast<int>(what["LAYER"].str()) : -1;
 
+    auto mode = core::route_mode::foreground;
+    if (layer >= 0) {
+        if (contains_param(L"BACKGROUND", params))
+            mode = core::route_mode::background;
+        else if (contains_param(L"NEXT", params))
+            mode = core::route_mode::next;
+    }
+
     auto channel_it = boost::find_if(dependencies.channels,
                                      [=](spl::shared_ptr<core::video_channel> ch) { return ch->index() == channel; });
 
@@ -125,7 +133,7 @@ spl::shared_ptr<core::frame_producer> create_route_producer(const core::frame_pr
 
     auto buffer = get_param(L"BUFFER", params, 0);
 
-    return spl::make_shared<route_producer>((*channel_it)->route(layer), buffer);
+    return spl::make_shared<route_producer>((*channel_it)->route(layer, mode), buffer);
 }
 
 }} // namespace caspar::core

--- a/src/core/producer/separated/separated_producer.cpp
+++ b/src/core/producer/separated/separated_producer.cpp
@@ -57,6 +57,10 @@ class separated_producer : public frame_producer
     {
         return draw_frame::mask(fill_producer_->last_frame(), key_producer_->last_frame());
     }
+    draw_frame first_frame() override
+    {
+        return draw_frame::mask(fill_producer_->first_frame(), key_producer_->first_frame());
+    }
 
     draw_frame receive_impl(int nb_samples) override
     {

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -28,6 +28,8 @@
 #include <common/memory.h>
 #include <common/tweener.h>
 
+#include <core/frame/draw_frame.h>
+
 #include <functional>
 #include <future>
 #include <map>
@@ -37,6 +39,13 @@
 FORWARD2(caspar, diagnostics, class graph);
 
 namespace caspar { namespace core {
+
+struct layer_frame
+{
+    draw_frame foreground;
+    draw_frame background;
+    bool       has_background;
+};
 
 class stage final
 {
@@ -49,7 +58,8 @@ class stage final
 
     explicit stage(int channel_index, spl::shared_ptr<caspar::diagnostics::graph> graph);
 
-    std::map<int, draw_frame> operator()(const video_format_desc& format_desc, int nb_samples);
+    std::map<int, layer_frame>
+    operator()(const video_format_desc& format_desc, int nb_samples, std::vector<int>& fetch_background);
 
     std::future<void> apply_transforms(const std::vector<transform_tuple_t>& transforms);
     std::future<void>

--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -163,6 +163,8 @@ class sting_producer : public frame_producer
         return res;
     }
 
+    core::draw_frame first_frame() override { return dst_producer_->first_frame(); }
+
     uint32_t nb_frames() const override { return dst_producer_->nb_frames(); }
 
     uint32_t frame_number() const override { return dst_producer_->frame_number(); }

--- a/src/core/producer/transition/transition_producer.cpp
+++ b/src/core/producer/transition/transition_producer.cpp
@@ -67,6 +67,8 @@ class transition_producer : public frame_producer
         return dst && current_frame_ >= info_.duration ? dst : src;
     }
 
+    core::draw_frame first_frame() override { return dst_producer_->first_frame(); }
+
     void leading_producer(const spl::shared_ptr<frame_producer>& producer) override { src_producer_ = producer; }
 
     spl::shared_ptr<frame_producer> following_producer() const override

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -35,6 +35,21 @@
 
 namespace caspar { namespace core {
 
+enum route_mode
+{
+    foreground,
+    background,
+    next, // background if any, otherwise foreground
+};
+
+struct route_id
+{
+    int        index;
+    route_mode mode;
+
+    bool const operator==(const route_id& o) { return index == o.index && mode == o.mode; }
+};
+
 struct route
 {
     route()             = default;
@@ -77,7 +92,7 @@ class video_channel final
 
     int index() const;
 
-    std::shared_ptr<core::route> route(int index = -1);
+    std::shared_ptr<core::route> route(int index = -1, route_mode mode = route_mode::foreground);
 
   private:
     struct impl;

--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -633,6 +633,8 @@ class decklink_producer_proxy : public core::frame_producer
 
     core::draw_frame receive_impl(int nb_samples) override { return producer_->get_frame(); }
 
+    core::draw_frame first_frame() override { return receive_impl(0); }
+
     uint32_t nb_frames() const override { return length_; }
 
     std::wstring print() const override { return producer_->print(); }

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -525,10 +525,10 @@ struct AVProducer::Impl
     std::string afilter_;
     std::string vfilter_;
 
-    int64_t          frame_count_ = 0;
-    bool             frame_flush_ = true;
-    bool             frame_eof_ = false;
-    int64_t          frame_time_ = AV_NOPTS_VALUE;
+    int64_t          frame_count_    = 0;
+    bool             frame_flush_    = true;
+    bool             frame_eof_      = false;
+    int64_t          frame_time_     = AV_NOPTS_VALUE;
     int64_t          frame_duration_ = AV_NOPTS_VALUE;
     core::draw_frame frame_;
 
@@ -745,9 +745,9 @@ struct AVProducer::Impl
     {
         graph_->set_text(u16(print()));
         boost::lock_guard<boost::mutex> lock(state_mutex_);
-        state_["file/clip"] = { start().value_or(0) / format_desc_.fps, duration().value_or(0) / format_desc_.fps };
-        state_["file/time"] = { time() / format_desc_.fps, file_duration().value_or(0) / format_desc_.fps };
-        state_["loop"] = loop_;
+        state_["file/clip"] = {start().value_or(0) / format_desc_.fps, duration().value_or(0) / format_desc_.fps};
+        state_["file/time"] = {time() / format_desc_.fps, file_duration().value_or(0) / format_desc_.fps};
+        state_["loop"]      = loop_;
     }
 
     core::draw_frame prev_frame()
@@ -758,11 +758,11 @@ struct AVProducer::Impl
             boost::lock_guard<boost::mutex> lock(buffer_mutex_);
 
             if (!buffer_.empty()) {
-                frame_ = buffer_[0].frame;
-                frame_time_ = buffer_[0].pts;
+                frame_          = buffer_[0].frame;
+                frame_time_     = buffer_[0].pts;
                 frame_duration_ = buffer_[0].duration;
-                frame_flush_ = false;
-                frame_eof_ = false;
+                frame_flush_    = false;
+                frame_eof_      = false;
             }
         }
 
@@ -790,11 +790,11 @@ struct AVProducer::Impl
             latency_ = -1;
         }
 
-        frame_ = buffer_[0].frame;
-        frame_time_ = buffer_[0].pts;
+        frame_          = buffer_[0].frame;
+        frame_time_     = buffer_[0].pts;
         frame_duration_ = buffer_[0].duration;
-        frame_flush_ = false;
-        frame_eof_ = false;
+        frame_flush_    = false;
+        frame_eof_      = false;
 
         buffer_.pop_front();
         buffer_cond_.notify_all();

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -423,6 +423,8 @@ class html_producer : public core::frame_producer
         return core::draw_frame::empty();
     }
 
+    core::draw_frame first_frame() override { return receive_impl(0); }
+
     std::future<std::wstring> call(const std::vector<std::wstring>& params) override
     {
         if (!client_)

--- a/src/modules/image/producer/image_producer.cpp
+++ b/src/modules/image/producer/image_producer.cpp
@@ -105,6 +105,8 @@ struct image_producer : public core::frame_producer
 
     core::draw_frame last_frame() override { return frame_; }
 
+    core::draw_frame first_frame() override { return frame_; }
+
     core::draw_frame receive_impl(int nb_samples) override
     {
         state_["file/path"] = description_;

--- a/src/protocol/osc/client.cpp
+++ b/src/protocol/osc/client.cpp
@@ -73,15 +73,15 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
     std::map<udp::endpoint, int>             reference_counts_by_endpoint_;
     std::vector<char>                        buffer_;
 
-    std::mutex                            mutex_;
-    std::condition_variable               cond_;
-    core::monitor::state                  bundle_;
-    uint64_t                              bundle_time_ = 0;
+    std::mutex              mutex_;
+    std::condition_variable cond_;
+    core::monitor::state    bundle_;
+    uint64_t                bundle_time_ = 0;
 
-    uint64_t                              time_ = 0;
+    uint64_t time_ = 0;
 
-    std::atomic<bool>                     abort_request_{false};
-    std::thread                           thread_;
+    std::atomic<bool> abort_request_{false};
+    std::thread       thread_;
 
   public:
     impl(std::shared_ptr<boost::asio::io_service> service)
@@ -104,8 +104,8 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
                             return;
                         }
 
-                        bundle = std::move(bundle_);
-                        bundle_time = bundle_time_;
+                        bundle       = std::move(bundle_);
+                        bundle_time  = bundle_time_;
                         bundle_time_ = 0;
 
                         for (auto& p : reference_counts_by_endpoint_) {
@@ -194,7 +194,7 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
 
             // TODO: time_++ is a hack. Use proper channel time.
             bundle_time_ = time_++;
-            bundle_ = state;
+            bundle_      = state;
         }
         cond_.notify_all();
     }


### PR DESCRIPTION
```
PLAY 2-10 route://1-10 BACKGROUND
PLAY 2-10 route://1-10 NEXT
```
This allows you to view the first frame of the background producer. Intended as a preview of the source to make it possible to visibly show to users that the clip is loaded and it is the correct clip.
BACKGROUND mode will only ever show the first frame of the layer background producer,
NEXT mode will show the first frame of the background clip if one is loaded, otherwise will show the foreground. So if you LOADBG then PLAY, the clip will continue playing.

@ronag I have tried to avoid calling receive on the background producers as much as possible, to avoid adding additional cpu usage for who doesn't use this feature. It would be a bit cleaner to always generate them though.

This also fixes a bug where CLEARing a layer which was being routed would cause that route to freeze on last frame until any operation was performed on that empty layer (even a CALL would cause it to unfreeze). This was from the layer no longer existing, so there was no frame to send to a route, when we should have been sending an empty frame.
