### PR TITLE
NTSC Audio Fix

### DIFF
--- a/src/core/mixer/audio/audio_mixer.cpp
+++ b/src/core/mixer/audio/audio_mixer.cpp
@@ -36,6 +36,7 @@
 #include <stack>
 #include <vector>
 
+
 namespace caspar { namespace core {
 
 using namespace boost::container;
@@ -100,9 +101,14 @@ struct audio_mixer::impl
 
         for (auto& item : items) {
             auto ptr  = item.samples.data();
-            auto size = std::min(item.samples.size(), result.size());
+            auto size = result.size();
             for (auto n = 0; n < size; ++n) {
-                mixed[n] = static_cast<double>(ptr[n]) * item.transform.volume + mixed[n];
+		if (n<item.samples.size()){
+                    mixed[n] = static_cast<double>(ptr[n]) * item.transform.volume + mixed[n];
+		}else{
+		    auto offset = (item.samples.size()) - (channels-(n%channels));
+                    mixed[n] = static_cast<double>(ptr[offset]) * item.transform.volume + mixed[n];
+		}
             }
         }
 

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -149,7 +149,7 @@ struct video_channel::impl final
                         frames.push_back(p.second.foreground);
                     }
 
-                    auto mixed_frame = mixer_(frames, format_desc, format_desc.audio_cadence[0]);
+                    auto mixed_frame = mixer_(frames, format_desc, nb_samples);
                     graph_->set_value("mix-time", mix_timer.elapsed() * format_desc.fps * 0.5);
 
                     // Consume


### PR DESCRIPTION
Modified audio mixer to prevent asynchronous audio cadences from causing crackling, and modified video_channel to actually use the cadence instead of the first element of the cadence array.
With regard to issues #838 #1145 