### PR TITLE
Ingoring carret return when shader convertion to C header.

### DIFF
--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -2,33 +2,33 @@ cmake_minimum_required (VERSION 2.6)
 project (accelerator)
 
 set(SOURCES
-		ogl/image/image_kernel.cpp
-		ogl/image/image_mixer.cpp
-		ogl/image/image_shader.cpp
+	ogl/image/image_kernel.cpp
+	ogl/image/image_mixer.cpp
+	ogl/image/image_shader.cpp
 
-		ogl/util/buffer.cpp
-		ogl/util/device.cpp
-		ogl/util/shader.cpp
-		ogl/util/texture.cpp
+	ogl/util/buffer.cpp
+	ogl/util/device.cpp
+	ogl/util/shader.cpp
+	ogl/util/texture.cpp
 
-		accelerator.cpp
-		StdAfx.cpp
+	accelerator.cpp
+	StdAfx.cpp
 )
 set(HEADERS
-		ogl/image/image_kernel.h
-		ogl/image/image_mixer.h
-        ogl/image/image_shader.h
+	ogl/image/image_kernel.h
+	ogl/image/image_mixer.h
+	ogl/image/image_shader.h
 
-		ogl/util/buffer.h
-		ogl/util/device.h
-		ogl/util/shader.h
-        ogl/util/texture.h
+	ogl/util/buffer.h
+	ogl/util/device.h
+	ogl/util/shader.h
+	ogl/util/texture.h
 
-		ogl_image_vertex.h
-		ogl_image_fragment.h
+	ogl_image_vertex.h
+	ogl_image_fragment.h
 
-		accelerator.h
-		StdAfx.h
+	accelerator.h
+	StdAfx.h
 )
 
 bin2c("ogl/image/shader.vert" "ogl_image_vertex.h" "caspar::accelerator::ogl" "vertex_shader")

--- a/src/accelerator/ogl/image/image_shader.cpp
+++ b/src/accelerator/ogl/image/image_shader.cpp
@@ -23,8 +23,8 @@
 #include "../util/device.h"
 #include "../util/shader.h"
 
-#include "ogl_image_vertex.h"
 #include "ogl_image_fragment.h"
+#include "ogl_image_vertex.h"
 
 namespace caspar { namespace accelerator { namespace ogl {
 

--- a/src/modules/screen/CMakeLists.txt
+++ b/src/modules/screen/CMakeLists.txt
@@ -9,8 +9,8 @@ set(SOURCES
 set(HEADERS
 	consumer/screen_consumer.h
 
-    consumer_screen_vertex.h
-    consumer_screen_fragment.h
+	consumer_screen_vertex.h
+	consumer_screen_fragment.h
 
 	screen.h
 )

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -60,9 +60,9 @@
 #include "../util/x11_util.h"
 #endif
 
-#include <accelerator/ogl/util/shader.h>
 #include "consumer_screen_fragment.h"
 #include "consumer_screen_vertex.h"
+#include <accelerator/ogl/util/shader.h>
 
 namespace caspar { namespace screen {
 

--- a/src/tools/bin2c.cpp
+++ b/src/tools/bin2c.cpp
@@ -4,12 +4,20 @@
 
 int main(int argc, char** argv)
 {
-    assert(argc == 4);
+    if (argc != 4) {
+        fprintf(stderr, "Usage: %s \"namespace\" \"constant_name\" \"input_filename\"\n", argv[0]);
+        return -1;
+    }
     char* fn = argv[3];
     FILE* f  = fopen(fn, "rb");
 
-    int count = 0;
-    char* pch = strtok(argv[1], "::");
+    if (f == nullptr) {
+        fprintf(stderr, "Error opening file: %s\n", strerror(errno));
+        return -1;
+    }
+
+    int   count = 0;
+    char* pch   = strtok(argv[1], "::");
     while (pch != nullptr) {
         printf("namespace %s {\n", pch);
         pch = strtok(nullptr, "::");
@@ -22,6 +30,8 @@ int main(int argc, char** argv)
         unsigned char c;
         if (fread(&c, 1, 1, f) == 0)
             break;
+        if ('\r' == c) // ignore carret return
+            continue;
         printf("0x%.2X,", (int)c);
         ++n;
         if (n % 10 == 0)
@@ -32,4 +42,6 @@ int main(int argc, char** argv)
 
     for (int i = 0; i < count; i++)
         printf("}\n");
+
+    return 0;
 }


### PR DESCRIPTION
Added bin2c arguments validation and ingoring carret return when shader convertion to C header.
Fixed windows build after #1182 