### PR TITLE
Fix boost::filesystem:canonical symlink bug (infinity loop) in Windows

### DIFF
--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -102,7 +102,7 @@ auto run(const std::wstring& config_file_name, std::atomic<bool>& should_wait_fo
     std::wstringstream                                      str;
     boost::property_tree::xml_writer_settings<std::wstring> w(' ', 3);
     boost::property_tree::write_xml(str, env::properties(), w);
-    CASPAR_LOG(info) << boost::filesystem::canonical(config_file_name)
+    CASPAR_LOG(info) << boost::filesystem::absolute(config_file_name).lexically_normal()
                      << L":\n-----------------------------------------\n"
                      << str.str() << L"-----------------------------------------";
 


### PR DESCRIPTION
Fixing bug in Boost library - https://www.bountysource.com/issues/32827214-boost-filesystem-canonical-enters-infinite-loop-when-current-path-is-a-directory-symlink-on-windows