### PR TITLE
FFmpeg producer allways resample to 48kHz

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -223,7 +223,7 @@ struct Filter
                 filter_spec = "anull";
             }
 
-            filter_spec += (boost::format(",aresample=async=1000:first_pts=%d:min_comp=0.01,asetrate=r=%d,"
+            filter_spec += (boost::format(",aresample=async=1000:first_pts=%d:min_comp=0.01,aresample=%d,"
                                           "asetnsamples=n=1024:p=0") %
                             av_rescale_q(start_time, TIME_BASE_Q, {1, format_desc.audio_sample_rate}) %
                             format_desc.audio_sample_rate)


### PR DESCRIPTION
Fixes audio out of sync when source is not in 48kHz sample rate.
Fixes: https://github.com/CasparCG/server/issues/1194 https://github.com/CasparCG/server/issues/1170