### PR TITLE
Fix #1281 Change decoding number of threads default value

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -104,8 +104,12 @@ struct Decoder
 
         FF(av_opt_set_int(ctx.get(), "refcounted_frames", 1, 0));
 
-        // TODO (fix): Remove limit.
-        FF(av_opt_set_int(ctx.get(), "threads", env::properties().get(L"configuration.ffmpeg.producer.threads", 4), 0));
+        int defaultNumThreads =
+            codec->capabilities & AV_CODEC_CAP_AUTO_THREADS
+                ? 0 : codec->capabilities & (AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS)
+                        ? std::thread::hardware_concurrency()
+                        : 1;
+        FF(av_opt_set_int(ctx.get(), "threads", env::properties().get(L"configuration.ffmpeg.producer.threads", defaultNumThreads), 0));
         // FF(av_opt_set_int(ctx.get(), "enable_er", 1, 0));
 
         ctx->pkt_timebase = stream->time_base;

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -106,8 +106,11 @@ struct Decoder
 
         int defaultNumThreads =
             codec->capabilities & AV_CODEC_CAP_AUTO_THREADS
-                ? 0 : codec->capabilities & (AV_CODEC_CAP_FRAME_THREADS | AV_CODEC_CAP_SLICE_THREADS)
-                        ? std::thread::hardware_concurrency()
+                ? 0
+                : codec->capabilities & AV_CODEC_CAP_SLICE_THREADS
+                    ? std::min<int>(8, std::thread::hardware_concurrency() / 2)
+                    : codec->capabilities & AV_CODEC_CAP_FRAME_THREADS
+                        ? std::thread::hardware_concurrency() / 2
                         : 1;
         FF(av_opt_set_int(ctx.get(), "threads", env::properties().get(L"configuration.ffmpeg.producer.threads", defaultNumThreads), 0));
         // FF(av_opt_set_int(ctx.get(), "enable_er", 1, 0));


### PR DESCRIPTION
FFmpeg decoding was set to use 4 threads by default. This change checks the codec capabilities and sets the default number of threads to auto if supported or the detected number of cores if codec threading is supported. Configuration parameter _ffmpeg/producer/threads_ will override this value.