### PR TITLE
#1055 Decklink producer should deliver frames on LOAD

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -713,6 +713,8 @@ class decklink_producer_proxy : public core::frame_producer
 
     core::draw_frame first_frame() override { return receive_impl(0); }
 
+    core::draw_frame last_frame() override { return core::draw_frame::still(receive_impl(0)); }
+
     uint32_t nb_frames() const override { return length_; }
 
     std::wstring print() const override { return producer_->print(); }


### PR DESCRIPTION
When a layer is not playing the last_frame() function is called. This change implements last_frame() for the decklink producer to deliver the most recent buffered frame.
The frame is delivered with the audio volume set to 0 so that no audio will be heard.
The behaviour during pause is the same as for load - the producer will continue to deliver frames.