### PR TITLE
Startup producers in config file

### DIFF
--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
 		util/lock_container.cpp
 		util/strategy_adapters.cpp
 		util/http_request.cpp
+		util/tokenize.cpp
 
 		StdAfx.cpp
 )
@@ -62,6 +63,7 @@ set(HEADERS
 		util/protocol_strategy.h
 		util/strategy_adapters.h
 		util/http_request.h
+		util/tokenize.h
 
 		StdAfx.h
 )

--- a/src/protocol/amcp/AMCPCommand.h
+++ b/src/protocol/amcp/AMCPCommand.h
@@ -86,17 +86,19 @@ class AMCPCommand
     const amcp_command_func command_;
     const int               min_num_params_;
     const std::wstring      name_;
-    std::wstring            request_id_;
+    const std::wstring      request_id_;
 
   public:
-    AMCPCommand(const command_context&   ctx,
+    AMCPCommand(const command_context&     ctx,
                 const amcp_command_func& command,
                 int                      min_num_params,
-                const std::wstring&      name)
+                const std::wstring&      name,
+                const std::wstring& request_id)
         : ctx_(ctx)
         , command_(command)
         , min_num_params_(min_num_params)
         , name_(name)
+        , request_id_(request_id)
     {
     }
 
@@ -122,10 +124,10 @@ class AMCPCommand
 
     const std::vector<std::wstring>& parameters() const { return ctx_.parameters; }
 
+    int channel_index() const { return ctx_.channel_index; }
+
     IO::ClientInfoPtr client() const { return ctx_.client; }
 
     const std::wstring& print() const { return name_; }
-
-    void set_request_id(std::wstring request_id) { request_id_ = std::move(request_id); }
 };
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -239,10 +239,6 @@ struct AMCPProtocolStrategy::impl
             if (!result.command)
                 result.error = error_state::command_error;
             else {
-                std::vector<std::wstring> parameters(tokens.begin(), tokens.end());
-
-                result.command->parameters() = std::move(parameters);
-
                 if (result.command->parameters().size() < result.command->minimum_parameters())
                     result.error = error_state::parameters_error;
             }

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -27,6 +27,8 @@
 #include "amcp_command_repository.h"
 #include "amcp_shared.h"
 
+#include "../util/tokenize.h"
+
 #include <algorithm>
 
 #include <boost/algorithm/string/split.hpp>
@@ -98,7 +100,7 @@ struct AMCPProtocolStrategy::impl
     void Parse(const std::wstring& message, ClientInfoPtr client)
     {
         std::list<std::wstring> tokens;
-        tokenize(message, tokens);
+        IO::tokenize(message, tokens);
 
         if (!tokens.empty() && boost::iequals(tokens.front(), L"PING")) {
             tokens.pop_front();
@@ -256,72 +258,6 @@ struct AMCPProtocolStrategy::impl
         }
 
         return result.error == error_state::no_error;
-    }
-
-    template <typename C>
-    std::size_t tokenize(const std::wstring& message, C& pTokenVector)
-    {
-        // split on whitespace but keep strings within quotationmarks
-        // treat \ as the start of an escape-sequence: the following char will indicate what to actually put in the
-        // string
-
-        std::wstring currentToken;
-
-        bool inQuote        = false;
-        bool getSpecialCode = false;
-
-        for (unsigned int charIndex = 0; charIndex < message.size(); ++charIndex) {
-            if (getSpecialCode) {
-                // insert code-handling here
-                switch (message[charIndex]) {
-                    case L'\\':
-                        currentToken += L"\\";
-                        break;
-                    case L'\"':
-                        currentToken += L"\"";
-                        break;
-                    case L'n':
-                        currentToken += L"\n";
-                        break;
-                    default:
-                        break;
-                }
-                getSpecialCode = false;
-                continue;
-            }
-
-            if (message[charIndex] == L'\\') {
-                getSpecialCode = true;
-                continue;
-            }
-
-            if (message[charIndex] == L' ' && inQuote == false) {
-                if (!currentToken.empty()) {
-                    pTokenVector.push_back(currentToken);
-                    currentToken.clear();
-                }
-                continue;
-            }
-
-            if (message[charIndex] == L'\"') {
-                inQuote = !inQuote;
-
-                if (!currentToken.empty() || !inQuote) {
-                    pTokenVector.push_back(currentToken);
-                    currentToken.clear();
-                }
-                continue;
-            }
-
-            currentToken += message[charIndex];
-        }
-
-        if (!currentToken.empty()) {
-            pTokenVector.push_back(currentToken);
-            currentToken.clear();
-        }
-
-        return pTokenVector.size();
     }
 };
 

--- a/src/protocol/amcp/amcp_command_repository.cpp
+++ b/src/protocol/amcp/amcp_command_repository.cpp
@@ -32,7 +32,8 @@
 namespace caspar { namespace protocol { namespace amcp {
 
 AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_command_func, int>>& commands,
-                                   const std::wstring&                                              str,
+                                   const std::wstring&                                              name,
+                                   const std::wstring&                                              request_id,
                                    command_context&                                                 ctx,
                                    std::list<std::wstring>&                                         tokens)
 {
@@ -43,26 +44,60 @@ AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_c
 
     // Start with subcommand syntax like MIXER CLEAR etc
     if (!subcommand.empty()) {
-        auto s      = str + L" " + subcommand;
-        auto subcmd = commands.find(s);
+        auto fullname      = name + L" " + subcommand;
+        auto subcmd = commands.find(fullname);
 
         if (subcmd != commands.end()) {
             tokens.pop_front();
-            return std::make_shared<AMCPCommand>(ctx, subcmd->second.first, subcmd->second.second, s);
+            return std::make_shared<AMCPCommand>(
+                ctx, subcmd->second.first, subcmd->second.second, fullname, request_id);
         }
     }
 
     // Resort to ordinary command
-    auto s       = str;
-    auto command = commands.find(s);
-
+    auto command = commands.find(name);
     if (command != commands.end()) {
         ctx.parameters = std::move(std::vector<std::wstring>(tokens.begin(), tokens.end()));
-        return std::make_shared<AMCPCommand>(ctx, command->second.first, command->second.second, s);
+        return std::make_shared<AMCPCommand>(ctx, command->second.first, command->second.second, name, request_id);
     }
 
     return nullptr;
 }
+
+template <typename Out, typename In>
+bool try_lexical_cast(const In& input, Out& result)
+{
+    Out        saved   = result;
+    const bool success = boost::conversion::detail::try_lexical_convert(input, result);
+
+    if (!success)
+        result = saved; // Needed because of how try_lexical_convert is implemented.
+
+    return success;
+}
+
+static void
+parse_channel_id(std::list<std::wstring>& tokens, std::wstring& channel_spec, int& channel_index, int& layer_index)
+{
+    if (!tokens.empty()) {
+        channel_spec                            = tokens.front();
+        std::wstring              channelid_str = boost::trim_copy(channel_spec);
+        std::vector<std::wstring> split;
+        boost::split(split, channelid_str, boost::is_any_of("-"));
+
+        // Use non_throwing lexical cast to not hit exception break point all the time.
+        if (try_lexical_cast(split[0], channel_index)) {
+            --channel_index;
+
+            if (split.size() > 1)
+                try_lexical_cast(split[1], layer_index);
+
+            // Consume channel-spec
+            tokens.pop_front();
+        }
+    }
+}
+
 
 struct amcp_command_repository::impl
 {
@@ -100,6 +135,100 @@ struct amcp_command_repository::impl
             ++index;
         }
     }
+
+
+    AMCPCommand::ptr_type create_command(const std::wstring&      name,
+                                         const std::wstring&      request_id,
+                                                                  IO::ClientInfoPtr        client,
+                                                                  std::list<std::wstring>& tokens) const
+    {
+        command_context ctx(std::move(client),
+                            channel_context(),
+                            -1,
+                            -1,
+                            channels,
+                            cg_registry,
+                            producer_registry,
+                            consumer_registry,
+                            shutdown_server_now,
+                            proxy_host,
+                            proxy_port,
+                            ogl_device);
+
+        return find_command(commands, name, request_id, ctx, tokens);
+    }
+
+    AMCPCommand::ptr_type create_channel_command(const std::wstring&      name,
+        const std::wstring& request_id,
+                                                                          IO::ClientInfoPtr        client,
+                                                                          unsigned int             channel_index,
+                                                                          int                      layer_index,
+                                                                          std::list<std::wstring>& tokens) const
+    {
+        auto channel = channels.at(channel_index);
+
+        command_context ctx(std::move(client),
+                            channel,
+                            channel_index,
+                            layer_index,
+                            channels,
+                            cg_registry,
+                            producer_registry,
+                            consumer_registry,
+                            shutdown_server_now,
+                            proxy_host,
+                            proxy_port,
+                            ogl_device);
+
+        return find_command(channel_commands, name, request_id, ctx, tokens);
+    }
+
+    std::shared_ptr<AMCPCommand>
+    parse_command(IO::ClientInfoPtr client, std::list<std::wstring> tokens, const std::wstring& request_id) const
+    {
+        // Consume command name
+        const std::basic_string<wchar_t> command_name = boost::to_upper_copy(tokens.front());
+        tokens.pop_front();
+
+        // Determine whether the next parameter is a channel spec or not
+        int          channel_index = -1;
+        int          layer_index   = -1;
+        std::wstring channel_spec;
+        parse_channel_id(tokens, channel_spec, channel_index, layer_index);
+
+        // Create command instance
+        std::shared_ptr<AMCPCommand> command;
+        if (channel_index >= 0) {
+            command = create_channel_command(command_name, request_id, client, channel_index, layer_index, tokens);
+
+            if (!command) // Might be a non channel command, although the first argument is numeric
+            {
+                // Restore backed up channel spec string.
+                tokens.push_front(channel_spec);
+            }
+        }
+
+        // Create global instance
+        if (!command) {
+            command = create_command(command_name, request_id, client, tokens);
+        }
+
+        if (command && command->parameters().size() < command->minimum_parameters()) {
+            CASPAR_LOG(error) << "Not enough parameters in command: " << command_name;
+            return nullptr;
+        }
+
+        return std::move(command);
+    }
+
+    bool check_channel_lock(IO::ClientInfoPtr client, int channel_index) const
+    {
+        if (channel_index < 0)
+            return true;
+
+        auto lock = channels.at(channel_index).lock;
+        return !(lock && !lock->check_access(client));
+    }
 };
 
 amcp_command_repository::amcp_command_repository(
@@ -117,64 +246,36 @@ void amcp_command_repository::init(const std::vector<spl::shared_ptr<core::video
     impl_->init(channels);
 }
 
-AMCPCommand::ptr_type amcp_command_repository::create_command(const std::wstring&      s,
+AMCPCommand::ptr_type amcp_command_repository::create_command(const std::wstring&      name,
+                                                              const std::wstring&      request_id,
                                                               IO::ClientInfoPtr        client,
                                                               std::list<std::wstring>& tokens) const
 {
-    auto& self = *impl_;
-
-    command_context ctx(std::move(client),
-                        channel_context(),
-                        -1,
-                        -1,
-                        self.channels,
-                        self.cg_registry,
-                        self.producer_registry,
-                        self.consumer_registry,
-                        self.shutdown_server_now,
-                        self.proxy_host,
-                        self.proxy_port,
-                        self.ogl_device);
-
-    auto command = find_command(self.commands, s, ctx, tokens);
-
-    if (command)
-        return command;
-
-    return nullptr;
+    return impl_->create_command(name, request_id, client, tokens);
 }
 
 const std::vector<channel_context>& amcp_command_repository::channels() const { return impl_->channels; }
 
-AMCPCommand::ptr_type amcp_command_repository::create_channel_command(const std::wstring&      s,
+std::shared_ptr<AMCPCommand> amcp_command_repository::parse_command(IO::ClientInfoPtr       client,
+                                                                    std::list<std::wstring> tokens,
+                                                                    const std::wstring&     request_id) const
+{
+    return impl_->parse_command(client, tokens, request_id);
+}
+
+bool amcp_command_repository::check_channel_lock(IO::ClientInfoPtr client, int channel_index) const
+{
+    return impl_->check_channel_lock(client, channel_index);
+}
+
+AMCPCommand::ptr_type amcp_command_repository::create_channel_command(const std::wstring&      name,
+                                                                      const std::wstring&      request_id,
                                                                       IO::ClientInfoPtr        client,
                                                                       unsigned int             channel_index,
                                                                       int                      layer_index,
                                                                       std::list<std::wstring>& tokens) const
 {
-    auto& self = *impl_;
-
-    auto channel = self.channels.at(channel_index);
-
-    command_context ctx(std::move(client),
-                        channel,
-                        channel_index,
-                        layer_index,
-                        self.channels,
-                        self.cg_registry,
-                        self.producer_registry,
-                        self.consumer_registry,
-                        self.shutdown_server_now,
-                        self.proxy_host,
-                        self.proxy_port,
-                        self.ogl_device);
-
-    auto command = find_command(self.channel_commands, s, ctx, tokens);
-
-    if (command)
-        return command;
-
-    return nullptr;
+    return impl_->create_channel_command(name, request_id, client, channel_index, layer_index, tokens);
 }
 
 void amcp_command_repository::register_command(std::wstring      category,
@@ -182,8 +283,7 @@ void amcp_command_repository::register_command(std::wstring      category,
                                                amcp_command_func command,
                                                int               min_num_params)
 {
-    auto& self = *impl_;
-    self.commands.insert(std::make_pair(std::move(name), std::make_pair(std::move(command), min_num_params)));
+    impl_->commands.insert(std::make_pair(std::move(name), std::make_pair(std::move(command), min_num_params)));
 }
 
 void amcp_command_repository::register_channel_command(std::wstring      category,
@@ -191,8 +291,7 @@ void amcp_command_repository::register_channel_command(std::wstring      categor
                                                        amcp_command_func command,
                                                        int               min_num_params)
 {
-    auto& self = *impl_;
-    self.channel_commands.insert(std::make_pair(std::move(name), std::make_pair(std::move(command), min_num_params)));
+    impl_->channel_commands.insert(std::make_pair(std::move(name), std::make_pair(std::move(command), min_num_params)));
 }
 
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/amcp_command_repository.cpp
+++ b/src/protocol/amcp/amcp_command_repository.cpp
@@ -33,7 +33,7 @@ namespace caspar { namespace protocol { namespace amcp {
 
 AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_command_func, int>>& commands,
                                    const std::wstring&                                              str,
-                                   const command_context&                                           ctx,
+                                   command_context&                                                 ctx,
                                    std::list<std::wstring>&                                         tokens)
 {
     std::wstring subcommand;
@@ -56,8 +56,10 @@ AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_c
     auto s       = str;
     auto command = commands.find(s);
 
-    if (command != commands.end())
+    if (command != commands.end()) {
+        ctx.parameters = std::move(std::vector<std::wstring>(tokens.begin(), tokens.end()));
         return std::make_shared<AMCPCommand>(ctx, command->second.first, command->second.second, s);
+    }
 
     return nullptr;
 }

--- a/src/protocol/amcp/amcp_command_repository.h
+++ b/src/protocol/amcp/amcp_command_repository.h
@@ -43,13 +43,20 @@ class amcp_command_repository
 
     void init(const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
-    AMCPCommand::ptr_type
-                          create_command(const std::wstring& s, IO::ClientInfoPtr client, std::list<std::wstring>& tokens) const;
-    AMCPCommand::ptr_type create_channel_command(const std::wstring&      s,
+    AMCPCommand::ptr_type create_command(const std::wstring&      name,
+                                         const std::wstring&      request_id,
+                                         IO::ClientInfoPtr        client,
+                                         std::list<std::wstring>& tokens) const;
+    AMCPCommand::ptr_type create_channel_command(const std::wstring&      name,
+                                                 const std::wstring&      request_id,
                                                  IO::ClientInfoPtr        client,
                                                  unsigned int             channel_index,
                                                  int                      layer_index,
                                                  std::list<std::wstring>& tokens) const;
+
+    std::shared_ptr<AMCPCommand>
+                                        parse_command(IO::ClientInfoPtr client, std::list<std::wstring> tokens, const std::wstring& request_id) const;
+    bool                                check_channel_lock(IO::ClientInfoPtr client, int channel_index) const;
 
     const std::vector<channel_context>& channels() const;
 

--- a/src/protocol/util/tokenize.cpp
+++ b/src/protocol/util/tokenize.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "tokenize.h"
+
+namespace caspar { namespace IO {
+
+std::size_t tokenize(const std::wstring& message, std::list<std::wstring>& pTokenVector)
+{
+    // split on whitespace but keep strings within quotationmarks
+    // treat \ as the start of an escape-sequence: the following char will indicate what to actually put in the
+    // string
+
+    std::wstring currentToken;
+
+    bool inQuote        = false;
+    bool getSpecialCode = false;
+
+    for (unsigned int charIndex = 0; charIndex < message.size(); ++charIndex) {
+        if (getSpecialCode) {
+            // insert code-handling here
+            switch (message[charIndex]) {
+                case L'\\':
+                    currentToken += L"\\";
+                    break;
+                case L'\"':
+                    currentToken += L"\"";
+                    break;
+                case L'n':
+                    currentToken += L"\n";
+                    break;
+                default:
+                    break;
+            };
+            getSpecialCode = false;
+            continue;
+        }
+
+        if (message[charIndex] == L'\\') {
+            getSpecialCode = true;
+            continue;
+        }
+
+        if (message[charIndex] == L' ' && inQuote == false) {
+            if (!currentToken.empty()) {
+                pTokenVector.push_back(currentToken);
+                currentToken.clear();
+            }
+            continue;
+        }
+
+        if (message[charIndex] == L'\"') {
+            inQuote = !inQuote;
+
+            if (!currentToken.empty() || !inQuote) {
+                pTokenVector.push_back(currentToken);
+                currentToken.clear();
+            }
+            continue;
+        }
+
+        currentToken += message[charIndex];
+    }
+
+    if (!currentToken.empty()) {
+        pTokenVector.push_back(currentToken);
+        currentToken.clear();
+    }
+
+    return pTokenVector.size();
+}
+
+}} // namespace caspar::IO

--- a/src/protocol/util/tokenize.h
+++ b/src/protocol/util/tokenize.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.*
+ */
+
+#pragma once
+
+#include <string>
+#include <list>
+
+namespace caspar { namespace IO {
+
+std::size_t tokenize(const std::wstring& message, std::list<std::wstring>& pTokenVector);
+
+}} // namespace caspar::IO

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -111,6 +111,10 @@
                 <args>[most ffmpeg arguments related to filtering and output codecs]</args>
             </ffmpeg>
         </consumers>
+        <producers>
+            <producer id="0">AMB LOOP</producer>
+            <producer id="10">DECKLINK DEVICE 2</producer>
+        </producers>
     </channel>
 </channels>
 <osc>

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -245,20 +245,12 @@ struct server::impl
                     const int          id      = attrs.get(L"id", -1);
 
                     try {
-                        std::list<std::wstring> tokens{};
+                        std::list<std::wstring> tokens{L"PLAY",
+                                                       (boost::wformat(L"%i-%i") % channel->index() % id).str()};
                         IO::tokenize(command, tokens);
-                        auto cmd = amcp_command_repo_->create_channel_command(
-                            L"PLAY", console_client, channel->index() - 1, id, tokens);
-
-                        const std::vector<std::wstring> parameters(tokens.begin(), tokens.end());
-                        cmd->parameters() = std::move(parameters);
-
-                        if (cmd->parameters().size() < cmd->minimum_parameters()) {
-                            CASPAR_LOG(error) << "Not enough parameters in command: " << command;
-                        } else {
-                            cmd->Execute();
-                            cmd->SendReply();
-                            // console_client->send(std::move(res), false);
+                        auto cmd = amcp_command_repo_->parse_command(console_client, tokens, L"");
+                        if (cmd) {
+                            cmd->SendReply(cmd->Execute());
                         }
                     } catch (const user_error&) {
                         CASPAR_LOG(error) << "Failed to parse command: " << command;


### PR DESCRIPTION
A small portion taken from #1140, as it is useful on its own and quite well isolated.

This allows for defining producers to be created at startup in the config file. This can be useful as a holding state, or for channels which never change.

```
<channel>
  ...
  <producers>
    <producer id="0">AMB LOOP</producer>
    <producer id="10">DECKLINK 5 FORMAT 1080i5000</producer>
    <producer id="20">[HTML] http://localhost:3000/overlay.html</producer>
  </producers>
</channel>
```

Additionally, some refactoring was done to make the amcp types a bit cleaner and easier to work with 

Note: Not very tested yet, I will un-draft this once it has been tested more
Test build: https://builds.julusian.dev/casparcg/casparcg-server-2.3.x-plus-startup-producers.zip