### PR TITLE
Added support for DataVideo TC-100/TC-200 Character Generators

### DIFF
--- a/src/modules/screen/consumer/screen_shader.cpp
+++ b/src/modules/screen/consumer/screen_shader.cpp
@@ -26,40 +26,78 @@ namespace caspar { namespace screen {
 std::string get_vertex()
 {
     return R"shader(
-			#version 450
+            #version 450
             in vec4 TexCoordIn;
             in vec2 Position;
 
             out vec4 TexCoord;
-
-			void main()
-			{
-				TexCoord = TexCoordIn;
-				gl_Position = vec4(Position, 0, 1);
-			}
-	)shader";
+            void main()
+            {
+                TexCoord = TexCoordIn;
+                gl_Position = vec4(Position, 0, 1);
+            }
+        )shader";
 }
 
 std::string get_fragment()
 {
     return R"shader(
             #version 450
-            uniform sampler2D background;
 
-            in vec4 TexCoord;
-            out vec4 fragColor;
+                #define COLOUR_SPACE_RGB                0
+                #define COLOUR_SPACE_DATAVIDEO_FULL     1
+                #define COLOUR_SPACE_DATAVIDEO_LIMITED  2
 
-			uniform bool key_only;
+                #define RANGE_16        (16.0f / 256.0f)
+                #define RANGE_235       (235.0f / 256.0f)
+                #define RANGE_HALF      (0.5f / 256.0f)
+                #define RANGE_LIMITED   ((235.0f - 16.0f) / 256.0f)
 
-            void main() {
-                vec4 color = texture(background, TexCoord.st);
+                uniform sampler2D background;
 
-                if (key_only)
-                    color = vec4(color.aaa, 1);
+                in vec4 TexCoord;
+                out vec4 fragColor;
 
-                fragColor = color;
-            }
-	)shader";
+                uniform bool key_only;
+                uniform int colour_space;
+                uniform int window_width;
+
+                // rgb=0~255, y=16~235, uv=16~240
+                mat3 rgb2yuv_709 = mat3(0.183f, -0.101f, 0.439f,  0.614f, -0.338f, -0.399f, 0.062f, 0.439f,-0.040f);
+
+                vec4 dtv_color(vec4 color)
+                {
+                   color.stp = rgb2yuv_709 * clamp(color.rgb  / (color.a + 0.0000001f), 0.0f, 1.0f);
+                   return color;
+                }
+      
+                void main()
+                {
+                    vec4 color = texture(background, TexCoord.xy);
+                    if (key_only)
+                        color = vec4(color.aaa, 1);
+
+                   else if (colour_space == COLOUR_SPACE_DATAVIDEO_FULL) {  // Full range 0-255
+                        color = dtv_color(color);
+                        float x_coord = TexCoord.x * window_width * 0.5f;
+                        bool isEvenPixel = round(x_coord) - x_coord < 0.0f ;
+                        vec4 color2 = dtv_color(texture(background, TexCoord.xy + (isEvenPixel ? vec2(1.0f / window_width, 0.0f) : vec2(-1.0f / window_width, 0.0f))));
+                        color.s = clamp((color.s * RANGE_LIMITED) + RANGE_16 + RANGE_HALF, RANGE_16, RANGE_235);
+                        color.t = clamp(((isEvenPixel ? color.t + color2.t : color.p + color2.p) * RANGE_LIMITED * 0.5f) + RANGE_HALF + 0.5f, RANGE_16, RANGE_235);
+                        color.p = clamp((color.w * RANGE_LIMITED) + RANGE_16 + RANGE_HALF, RANGE_16, RANGE_235);
+
+                    } else if (colour_space == COLOUR_SPACE_DATAVIDEO_LIMITED) {  // Limited range 16-235
+                        color = dtv_color(color);
+                        float x_coord = TexCoord.x * window_width * 0.5f;
+                        bool isEvenPixel = round(x_coord) - x_coord < 0.0f ;
+                        vec4 color2 = dtv_color(texture(background, TexCoord.xy + (isEvenPixel ? vec2(1.0f / window_width, 0.0f) : vec2(-1.0f / window_width, 0.0f))));
+                        color.s = clamp(color.s + RANGE_HALF, 0.0f, 1.0f);
+                        color.t = clamp(((isEvenPixel ? color.t + color2.t : color.p + color2.p) * 0.5f) + RANGE_HALF + 0.5f, 0.0f, 1.0f);
+                        color.p = clamp(color.w + RANGE_HALF, 0.0f, 1.0f);
+                    }
+                    fragColor = color;
+                }
+        )shader";
 }
 
 std::unique_ptr<accelerator::ogl::shader> get_shader()

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <configuration>
     <paths>
@@ -88,6 +88,8 @@
                 <y>0</y>
                 <width>0 (0=not set)</width>
                 <height>0 (0=not set)</height>
+                <sbs-key>false [true|false]</sbs-key>
+                <colour-space>RGB [RGB|datavideo-full|datavideo-limited] (Enables colour space convertion for DataVideo TC-100 / TC-200)</colour-space>
             </screen>
             <newtek-ivga></newtek-ivga>
             <ffmpeg>


### PR DESCRIPTION
Related issue #1032.

Test build - https://1drv.ms/u/s!AsCJ7q9Sqbclk4oEa9M6zoJrtAbPIg

Example config:
```
        <channel>
            <video-mode>1080i5000</video-mode>
            <consumers>
                <screen>
		   <datavideo-colors>1</datavideo-colors>
              	   <device>2</device>
                   <aspect-ratio>16:9</aspect-ratio>
                   <stretch>none</stretch>
                   <windowed>true</windowed>
                   <vsync>true</vsync>
                   <borderless>true</borderless>
                   <interactive>false</interactive>
                   <always-on-top>true</always-on-top>
                   <x>0</x>
                   <y>0</y>
		</screen> 
            </consumers>
        </channel>
```
![fill](https://user-images.githubusercontent.com/1344732/52905289-4a2d6080-3249-11e9-87ac-3922cb193076.png)
![key](https://user-images.githubusercontent.com/1344732/52905290-4a2d6080-3249-11e9-9dfa-97f2c81a9b9d.png)
![coded](https://user-images.githubusercontent.com/1344732/52905291-4ac5f700-3249-11e9-8cd2-e87be0319c05.png)



