### PR TITLE
Update bluefish producer.cpp - further improvement of interlaced capture

### DIFF
--- a/src/modules/bluefish/producer/bluefish_producer.cpp
+++ b/src/modules/bluefish/producer/bluefish_producer.cpp
@@ -495,7 +495,7 @@ struct bluefish_producer : boost::noncopyable
     {
         try {
             if (reserved_frames_.front()->image_data()) {
-                if (sync_format_ == UPD_FMT_FIELD && !first_frame_) {
+                if (sync_format_ == UPD_FMT_FIELD && first_frame_) {
                     blue_->system_buffer_read(const_cast<uint8_t*>(reserved_frames_.front()->image_data()),
                                               static_cast<unsigned long>(reserved_frames_.front()->image_size()),
                                               BlueImage_DMABuffer(dma_ready_captured_frame_id_, BLUE_DATA_FRAME),


### PR DESCRIPTION
There is an intermittent issue where the producer sometimes start capturing on the wrong field, when capturing interlaced signals.
this fix solves this problem