### PR TITLE
Fix build in MSVC 2019

### DIFF
--- a/src/protocol/cii/CIIProtocolStrategy.h
+++ b/src/protocol/cii/CIIProtocolStrategy.h
@@ -90,7 +90,7 @@ class CIIProtocolStrategy : public IO::IProtocolStrategy
 
             return *this;
         }
-        bool operator==(const TitleHolder& rhs) { return pframe_producer == rhs.pframe_producer; }
+        bool operator==(const TitleHolder& rhs) const { return pframe_producer == rhs.pframe_producer; }
 
         std::wstring                          titleName;
         spl::shared_ptr<core::frame_producer> pframe_producer;


### PR DESCRIPTION
I was unable to build without this modification in Visual Studio 2019.
Allow a `const` left hand side for comparing TitleHolders.