### PR TITLE
Remove obsolete FSF postal addresse from source header

### DIFF
--- a/src/packages/openal/include/AL/alext.h
+++ b/src/packages/openal/include/AL/alext.h
@@ -11,11 +11,8 @@
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  Library General Public License for more details.
  *
- * You should have received a copy of the GNU Library General Public
- *  License along with this library; if not, write to the
- *  Free Software Foundation, Inc., 59 Temple Place - Suite 330,
- *  Boston, MA  02111-1307, USA.
- * Or go to http://www.gnu.org/copyleft/lgpl.html
+ * You should have received a copy of the GNU General Public License
+ *  along with this library. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef AL_ALEXT_H


### PR DESCRIPTION
The copyright statement in b/src/packages/openal/include/AL/alext.h
include the old postal address to FSF.  Replace text with the one
currently recommended by FSF.