### PR TITLE
Add field delay to decklink consumer in interlace mode to smooth impact on channel

### DIFF
--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -290,6 +290,23 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
 
     std::atomic<bool> abort_request_{false};
 
+    bool doFrame(std::shared_ptr<void>& image_data, std::vector<std::int32_t>& audio_data, bool topField)
+    {
+        core::const_frame frame(pop());
+        if (abort_request_)
+            return false;
+
+        int firstLine = topField ? 0 : 1;
+        for (auto y = firstLine; y < format_desc_.height; y += field_count_) {
+            std::memcpy(reinterpret_cast<char*>(image_data.get()) + (long long)y * format_desc_.width * 4,
+                        frame.image_data(0).data() + (long long)y * format_desc_.width * 4,
+                        (size_t)format_desc_.width * 4);
+        }
+        audio_data.insert(audio_data.end(), frame.audio_data().begin(), frame.audio_data().end());
+
+        return true;
+    }
+
   public:
     decklink_consumer(const configuration& config, const core::video_format_desc& format_desc, int channel_index)
         : channel_index_(channel_index)
@@ -306,6 +323,10 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         graph_->set_color("flushed-frame", diagnostics::color(0.4f, 0.3f, 0.8f));
         graph_->set_color("buffered-audio", diagnostics::color(0.9f, 0.9f, 0.5f));
         graph_->set_color("buffered-video", diagnostics::color(0.2f, 0.9f, 0.9f));
+
+        if (mode_->GetFieldDominance() != bmdProgressiveFrame) {
+            graph_->set_color("tick-time-f2", diagnostics::color(0.9f, 0.6f, 0.0f));
+        }
 
         if (key_context_) {
             graph_->set_color("key-offset", diagnostics::color(1.0f, 0.0f, 0.0f));
@@ -419,7 +440,13 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         }
 #endif
         try {
-            auto tick_time = tick_timer_.elapsed() * format_desc_.fps / field_count_ * 0.5;
+            auto elapsed = tick_timer_.elapsed();
+            int  fieldTimeMs = static_cast<int>(1000 / format_desc_.fps);
+            std::chrono::high_resolution_clock::time_point f2TimePoint =
+                std::chrono::high_resolution_clock::now() + std::chrono::milliseconds(
+                    std::max<int>(0, std::min<int>(fieldTimeMs, fieldTimeMs + static_cast<int>(2.0 * fieldTimeMs - elapsed))));
+
+            auto tick_time = elapsed * format_desc_.fps / field_count_ * 0.5;
             graph_->set_value("tick-time", tick_time);
             tick_timer_.restart();
 
@@ -461,38 +488,21 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
             std::shared_ptr<void>     image_data(scalable_aligned_malloc(format_desc_.size, 64), scalable_aligned_free);
             std::vector<std::int32_t> audio_data;
 
-            std::vector<core::const_frame> frames{pop()};
             if (mode_->GetFieldDominance() != bmdProgressiveFrame) {
-                frames.push_back(pop());
-
-                if (abort_request_) {
+                if (!doFrame(image_data, audio_data, mode_->GetFieldDominance() == bmdUpperFieldFirst))
                     return E_FAIL;
-                }
 
-                if (mode_->GetFieldDominance() != bmdUpperFieldFirst) {
-                    std::swap(frames[0], frames[1]);
-                }
+                // Wait to pull frame for second field...
+                std::this_thread::sleep_until(f2TimePoint);
 
-                for (auto y = 0; y < format_desc_.height; ++y) {
-                    std::memcpy(reinterpret_cast<char*>(image_data.get()) + y * format_desc_.width * 4,
-                                frames[y % 2].image_data(0).data() + y * format_desc_.width * 4,
-                                format_desc_.width * 4);
-                }
+                tick_time = tick_timer_.elapsed() * format_desc_.fps * 0.5;
+                graph_->set_value("tick-time-f2", tick_time);
 
-                audio_data.insert(audio_data.end(), frames[0].audio_data().begin(), frames[0].audio_data().end());
-                audio_data.insert(audio_data.end(), frames[1].audio_data().begin(), frames[1].audio_data().end());
+                if (!doFrame(image_data, audio_data, mode_->GetFieldDominance() != bmdUpperFieldFirst))
+                    return E_FAIL;
             } else {
-                if (abort_request_) {
+                if (!doFrame(image_data, audio_data, true))
                     return E_FAIL;
-                }
-
-                for (auto y = 0; y < format_desc_.height; ++y) {
-                    std::memcpy(reinterpret_cast<char*>(image_data.get()) + y * format_desc_.width * 4,
-                                frames[0].image_data(0).data() + y * format_desc_.width * 4,
-                                format_desc_.width * 4);
-                }
-
-                audio_data.insert(audio_data.end(), frames[0].audio_data().begin(), frames[0].audio_data().end());
             }
 
             const auto nb_samples = static_cast<int>(audio_data.size()) / format_desc_.audio_channels;

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -442,6 +442,10 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         try {
             auto elapsed = tick_timer_.elapsed();
             int  fieldTimeMs = static_cast<int>(1000 / format_desc_.fps);
+            // Calculate a time point for when a simulated second field action should occur for interlaced standards.
+            // The tick_timer will run at frame (2x field) rate. If the tick_timer has been delayed because the machine
+            // is busy this calculation reduces the delay before the second field so that it lands at the expected time,
+            // giving the channel the full amount of time to process the following frame.
             std::chrono::high_resolution_clock::time_point f2TimePoint =
                 std::chrono::high_resolution_clock::now() + std::chrono::milliseconds(
                     std::max<int>(0, std::min<int>(fieldTimeMs, fieldTimeMs + static_cast<int>(2.0 * fieldTimeMs - elapsed))));


### PR DESCRIPTION
The mixer runs with progressive frames even when the channel is set to be interlaced (eg 50 fps for a 50i channel). The current code pulls two frames from the channel at output 'frame' rate (eg 25 fps) which has an impact on the processing occurring upstream.
This change updates Decklink consumer to add a delay before pulling the second frame from the mixer. It uses the same approach as #1228 but with some changes which include addressing Julian's concerns expressed in that issue:
1. The second field delay time is reduced proportionally if the tick-time is extended to allow the decklink consumer to catch up
2. There is an extra line in the graph to show the field 2 tick time
3. The video and audio copies are now done per field to smooth the impact on the CPU
