### PR TITLE
fix(build): Linux fails on boost::lexical_cast not being defined in monitor.h

### DIFF
--- a/src/core/monitor/monitor.h
+++ b/src/core/monitor/monitor.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <boost/lexical_cast.hpp>
 #include <boost/variant.hpp>
 
 #include <cstdint>


### PR DESCRIPTION
@ronag any idea why it builds without this only on windows?