### PR TITLE
Add missing standard library include

### DIFF
--- a/src/tools/bin2c.cpp
+++ b/src/tools/bin2c.cpp
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <cerrno>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
If you try and build Caspar in Docker (using ```./tools/linux/build-in-docker```) it currently crashes out with the error:
```
/source/tools/bin2c.cpp: In function 'int main(int, char**)':
/source/tools/bin2c.cpp:15:62: error: 'errno' was not declared in this scope
         fprintf(stderr, "Error opening file: %s\n", strerror(errno));
                                                              ^~~~~
/source/tools/bin2c.cpp:15:62: note: suggested alternative: 'perror'
         fprintf(stderr, "Error opening file: %s\n", strerror(errno));
                                                              ^~~~~
                                                              perror
tools/CMakeFiles/bin2c.dir/build.make:62: recipe for target 'tools/CMakeFiles/bin2c.dir/bin2c.cpp.o' failed
make[2]: *** [tools/CMakeFiles/bin2c.dir/bin2c.cpp.o] Error 1
CMakeFiles/Makefile2:85: recipe for target 'tools/CMakeFiles/bin2c.dir/all' failed
make[1]: *** [tools/CMakeFiles/bin2c.dir/all] Error 2
```
This adds the missing standard library include, so the build passes.