### PR TITLE
Updated FFMPEG to 4.1.1 (Windows)

### DIFF
--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -85,9 +85,9 @@ add_definitions( -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE )
 add_definitions( -DBOOST_COROUTINES_NO_DEPRECATION_WARNING )
 
 # FFMPEG
-set(FFMPEG_INCLUDE_PATH "${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20180711.0.0/build/native/include")
-set(FFMPEG_BIN_PATH "${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20180711.0.0/build/native/bin/x64")
-link_directories("${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20180711.0.0/build/native/lib/x64")
+set(FFMPEG_INCLUDE_PATH "${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20190221.0.0/build/native/include")
+set(FFMPEG_BIN_PATH "${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20190221.0.0/build/native/bin/x64")
+link_directories("${NUGET_PACKAGES_FOLDER}/FFmpeg.Nightly.20190221.0.0/build/native/lib/x64")
 casparcg_add_runtime_dependency("${FFMPEG_BIN_PATH}/avcodec-58.dll")
 casparcg_add_runtime_dependency("${FFMPEG_BIN_PATH}/avdevice-58.dll")
 casparcg_add_runtime_dependency("${FFMPEG_BIN_PATH}/avfilter-7.dll")

--- a/src/modules/bluefish/packages.config
+++ b/src/modules/bluefish/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.66.0.0" targetFramework="native" />
-  <package id="FFmpeg.Nightly" version="20180711.0.0" targetFramework="native" />
+  <package id="FFmpeg.Nightly" version="20190221.0.0" targetFramework="native" />
 </packages>

--- a/src/modules/decklink/packages.config
+++ b/src/modules/decklink/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.66.0.0" targetFramework="native" />
-  <package id="FFmpeg.Nightly" version="20180711.0.0" targetFramework="native" />
+  <package id="FFmpeg.Nightly" version="20190221.0.0" targetFramework="native" />
 </packages>

--- a/src/modules/ffmpeg/packages.config
+++ b/src/modules/ffmpeg/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.66.0.0" targetFramework="native" />
-  <package id="FFmpeg.Nightly" version="20180711.0.0" targetFramework="native" />
+  <package id="FFmpeg.Nightly" version="20190221.0.0" targetFramework="native" />
 </packages>

--- a/src/modules/oal/packages.config
+++ b/src/modules/oal/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="boost" version="1.66.0.0" targetFramework="native" />
-  <package id="FFmpeg.Nightly" version="20180711.0.0" targetFramework="native" />
+  <package id="FFmpeg.Nightly" version="20190221.0.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Updated to stable FFMPEG release (21.02.2019)