### PR TITLE
Append preceding nodes name to digit-only nodes

### DIFF
--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -59,6 +59,7 @@
 #include <memory>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/regex.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/insert_linebreaks.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
@@ -1342,7 +1343,10 @@ std::wstring info_channel_command(command_context& ctx)
 
     auto state = ctx.channel.channel->state();
     for (const auto& p : state) {
-        const auto    path = boost::algorithm::replace_all_copy(p.first, "/", ".");
+        const auto replaced = boost::algorithm::replace_all_copy(p.first, "/", ".");
+        // avoid digit-only nodes in XML
+        const auto path  = boost::algorithm::replace_all_regex_copy(
+            replaced, boost::regex("\\.(.*?)\\.([0-9]*?)\\."), boost::lexical_cast<std::string>(".$1.$1_$2."));
         param_visitor param_visitor(path, channel_info);
         for (const auto& element : p.second) {
             boost::apply_visitor(param_visitor, element);


### PR DESCRIPTION
See #1062 for more info.

> Number-only nodes are not allowed in the XML spec so the INFO-command is currently breaking some XML-parsers. I've changed this so that the preceding name will be appended to the number. For example <0></0> will now be <layer_0></layer_0>

The regex looks for `.name.<digit>.` and replaces it with `.name.name_<digit>.`. This makes the INFO output valid XML.