### PR TITLE
(Again) some small state changes

### DIFF
--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -107,7 +107,9 @@ struct layer::impl
             }
 
             state_ = foreground_->state();
+            state_["producer"]               = foreground_->name();
             state_["background"] = background_->state();
+            state_["background"]["producer"] = background_->name();
             state_["paused"] = paused_;
 
             return frame;

--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -107,6 +107,7 @@ struct layer::impl
             }
 
             state_ = foreground_->state();
+            state_["background"] = background_->state();
             state_["paused"] = paused_;
 
             return frame;

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -59,6 +59,7 @@
 #include <memory>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/regex.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/insert_linebreaks.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -1342,7 +1343,10 @@ std::wstring info_channel_command(command_context& ctx)
 
     auto state = ctx.channel.channel->state();
     for (const auto& p : state) {
-        const auto    path = boost::algorithm::replace_all_copy(p.first, "/", ".");
+        const auto replaced = boost::algorithm::replace_all_copy(p.first, "/", ".");
+        // avoid digit-only nodes in XML
+        const auto path  = boost::algorithm::replace_all_regex_copy(
+            replaced, boost::regex("\\.(.*?)\\.([0-9]*?)\\."), boost::lexical_cast<std::string>(".$1.$1_$2."));
         param_visitor param_visitor(path, channel_info);
         for (const auto& element : p.second) {
             boost::apply_visitor(param_visitor, element);


### PR DESCRIPTION
Changed:

- Background-producer is now being stored in the state so we can retrieve it through OSC and `INFO`-command
- Names of producers are appended so it's easy to see which producer is currently on a layer (background and foreground)
- Number-only nodes are not allowed in the XML spec so the `INFO`-command is currently breaking some XML-parsers. I've changed this so that the preceding name will be appended to the number. For example `<layer><0></0></layer>` will now be `<layer><layer_0></layer_0></layer>`