### PR TITLE
CG REMOVE should destruct html producer

### DIFF
--- a/src/modules/html/html.cpp
+++ b/src/modules/html/html.cpp
@@ -312,7 +312,10 @@ class cef_task : public CefTask
     IMPLEMENT_REFCOUNTING(cef_task);
 };
 
-void invoke(const std::function<void()>& func) { begin_invoke(func).get(); }
+void invoke(const std::function<void()>& func) {
+    if (g_cef_executor != nullptr)
+        begin_invoke(func).get();
+}
 
 std::future<void> begin_invoke(const std::function<void()>& func)
 {

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -366,7 +366,6 @@ class html_client
         auto name = message->GetName().ToString();
 
         if (name == REMOVE_MESSAGE_NAME) {
-            // TODO fully remove producer
             this->close();
 
             {

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -636,6 +636,11 @@ std::wstring cg_remove_command(command_context& ctx)
     int layer = std::stoi(ctx.parameters.at(0));
     get_expected_cg_proxy(ctx)->remove(layer);
 
+    auto producer = spl::make_shared_ptr(
+        ctx.channel.channel->stage().foreground(ctx.layer_index(core::cg_proxy::DEFAULT_LAYER)).get());
+    if (0 == producer->name().compare(L"html"))
+        ctx.channel.channel->stage().clear(ctx.layer_index(core::cg_proxy::DEFAULT_LAYER));
+
     return L"202 CG OK\r\n";
 }
 


### PR DESCRIPTION
Fix #973 HTML producers do not use the cg_layer parameter so when an html cg layer is removed the html producer should be removed too. Flash producers behave differently so this change will not affect them.