### PR TITLE
Keep increasing frame time until we hit input_duration_ when we play out still frames;

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -774,6 +774,11 @@ struct AVProducer::Impl
         if (buffer_.empty() || (frame_flush_ && buffer_.size() < 4)) {
             if (buffer_eof_) {
                 frame_eof_ = true;
+                if (frame_time_ < input_duration_ && frame_duration_ != AV_NOPTS_VALUE) {
+                    frame_time_ += frame_duration_;
+                } else if (frame_time_ < input_duration_) {
+                    frame_time_ = input_duration_;
+                }
                 return core::draw_frame::still(frame_);
             }
             graph_->set_tag(diagnostics::tag_severity::WARNING, "underflow");
@@ -822,10 +827,6 @@ struct AVProducer::Impl
         }
 
         auto frame_time = frame_time_;
-
-        if (frame_eof_ && frame_duration_ != AV_NOPTS_VALUE) {
-            frame_time += frame_duration_;
-        }
 
         return av_rescale_q(frame_time, TIME_BASE_Q, format_tb_);
     }

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -524,7 +524,6 @@ struct AVProducer::Impl
 
     int64_t          frame_count_    = 0;
     bool             frame_flush_    = true;
-    bool             frame_eof_      = false;
     int64_t          frame_time_     = AV_NOPTS_VALUE;
     int64_t          frame_duration_ = AV_NOPTS_VALUE;
     core::draw_frame frame_;
@@ -758,7 +757,6 @@ struct AVProducer::Impl
                 frame_time_     = buffer_[0].pts;
                 frame_duration_ = buffer_[0].duration;
                 frame_flush_    = false;
-                frame_eof_      = false;
             }
         }
 
@@ -772,11 +770,10 @@ struct AVProducer::Impl
         boost::lock_guard<boost::mutex> lock(buffer_mutex_);
 
         if (buffer_.empty() || (frame_flush_ && buffer_.size() < 4)) {
-            if (buffer_eof_) {
-                frame_eof_ = true;
-                if (frame_time_ < input_duration_ && frame_duration_ != AV_NOPTS_VALUE) {
+            if (buffer_eof_ && !frame_flush_) {
+                if (frame_time_ < duration_ && frame_duration_ != AV_NOPTS_VALUE) {
                     frame_time_ += frame_duration_;
-                } else if (frame_time_ < input_duration_) {
+                } else if (frame_time_ < duration_) {
                     frame_time_ = input_duration_;
                 }
                 return core::draw_frame::still(frame_);
@@ -795,7 +792,6 @@ struct AVProducer::Impl
         frame_time_     = buffer_[0].pts;
         frame_duration_ = buffer_[0].duration;
         frame_flush_    = false;
-        frame_eof_      = false;
 
         buffer_.pop_front();
         buffer_cond_.notify_all();
@@ -826,9 +822,7 @@ struct AVProducer::Impl
             return 0;
         }
 
-        auto frame_time = frame_time_;
-
-        return av_rescale_q(frame_time, TIME_BASE_Q, format_tb_);
+        return av_rescale_q(frame_time_, TIME_BASE_Q, format_tb_);
     }
 
     void loop(bool loop)


### PR DESCRIPTION
fixes #1114  not working with video track shorter then audio track(s) without changing behavior regarding duration selection 