### PR TITLE
feat: zero delay routes

### DIFF
--- a/src/core/producer/route/route_producer.cpp
+++ b/src/core/producer/route/route_producer.cpp
@@ -37,7 +37,7 @@
 
 namespace caspar { namespace core {
 
-class route_producer : public frame_producer
+class route_producer : public frame_producer, public route_cross_channel
 {
     spl::shared_ptr<diagnostics::graph> graph_;
 
@@ -50,6 +50,15 @@ class route_producer : public frame_producer
     boost::signals2::scoped_connection connection_;
 
     core::draw_frame frame_;
+
+    // set the buffer depth to 2 for cross-channel routes, 1 otherwise
+    void set_cross_channel(bool cross) {
+        if (cross) {
+            buffer_.set_capacity(2);
+        } else {
+            buffer_.set_capacity(1);
+        }
+    }
 
   public:
     route_producer(std::shared_ptr<route> route, int buffer)
@@ -67,7 +76,7 @@ class route_producer : public frame_producer
             produce_timer_.restart();
         }))
     {
-        buffer_.set_capacity(buffer > 0 ? buffer : route->format_desc.field_count);
+        buffer_.set_capacity(buffer > 0 ? buffer : 1);
 
         graph_->set_color("late-frame", diagnostics::color(0.6f, 0.3f, 0.3f));
         graph_->set_color("produce-time", caspar::diagnostics::color(0.0f, 1.0f, 0.0f));

--- a/src/core/producer/route/route_producer.cpp
+++ b/src/core/producer/route/route_producer.cpp
@@ -37,7 +37,7 @@
 
 namespace caspar { namespace core {
 
-class route_producer : public frame_producer, public route_cross_channel
+class route_producer : public frame_producer, public route_control
 {
     spl::shared_ptr<diagnostics::graph> graph_;
 
@@ -50,6 +50,11 @@ class route_producer : public frame_producer, public route_cross_channel
     boost::signals2::scoped_connection connection_;
 
     core::draw_frame frame_;
+    int              source_channel_;
+    int              source_layer_;
+
+    int get_source_channel() const { return source_channel_; }
+    int get_source_layer() const { return source_layer_; }
 
     // set the buffer depth to 2 for cross-channel routes, 1 otherwise
     void set_cross_channel(bool cross) {
@@ -61,8 +66,10 @@ class route_producer : public frame_producer, public route_cross_channel
     }
 
   public:
-    route_producer(std::shared_ptr<route> route, int buffer)
+    route_producer(std::shared_ptr<route> route, int buffer, int source_channel, int source_layer)
         : route_(route)
+        , source_channel_(source_channel)
+        , source_layer_(source_layer)
         , connection_(route_->signal.connect([this](const core::draw_frame& frame) {
             auto frame2 = frame;
             if (!frame2) {
@@ -145,7 +152,7 @@ spl::shared_ptr<core::frame_producer> create_route_producer(const core::frame_pr
 
     auto buffer = get_param(L"BUFFER", params, 0);
 
-    return spl::make_shared<route_producer>((*channel_it)->route(layer, mode), buffer);
+    return spl::make_shared<route_producer>((*channel_it)->route(layer, mode), buffer, channel, layer);
 }
 
 }} // namespace caspar::core

--- a/src/core/producer/route/route_producer.h
+++ b/src/core/producer/route/route_producer.h
@@ -28,10 +28,14 @@
 
 namespace caspar { namespace core {
 
-class route_cross_channel
+class route_control
 {
   public:
-    virtual ~route_cross_channel() {}
+    virtual ~route_control() {}
+
+    virtual int  get_source_channel() const    = 0;
+    virtual int  get_source_layer() const      = 0;
+
     virtual void set_cross_channel(bool cross) = 0;
 };
 

--- a/src/core/producer/route/route_producer.h
+++ b/src/core/producer/route/route_producer.h
@@ -28,6 +28,13 @@
 
 namespace caspar { namespace core {
 
+class route_cross_channel
+{
+  public:
+    virtual ~route_cross_channel() {}
+    virtual void set_cross_channel(bool cross) = 0;
+};
+
 spl::shared_ptr<core::frame_producer> create_route_producer(const core::frame_producer_dependencies& dependencies,
                                                             const std::vector<std::wstring>&         params);
 

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -58,8 +58,10 @@ class stage final
 
     explicit stage(int channel_index, spl::shared_ptr<caspar::diagnostics::graph> graph);
 
-    std::map<int, layer_frame>
-    operator()(const video_format_desc& format_desc, int nb_samples, std::vector<int>& fetch_background);
+    std::map<int, layer_frame> operator()(const video_format_desc& format_desc,
+                                          int                      nb_samples,
+                                          std::vector<int>&        fetch_background,
+                                          std::function<void(int, const core::draw_frame)> routesCb);
 
     std::future<void> apply_transforms(const std::vector<transform_tuple_t>& transforms);
     std::future<void>

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -58,10 +58,10 @@ class stage final
 
     explicit stage(int channel_index, spl::shared_ptr<caspar::diagnostics::graph> graph);
 
-    std::map<int, layer_frame> operator()(const video_format_desc& format_desc,
-                                          int                      nb_samples,
-                                          std::vector<int>&        fetch_background,
-                                          std::function<void(int, const core::draw_frame)> routesCb);
+    std::vector<draw_frame> operator()(const video_format_desc&                     format_desc,
+                                       int                                          nb_samples,
+                                       std::vector<int>&                            fetch_background,
+                                       std::function<void(int, const layer_frame&)> routesCb);
 
     std::future<void> apply_transforms(const std::vector<transform_tuple_t>& transforms);
     std::future<void>


### PR DESCRIPTION
Adds logic to the stage processing to re-order the pulls from producers so that sources get pulled before the routes they support.
This provides zero delay routes within a channel. When a route is from a different channel the delay will be 1 frame.
