### PR TITLE
Feature/named pipe

### DIFF
--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -13,6 +13,7 @@ endif ()
 if (MSVC)
 	add_subdirectory(flash)
 	add_subdirectory(bluefish)
+	add_subdirectory(pipe)
 endif()
 
 add_subdirectory(image)

--- a/src/modules/pipe/CMakeLists.txt
+++ b/src/modules/pipe/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required (VERSION 2.6)
+project (pipe)
+
+set(SOURCES
+	consumer/pipe_consumer.cpp
+
+	pipe.cpp
+)
+set(HEADERS
+	consumer/pipe_consumer.h
+
+	pipe.h
+)
+
+add_library(pipe ${SOURCES} ${HEADERS})
+configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
+
+include_directories(..)
+include_directories(../..)
+include_directories(${BOOST_INCLUDE_PATH})
+include_directories(${TBB_INCLUDE_PATH})
+
+set_target_properties(pipe PROPERTIES FOLDER modules)
+source_group(sources\\consumer consumer/*)
+source_group(sources ./*)
+
+target_link_libraries(pipe common core)
+
+casparcg_add_include_statement("modules/pipe/pipe.h")
+casparcg_add_init_statement("pipe::init" "pipe")
+casparcg_add_module_project("pipe")

--- a/src/modules/pipe/consumer/pipe_consumer.cpp
+++ b/src/modules/pipe/consumer/pipe_consumer.cpp
@@ -52,9 +52,7 @@
 #include <namedpipeapi.h>
 #include <handleapi.h>
 #include <ioapiset.h>
-
-//#pragma warning(push)
-//#pragma warning(disable : 4244)
+#include <errhandlingapi.h>
 #endif
 
 
@@ -63,11 +61,12 @@ namespace caspar { namespace pipe {
 struct configuration
 {
     std::wstring    name            = L"Pipe consumer";
-    std::wstring    video_pipe_name = L"\\\\.\\pipe\\CasparCGVideo";
-    std::wstring    audio_pipe_name = L"\\\\.\\pipe\\CasparCGAudio";
-    bool            include_video   = true;
-    bool            include_audio   = false;
-    int             buffer_size     = 3;
+    std::wstring    video_pipe_name = L"";
+    std::wstring    audio_pipe_name = L"";
+    bool            use_video_pipe  = false;
+    bool            use_audio_pipe  = false;
+    bool            single_pipe     = false;
+    double          buffer_size     = 3.0;
     int             pipe_index      = 0;
 };
 
@@ -77,14 +76,18 @@ struct pipe_consumer
     core::video_format_desc format_desc_;
     int                     channel_index_;
 
-    spl::shared_ptr<diagnostics::graph> graph_;
-    caspar::timer                       tick_timer_;
+    spl::shared_ptr<diagnostics::graph> graph_video_;
+    spl::shared_ptr<diagnostics::graph> graph_audio_;
+    caspar::timer                       frame_timer_video_;
+    caspar::timer                       frame_timer_audio_;
 
-    tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_;
+    tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_video_;
+    tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_audio_;
 
     std::atomic<bool> is_running_{true};
     std::atomic<bool> ready_for_frames_{false};
-    std::thread       thread_;
+    std::thread       thread_video_;
+    std::thread       thread_audio_;
 
     pipe_consumer(const pipe_consumer&) = delete;
     pipe_consumer& operator=(const pipe_consumer&) = delete;
@@ -95,118 +98,316 @@ struct pipe_consumer
         , format_desc_(format_desc)
         , channel_index_(channel_index)
     {
-
-        frame_buffer_.set_capacity((int)(config_.buffer_size*format_desc_.fps));
-
-        graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
-        graph_->set_color("frame-time", diagnostics::color(0.1f, 1.0f, 0.1f));
-        graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
-        graph_->set_text(print());
-        diagnostics::register_graph(graph_);
-
-        thread_ = std::thread([this] {
-            // Create pipe (if requested)
-            CASPAR_LOG(info) << print() << L" Creating pipe...";
-            HANDLE pipe_h = CreateNamedPipeW(config_.video_pipe_name.c_str(),
-                                             PIPE_ACCESS_DUPLEX,
-                                             PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
-                                             1,
-                                             0,
-                                             0,
-                                             0,
-                                             NULL);
-            if (pipe_h == INVALID_HANDLE_VALUE) {
-                CASPAR_LOG(error) << print() << L" Failed to create named pipe "
-                                  << config_.video_pipe_name; // TODO: includeGetLastError
-                // close handle
-                closePipe(pipe_h);
-                is_running_ = false;
-                return;
+        // log pipe names
+        if (config_.use_video_pipe) {
+            CASPAR_LOG(debug) << print() << L": using video pipe name: " << config_.video_pipe_name;
+            if (config_.single_pipe) {
+                CASPAR_LOG(debug) << print()
+                                  << L": Single pipe enabled. Both video and audio (in that order) will be sent down "
+                                     L"the above pipe).";
             }
-
-            // Connect pipe
-            CASPAR_LOG(info) << print() << L" Pipe created. Connecting to pipe...";
-            if (!ConnectNamedPipe(pipe_h, NULL)) {
-                CASPAR_LOG(error) << print() << L" Failed to connect to named pipe "
-                                  << config_.video_pipe_name; // TODO: includeGetLastError
-                // close handle
-                closePipe(pipe_h);
-                is_running_ = false;
-                return;
+        }
+        if (config_.use_audio_pipe) {
+            CASPAR_LOG(debug) << print() << L": using audio pipe name: " << config_.audio_pipe_name;
+            if (config_.single_pipe) {
+                CASPAR_LOG(debug) << print()
+                                  << L": Single pipe enabled. Both audio and video (in that order) will be sent down "
+                                     L"the above pipe).";
             }
-            CASPAR_LOG(info) << print() << L" Pipe connected";
-            ready_for_frames_ = true;
+        }
 
-            try {
-                while (is_running_) {
-                    core::const_frame in_frame;
-                    DWORD             numBytesWritten = 0;
-                    DWORD             numBytesToWrite = format_desc_.width*format_desc_.height*4; //assumes RGBA
+        // If no pipes were specified, don't start the consumer and log an error.
+        if (!config_.use_audio_pipe && !config_.use_video_pipe)
+        {
+            CASPAR_LOG(error) << print()
+                              << L": No pipe name specified. You must specify one or both of VIDEO_PIPE and AUDIO_PIPE "
+                                 L"parameters followed by the pipe name (e.g. VIDEO_PIPE \\\\.\\pipe\\CasparCGVideo)";
+            is_running_ = false;
+            return;
+        }
 
-                    while (!frame_buffer_.try_pop(in_frame) && is_running_) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(2));
-                    }
+        // set buffer size
+        frame_buffer_video_.set_capacity((int)std::round(config_.buffer_size * format_desc_.fps));
+        frame_buffer_audio_.set_capacity((int)std::round(config_.buffer_size * format_desc_.fps));
 
-                    if (!in_frame) {
-                        is_running_ = false;
-                        break;
-                    }
+        // Start the thread(s)
+        if (config_.use_video_pipe) {
+            graph_video_->set_color("frame-time", diagnostics::color(0.1f, 1.0f, 0.1f));
+            graph_video_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
+            graph_video_->set_color("input", diagnostics::color(0.7f, 0.4f, 0.4f));
+            graph_video_->set_text(print(L"video"));
+            diagnostics::register_graph(graph_video_);
 
-                    if (core::pixel_format::bgra != in_frame.pixel_format_desc().format) {
-                        CASPAR_LOG(error) << print() << L" Unsupported pixel format " << std::to_string((int)in_frame.pixel_format_desc().format);
-                        is_running_ = false;
-                        break;
-                    }
-
-                    if (in_frame.image_data(0).size() != numBytesToWrite) {
-                        CASPAR_LOG(error) << print() << L" Unsupported frame video array format";
-                        is_running_ = false;
-                        break;
-                    }
-
-                    // send frame data
-                    bool writeSuccess =
-                        WriteFile(pipe_h, in_frame.image_data(0).data(), numBytesToWrite, &numBytesWritten, NULL);
-                    if (!writeSuccess || numBytesToWrite != numBytesWritten) {
-                        CASPAR_LOG(warning) << print() << L" Frame dropped (failed to write frame to pipe)"; // TODO: Add GetLastError
-                        is_running_ = false;
-                        break;
-                    }
-
-                    graph_->set_value("tick-time", tick_timer_.elapsed() * format_desc_.fps * 0.5);
-                    tick_timer_.restart();
+            thread_video_ = std::thread([this] {
+                // open the pipe (this will block until the receiver opens the pipe)
+                HANDLE pipe_h;
+                if (!openPipe(L"video", config_.video_pipe_name, pipe_h)) {
+                    return;
                 }
-            } catch (tbb::user_abort&) {
-                // we are ending
-            } catch (...) {
-                CASPAR_LOG_CURRENT_EXCEPTION();
-                is_running_ = false;
-            }
-            // close handle
-            closePipe(pipe_h);
-        });
+
+                try {
+                    while (is_running_) {
+                        core::const_frame in_frame;
+
+                        while (!frame_buffer_video_.try_pop(in_frame) && is_running_) {
+                            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                        }
+
+                        graph_video_->set_value("input",
+                                                static_cast<double>(frame_buffer_video_.size() + 0.001) /
+                                                    frame_buffer_video_.capacity());
+
+                        if (!in_frame) {
+                            is_running_ = false;
+                            break;
+                        }
+
+                        bool successV = writeVideo(L"video", in_frame, pipe_h);
+                        bool successA = true;
+                        if (config_.single_pipe && successV) {
+                            // Note: avType is set as "video" here even though we are calling writeAudio.
+                            //       This is so the error message to internal calls to print() are correct.
+                            successA = writeAudio(L"video", in_frame, pipe_h);
+                        }
+
+                        if (!successA || !successV) {
+                            // Log the dropped frame
+                            graph_video_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+                            // Then terminate the pipe consumer because there is no recovery from a failed/partial write
+                            // when the write to the pipe is synchronous and should thus block until completion
+                            is_running_ = false;
+                            break;
+                        }
+                        
+                        graph_video_->set_value("frame-time", frame_timer_video_.elapsed() * format_desc_.fps * 0.5);
+                        frame_timer_video_.restart();
+                    }
+                } catch (tbb::user_abort&) {
+                    // we are ending
+                } catch (...) {
+                    CASPAR_LOG_CURRENT_EXCEPTION();
+                    is_running_ = false;
+                }
+                // close handle
+                closePipe(L"video", pipe_h);
+            });
+        }
+        if (config_.use_audio_pipe) {
+            graph_audio_->set_color("frame-time", diagnostics::color(0.1f, 1.0f, 0.1f));
+            graph_audio_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
+            graph_audio_->set_color("input", diagnostics::color(0.7f, 0.4f, 0.4f));
+            graph_audio_->set_text(print(L"audio"));
+            diagnostics::register_graph(graph_audio_);
+
+            thread_audio_ = std::thread([this] {
+                // open the pipe (this will block until the receiver opens the pipe)
+                HANDLE pipe_h;
+                if (!openPipe(L"audio", config_.audio_pipe_name, pipe_h)) {
+                    return;
+                }
+
+                try {
+                    while (is_running_) {
+                        core::const_frame in_frame;
+
+                        while (!frame_buffer_audio_.try_pop(in_frame) && is_running_) {
+                            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                        }
+                        graph_audio_->set_value("input",
+                                                static_cast<double>(frame_buffer_audio_.size() + 0.001) /
+                                                    frame_buffer_audio_.capacity());
+
+                        if (!in_frame) {
+                            is_running_ = false;
+                            break;
+                        }
+
+                        bool successA = writeAudio(L"audio", in_frame, pipe_h);
+                        bool successV = true;
+                        if (config_.single_pipe && successA) {
+                            // Note: avType is set as "audio" here even though we are calling writeVideo.
+                            //       This is so the error message to internal calls to print() are correct.
+                            successV = writeVideo(L"audio", in_frame, pipe_h);
+                        }
+
+                        if (!successA || !successV) {
+                            // Log the dropped frame
+                            graph_audio_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+                            // Then terminate the pipe consumer because there is no recovery from a failed/partial write
+                            // when the write to the pipe is synchronous and should thus block until completion
+                            is_running_ = false;
+                            break;
+                        }
+                        graph_audio_->set_value("frame-time", frame_timer_audio_.elapsed() * format_desc_.fps * 0.5);
+                        frame_timer_audio_.restart();
+                    }
+                } catch (tbb::user_abort&) {
+                    // we are ending
+                } catch (...) {
+                    CASPAR_LOG_CURRENT_EXCEPTION();
+                    is_running_ = false;
+                }
+                // close handle
+                closePipe(L"audio", pipe_h);
+            });
+        }
     }
 
     ~pipe_consumer()
     {
         is_running_ = false;
-        frame_buffer_.abort();
+        frame_buffer_video_.abort();
+        frame_buffer_audio_.abort();
         // Some pipe functions will block - This should unblock them so that join() succeeds
-        if (!CancelSynchronousIo(thread_.native_handle())) {
-            DWORD lastError = GetLastError();
-            if (lastError != ERROR_NOT_FOUND) {
-                CASPAR_LOG(error)
-                    << print()
-                    << L" Failed to cancel synchronous IO (CasparCG may now lock up)"; // TODO: Add GetLastError
+        if (config_.use_video_pipe) {
+            if (!CancelSynchronousIo(thread_video_.native_handle())) {
+                DWORD lastError = GetLastError();
+                if (lastError != ERROR_NOT_FOUND) {
+                    CASPAR_LOG(error) << print(L"video")
+                                      << L" Failed to cancel synchronous IO (CasparCG may now lock up). Error code: "
+                                      << std::to_wstring(lastError);
+                }
             }
         }
-        thread_.join();
+        if (config_.use_audio_pipe) {
+            if (!CancelSynchronousIo(thread_audio_.native_handle())) {
+                DWORD lastError = GetLastError();
+                if (lastError != ERROR_NOT_FOUND) {
+                    CASPAR_LOG(error) << print(L"audio")
+                                      << L" Failed to cancel synchronous IO (CasparCG may now lock up). Error code: "
+                                      << std::to_wstring(lastError);
+                }
+            }
+        }
+        if (config_.use_video_pipe) {
+            thread_video_.join();
+        }
+        if (config_.use_audio_pipe) {
+            thread_audio_.join();
+        }
+        CASPAR_LOG(debug) << print() << L" PIPE consumer destructed";
     }
 
-    bool closePipe(HANDLE handle)
+    bool openPipe(std::wstring avType, std::wstring pipeName, HANDLE& pipe_h)
+    {
+        int max_retries = 20;
+        int retries     = 0;
+        DWORD lastError = 0;
+        // Create pipe
+        CASPAR_LOG(info) << print(avType) << L" Creating pipe...";
+        // If the pipe creation fails because of ERROR_PIPE_BUSY, loop for a couple of seconds to
+        // see if it becomes free.
+        do {
+            pipe_h = CreateNamedPipeW(pipeName.c_str(),
+                                      PIPE_ACCESS_DUPLEX,
+                                      PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                                      1,
+                                      0,
+                                      0,
+                                      0,
+                                      NULL);
+            if (pipe_h == INVALID_HANDLE_VALUE) {
+                lastError = GetLastError();
+                if (lastError == ERROR_PIPE_BUSY) {
+                    CASPAR_LOG(debug) << print(avType) << L" Pipe creation failed (PIPE_BUSY). Will retry in 100ms.";
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    retries++;
+                }
+            }
+            
+        } while (lastError == ERROR_PIPE_BUSY && retries <= max_retries);
+
+        // Handle error on pipe creation
+        if (pipe_h == INVALID_HANDLE_VALUE) {
+            std::wstring msg = L"Error code: " + std::to_wstring(lastError) + L".";
+            // print message for the most common errors
+            if (lastError == ERROR_INVALID_NAME) {
+                msg += L" Error message: The pipe name is invalid.";
+            } else if (lastError == ERROR_BAD_PATHNAME) {
+                msg += L" Error message: The pipe path is invalid";
+            }
+            CASPAR_LOG(error) << print(avType) << L" Failed to create named pipe " << pipeName << L" . " << msg;
+            // close handle
+            closePipe(avType, pipe_h);
+            is_running_ = false;
+            return false;
+        }
+
+        // Connect pipe
+        CASPAR_LOG(info) << print(avType) << L" Pipe created. Connecting to pipe...";
+        if (!ConnectNamedPipe(pipe_h, NULL)) {
+            lastError = GetLastError();
+            CASPAR_LOG(error) << print(avType) << L" Failed to connect to named pipe " << pipeName << L" . Error code: "
+                              << std::to_wstring(lastError);
+            // close handle
+            closePipe(avType, pipe_h);
+            is_running_ = false;
+            return false;
+        }
+        CASPAR_LOG(info) << print(avType) << L" Pipe connected";
+        ready_for_frames_ = true;
+        return true;
+    }
+
+    bool writeVideo(std::wstring avType, const core::const_frame& in_frame, HANDLE& pipe_h)
+    {
+        DWORD numBytesWritten = 0;
+        DWORD numBytesToWrite = format_desc_.width * format_desc_.height * 4; // assumes RGBA
+
+        // Check video frame format is supported
+        if (core::pixel_format::bgra != in_frame.pixel_format_desc().format) {
+            CASPAR_LOG(error) << print(avType) << L" Unsupported pixel format "
+                              << std::to_string((int)in_frame.pixel_format_desc().format);
+            is_running_ = false;
+            return false;
+        }
+
+        if (in_frame.image_data(0).size() != numBytesToWrite) {
+            CASPAR_LOG(error) << print(avType) << L" Unsupported frame video array format";
+            is_running_ = false;
+            return false;
+        }
+
+        // send frame data
+        bool writeSuccess = WriteFile(pipe_h, in_frame.image_data(0).data(), numBytesToWrite, &numBytesWritten, NULL);
+        if (!writeSuccess || numBytesToWrite != numBytesWritten) {
+            DWORD lastError = GetLastError();
+            CASPAR_LOG(error) << print(avType) << L" Video frame dropped (failed to write frame to pipe). Error code: "
+                              << std::to_wstring(lastError);
+            return false;
+        }
+        return true;
+    }
+
+    bool writeAudio(std::wstring avType, const core::const_frame& in_frame, HANDLE& pipe_h)
+    {
+        DWORD numBytesWritten = 0;
+        DWORD numBytesToWrite = 0;
+
+        // check there is audio data to send
+        if (in_frame.audio_data().size() == 0) {
+            CASPAR_LOG(warning) << print(avType) << L" No audio data in frame. Skipping writing.";
+            return true;
+        }
+
+        // send frame data
+        numBytesToWrite = static_cast<DWORD>(in_frame.audio_data().size() * sizeof(in_frame.audio_data().data()[0]));
+        bool writeSuccess = WriteFile(pipe_h, in_frame.audio_data().data(), numBytesToWrite, &numBytesWritten, NULL);
+        if (!writeSuccess || numBytesToWrite != numBytesWritten) {
+            DWORD lastError = GetLastError();
+            CASPAR_LOG(error) << print(avType) << L" Audio frame dropped (failed to write frame to pipe). Error code: "
+                              << std::to_wstring(lastError);
+            return false;
+        }
+        return true;
+    }
+
+    bool closePipe(std::wstring avType, HANDLE& handle)
     {
         if (!CloseHandle(handle)) {
-            CASPAR_LOG(error) << print() << L" Failed to close named pipe";
+            DWORD lastError = GetLastError();
+            CASPAR_LOG(error) << print(avType) << L" Failed to close named pipe. Error code: "
+                              << std::to_wstring(lastError);
             return false;
         }
         return true;
@@ -214,10 +415,34 @@ struct pipe_consumer
 
     std::future<bool> send(const core::const_frame& frame)
     {
+        bool vPushResult = true;
+        bool aPushResult = true;
         // silently drop frames until the pipe is connected
         if (ready_for_frames_) {
-            if (!frame_buffer_.try_push(frame)) {
-                graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+            if (config_.use_video_pipe) {
+                vPushResult = frame_buffer_video_.try_push(frame);
+                if (!vPushResult) {
+                    graph_video_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+                }
+            }
+            if (config_.use_audio_pipe) {
+                aPushResult = frame_buffer_audio_.try_push(frame);
+                if (!aPushResult) {
+                    graph_audio_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+                }
+            }
+            // If only one dropped a frame, warn in the log that the A/V sync will be out
+            if (!(!vPushResult && !aPushResult)) {
+                if (!vPushResult) {
+                    CASPAR_LOG(warning) << print()
+                                        << L" A video frame was dropped but an audio frame was not. The audio-video "
+                                            L"sync will be out.";
+                }
+                else if (!aPushResult) {
+                    CASPAR_LOG(warning) << print()
+                                        << L" An audio frame was dropped but a video frame was not. The audio-video "
+                                            L"sync will be out.";
+                }
             }
         }
         return make_ready_future(is_running_.load());
@@ -228,7 +453,24 @@ struct pipe_consumer
         return L"[" + std::to_wstring(channel_index_) + L"|" + format_desc_.name + L"]";
     }
 
-    std::wstring print() const { return config_.name + L" " + channel_and_format(); }
+    std::wstring print(std::wstring avType) const
+    {
+        std::wstring msg = config_.name + L" " + channel_and_format();
+        if (!boost::iequals(avType, L"")) {
+            msg += L"[" + avType;
+            if (config_.single_pipe) {
+                if (boost::iequals(avType, L"video")) {
+                    msg += L"+audio";
+                } else {
+                    msg += L"+video";
+                }
+            }
+            msg += L"]";
+        }
+        return msg;
+    }
+
+    std::wstring print() { return print(L""); }
 };
 
 struct pipe_consumer_proxy : public core::frame_consumer
@@ -282,24 +524,30 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
         }
     }
 
-    // Default: include video only
-    config.include_video = !contains_param(L"EXCLUDE_VIDEO", params); 
-    config.include_audio = contains_param(L"INCLUDE_AUDIO", params);
+    config.single_pipe = contains_param(L"SINGLE_PIPE", params);
 
-    if (contains_param(L"VIDEO_PIPE_NAME", params)) {
-        config.video_pipe_name = get_param(L"VIDEO_PIPE_NAME", params);
-    } else if (config.include_video) {
-        CASPAR_LOG(info) << config.name << L": using default video pipe name: " << config.video_pipe_name;
+    // Read in pipe names
+    if (contains_param(L"VIDEO_PIPE", params)) {
+        config.video_pipe_name = get_param(L"VIDEO_PIPE", params);
+        config.use_video_pipe   = true;
     }
-    if (contains_param(L"AUDIO_PIPE_NAME", params)) {
-        config.audio_pipe_name = get_param(L"AUDIO_PIPE_NAME", params);
-    } else if (config.include_audio) {
-        CASPAR_LOG(info) << config.name << L": using default audio pipe name: " << config.audio_pipe_name;
+    if (contains_param(L"AUDIO_PIPE", params)) {
+        config.audio_pipe_name = get_param(L"AUDIO_PIPE", params);
+        config.use_audio_pipe   = true;
     }
 
+    // If separate pipes were specified for A/V but a single pipe was also requested, ignore the AUDIO_PIPE
+    // parameter
+    if (config.single_pipe && config.use_audio_pipe && config.use_video_pipe) {
+        CASPAR_LOG(warning)
+            << config.name
+            << L": Ignoring AUDIO_PIPE parameter (conflicts with SINGLE_PIPE when VIDEO_PIPE also specified).";
+        config.use_audio_pipe = false;
+    }
+    
     if (contains_param(L"BUFFER_SIZE", params)) {
         try{
-            config.buffer_size = std::stoi(get_param(L"BUFFER_SIZE", params));
+            config.buffer_size = std::stod(get_param(L"BUFFER_SIZE", params));
         }
         catch (...) {
             CASPAR_LOG(warning) << config.name << L": param BUFFER_SIZE ignored.";
@@ -318,9 +566,19 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
     config.pipe_index      = ptree.get(L"index", config.pipe_index + 1) - 1;
     config.video_pipe_name = ptree.get(L"video-pipe-name", config.video_pipe_name);
     config.audio_pipe_name = ptree.get(L"audio-pipe-name", config.audio_pipe_name);
-    config.include_video   = ptree.get(L"include-video", config.include_video);
-    config.include_audio   = ptree.get(L"include-audio", config.include_audio);
+    config.use_video_pipe  = boost::iequals(config.video_pipe_name, L"") ? false : true;
+    config.use_audio_pipe  = boost::iequals(config.audio_pipe_name, L"") ? false : true;
+    config.single_pipe     = ptree.get(L"single-pipe", config.single_pipe);
     config.buffer_size     = ptree.get(L"buffer-size", config.buffer_size);
+
+    // If separate pipes were specified for A/V but a single pipe was also requested, ignore the AUDIO_PIPE
+    // parameter
+    if (config.single_pipe && config.use_audio_pipe && config.use_video_pipe) {
+        CASPAR_LOG(warning)
+            << config.name
+            << L": Ignoring AUDIO_PIPE parameter (conflicts with SINGLE_PIPE when VIDEO_PIPE also specified).";
+        config.use_audio_pipe = false;
+    }
 
     return spl::make_shared<pipe_consumer_proxy>(config);
 }

--- a/src/modules/pipe/consumer/pipe_consumer.cpp
+++ b/src/modules/pipe/consumer/pipe_consumer.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Philip Starkey, https://github.com/philipstarkey
+ * Author: Robert Nagy, ronag89@gmail.com
+ */
+
+#include "pipe_consumer.h"
+
+#include <common/array.h>
+#include <common/diagnostics/graph.h>
+#include <common/future.h>
+#include <common/gl/gl_check.h>
+#include <common/log.h>
+#include <common/memory.h>
+#include <common/memshfl.h>
+#include <common/param.h>
+#include <common/timer.h>
+#include <common/utf.h>
+
+#include <core/consumer/frame_consumer.h>
+#include <core/frame/frame.h>
+#include <core/frame/geometry.h>
+#include <core/frame/pixel_format.h>
+#include <core/video_format.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <tbb/concurrent_queue.h>
+
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(_MSC_VER)
+#include <windows.h>
+#include <fileapi.h>
+#include <winbase.h>
+#include <namedpipeapi.h>
+#include <handleapi.h>
+#include <ioapiset.h>
+
+//#pragma warning(push)
+//#pragma warning(disable : 4244)
+#endif
+
+
+namespace caspar { namespace pipe {
+
+enum class stretch
+{
+    none,
+    uniform,
+    fill,
+    uniform_to_fill
+};
+
+struct configuration
+{
+    enum class aspect_ratio
+    {
+        aspect_4_3 = 0,
+        aspect_16_9,
+        aspect_invalid,
+    };
+
+    enum class colour_spaces
+    {
+        RGB               = 0,
+        datavideo_full    = 1,
+        datavideo_limited = 2
+    };
+
+    std::wstring    name          = L"Pipe consumer";
+    int             screen_index  = 0;
+    int             screen_x      = 0;
+    int             screen_y      = 0;
+    int             screen_width  = 0;
+    int             screen_height = 0;
+    pipe::stretch stretch       = pipe::stretch::fill;
+    bool            windowed      = true;
+    bool            key_only      = false;
+    bool            sbs_key       = false;
+    aspect_ratio    aspect        = aspect_ratio::aspect_invalid;
+    bool            vsync         = false;
+    bool            interactive   = true;
+    bool            borderless    = false;
+    bool            always_on_top = false;
+    colour_spaces   colour_space  = colour_spaces::RGB;
+};
+
+struct pipe_consumer
+{
+    const configuration     config_;
+    core::video_format_desc format_desc_;
+    int                     channel_index_;
+
+    //std::vector<frame> frames_;
+
+    int screen_width_  = format_desc_.width;
+    int screen_height_ = format_desc_.height;
+    int square_width_  = format_desc_.square_width;
+    int square_height_ = format_desc_.square_height;
+    int screen_x_      = 0;
+    int screen_y_      = 0;
+
+    std::vector<core::frame_geometry::coord> draw_coords_;
+
+
+    spl::shared_ptr<diagnostics::graph> graph_;
+    caspar::timer                       tick_timer_;
+
+    tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_;
+
+    std::atomic<bool> is_running_{true};
+    std::atomic<bool> ready_for_frames_{false};
+    std::thread       thread_;
+
+    pipe_consumer(const pipe_consumer&) = delete;
+    pipe_consumer& operator=(const pipe_consumer&) = delete;
+
+  public:
+    pipe_consumer(const configuration& config, const core::video_format_desc& format_desc, int channel_index)
+        : config_(config)
+        , format_desc_(format_desc)
+        , channel_index_(channel_index)
+    {
+
+        frame_buffer_.set_capacity(180); //TODO: Update to default of 3s and make configurable
+
+        graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
+        graph_->set_color("frame-time", diagnostics::color(0.1f, 1.0f, 0.1f));
+        graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
+        graph_->set_text(print());
+        diagnostics::register_graph(graph_);
+        // CASPAR_LOG(warning) << print() << L" Screen-index is not supported on linux";
+
+        
+
+        thread_ = std::thread([this] {
+            // Create pipe (if requested)
+            CASPAR_LOG(info) << print() << L" Creating pipe...";
+            HANDLE pipe_h = CreateNamedPipeA("\\\\.\\pipe\\caspartest",
+                                             PIPE_ACCESS_DUPLEX,
+                                             PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                                             1,
+                                             0,
+                                             0,
+                                             0,
+                                             NULL);
+            if (pipe_h == INVALID_HANDLE_VALUE) {
+                CASPAR_LOG(error) << print() << L" Failed to create named pipe"; //TODO: include pipe name and GetLastError
+                if (!CloseHandle(pipe_h)) {
+                    CASPAR_LOG(error) << print() << L" Failed to close named pipe";
+                }
+                is_running_ = false;
+                return;
+            }
+
+            // Connect pipe
+            CASPAR_LOG(info) << print() << L" Pipe created. Connecting to pipe...";
+            if (!ConnectNamedPipe(pipe_h, NULL)) {
+                CASPAR_LOG(error) << print() << L" Failed to connect to named pipe"; // TODO: include pipe name and GetLastError
+                if (!CloseHandle(pipe_h)) {
+                    CASPAR_LOG(error) << print() << L" Failed to close named pipe";
+                }
+                is_running_ = false;
+                return;
+            }
+            CASPAR_LOG(info) << print() << L" Pipe connected";
+            ready_for_frames_ = true;
+
+            try {
+                while (is_running_) {
+                    core::const_frame in_frame;
+                    DWORD             numBytesWritten = 0;
+                    DWORD             numBytesToWrite = format_desc_.width*format_desc_.height*4; //assumes RGBA
+
+                    while (!frame_buffer_.try_pop(in_frame) && is_running_) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                    }
+
+                    if (!in_frame) {
+                        is_running_ = false;
+                        break;
+                    }
+
+                    if (core::pixel_format::bgra != in_frame.pixel_format_desc().format) {
+                        CASPAR_LOG(error) << print() << L" Unsupported pixel format " << std::to_string((int)in_frame.pixel_format_desc().format);
+                        is_running_ = false;
+                        break;
+                    }
+
+                    if (in_frame.image_data(0).size() != numBytesToWrite) {
+                        CASPAR_LOG(error) << print() << L" Unsupported frame video array format";
+                        is_running_ = false;
+                        break;
+                    }
+
+                    // TODO: send frame data
+                    //       The frame format is separated into lines, not a continuous buffer.
+                    //       To save on memcpy, we should send each line separately rather than the whole frame
+                    //       Need to check performance of that though!
+                    /*for (int n = 0; n < planes.size(); ++n) {
+                        for (int y = 0; y < av_frame->height; ++y) {
+                            std::memcpy(av_frame->data[n] + y * av_frame->linesize[n],
+                                        frame.image_data(n).data() + y * planes[n].linesize,
+                                        planes[n].linesize);
+
+                        }
+                    }*/
+                    bool writeSuccess =
+                        WriteFile(pipe_h, in_frame.image_data(0).data(), numBytesToWrite, &numBytesWritten, NULL);
+                    if (!writeSuccess ||
+                        numBytesToWrite != numBytesWritten) {
+                        CASPAR_LOG(warning) << print() << L" Frame dropped (failed to write frame to pipe)"; // TODO: Add frame number counter and GetLastError
+                        // TODO: DO I need to set something up with the graph to log this dropped frame?
+                    }
+
+                    graph_->set_value("tick-time", tick_timer_.elapsed() * format_desc_.fps * 0.5);
+                    tick_timer_.restart();
+                }
+            } catch (tbb::user_abort&) {
+                // we are ending
+            } catch (...) {
+                CASPAR_LOG_CURRENT_EXCEPTION();
+                is_running_ = false;
+            }
+            // close handle
+            if (!CloseHandle(pipe_h)) {
+                CASPAR_LOG(error) << print() << L" Failed to close named pipe";
+            }
+        });
+    }
+
+    ~pipe_consumer()
+    {
+        is_running_ = false;
+        frame_buffer_.abort();
+        // Some pipe functions will block - This should unblock them so that join() succeeds
+        if (!CancelSynchronousIo(thread_.native_handle())) {
+            DWORD lastError = GetLastError();
+            if (lastError != ERROR_NOT_FOUND) {
+                CASPAR_LOG(error)
+                    << print()
+                    << L" Failed to cancel synchronous IO (CasparCG may now lock up)"; // TODO: Add GetLastError
+            }
+        }
+        thread_.join();
+    }
+
+    std::future<bool> send(const core::const_frame& frame)
+    {
+        // silently drop frames until the pipe is connected
+        if (ready_for_frames_) {
+            if (!frame_buffer_.try_push(frame)) {
+                graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
+            }
+        }
+        return make_ready_future(is_running_.load());
+    }
+
+    std::wstring channel_and_format() const
+    {
+        return L"[" + std::to_wstring(channel_index_) + L"|" + format_desc_.name + L"]";
+    }
+
+    std::wstring print() const { return config_.name + L" " + channel_and_format(); }
+};
+
+struct pipe_consumer_proxy : public core::frame_consumer
+{
+    const configuration              config_;
+    std::unique_ptr<pipe_consumer> consumer_;
+
+  public:
+    explicit pipe_consumer_proxy(configuration config)
+        : config_(std::move(config))
+    {
+    }
+
+    // frame_consumer
+
+    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    {
+        consumer_.reset();
+        consumer_ = std::make_unique<pipe_consumer>(config_, format_desc, channel_index);
+    }
+
+    std::future<bool> send(core::const_frame frame) override { return consumer_->send(frame); }
+
+    std::wstring print() const override { return consumer_ ? consumer_->print() : L"[pipe_consumer]"; }
+
+    std::wstring name() const override { return L"pipe"; }
+
+    bool has_synchronization_clock() const override { return false; }
+
+    int index() const override { return 600 + (config_.key_only ? 10 : 0) + config_.screen_index; } // TODO: WHat is this?
+};
+
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&                         params,
+                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels)
+{
+    if (params.empty() || !boost::iequals(params.at(0), L"PIPE")) {
+        return core::frame_consumer::empty();
+    }
+
+    configuration config;
+
+    if (params.size() > 1) {
+        try {
+            config.screen_index = std::stoi(params.at(1));
+        } catch (...) {
+        }
+    }
+
+    config.windowed    = !contains_param(L"FULLSCREEN", params); //TODO: Update config
+    config.key_only    = contains_param(L"KEY_ONLY", params);
+    config.sbs_key     = contains_param(L"SBS_KEY", params);
+    config.interactive = !contains_param(L"NON_INTERACTIVE", params);
+    config.borderless  = contains_param(L"BORDERLESS", params);
+
+    if (contains_param(L"NAME", params)) {
+        config.name = get_param(L"NAME", params);
+    }
+
+    if (config.sbs_key && config.key_only) {
+        CASPAR_LOG(warning) << L" Key-only not supported with configuration of side-by-side fill and key. Ignored.";
+        config.key_only = false;
+    }
+
+    return spl::make_shared<pipe_consumer_proxy>(config);
+}
+
+spl::shared_ptr<core::frame_consumer>
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
+{
+    configuration config;
+    config.name          = ptree.get(L"name", config.name);
+    config.screen_index  = ptree.get(L"device", config.screen_index + 1) - 1;
+    config.screen_x      = ptree.get(L"x", config.screen_x);
+    config.screen_y      = ptree.get(L"y", config.screen_y);
+    config.screen_width  = ptree.get(L"width", config.screen_width);
+    config.screen_height = ptree.get(L"height", config.screen_height);
+    config.windowed      = ptree.get(L"windowed", config.windowed);
+    config.key_only      = ptree.get(L"key-only", config.key_only);
+    config.sbs_key       = ptree.get(L"sbs-key", config.sbs_key);
+    config.vsync         = ptree.get(L"vsync", config.vsync);
+    config.interactive   = ptree.get(L"interactive", config.interactive);
+    config.borderless    = ptree.get(L"borderless", config.borderless);
+    config.always_on_top = ptree.get(L"always-on-top", config.always_on_top);
+
+    auto colour_space_value = ptree.get(L"colour-space", L"RGB");
+    config.colour_space     = configuration::colour_spaces::RGB;
+    if (colour_space_value == L"datavideo-full")
+        config.colour_space = configuration::colour_spaces::datavideo_full;
+    else if (colour_space_value == L"datavideo-limited")
+        config.colour_space = configuration::colour_spaces::datavideo_limited;
+
+    if (config.sbs_key && config.key_only) {
+        CASPAR_LOG(warning) << L" Key-only not supported with configuration of side-by-side fill and key. Ignored.";
+        config.key_only = false;
+    }
+
+    if ((config.colour_space == configuration::colour_spaces::datavideo_full ||
+         config.colour_space == configuration::colour_spaces::datavideo_limited) &&
+        config.sbs_key) {
+        CASPAR_LOG(warning) << L" Side-by-side fill and key not supported for DataVideo TC100/TC200. Ignored.";
+        config.sbs_key = false;
+    }
+
+    if ((config.colour_space == configuration::colour_spaces::datavideo_full ||
+         config.colour_space == configuration::colour_spaces::datavideo_limited) &&
+        config.key_only) {
+        CASPAR_LOG(warning) << L" Key only not supported for DataVideo TC100/TC200. Ignored.";
+        config.key_only = false;
+    }
+
+    auto stretch_str = ptree.get(L"stretch", L"fill");
+    if (stretch_str == L"none") {
+        config.stretch = pipe::stretch::none;
+    } else if (stretch_str == L"uniform") {
+        config.stretch = pipe::stretch::uniform;
+    } else if (stretch_str == L"uniform_to_fill") {
+        config.stretch = pipe::stretch::uniform_to_fill;
+    }
+
+    auto aspect_str = ptree.get(L"aspect-ratio", L"default");
+    if (aspect_str == L"16:9") {
+        config.aspect = configuration::aspect_ratio::aspect_16_9;
+    } else if (aspect_str == L"4:3") {
+        config.aspect = configuration::aspect_ratio::aspect_4_3;
+    }
+
+    return spl::make_shared<pipe_consumer_proxy>(config);
+}
+
+}} // namespace caspar::pipe

--- a/src/modules/pipe/consumer/pipe_consumer.h
+++ b/src/modules/pipe/consumer/pipe_consumer.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Philip Starkey, https://github.com/philipstarkey
+ * Author: Robert Nagy, ronag89@gmail.com
+ */
+
+#pragma once
+
+#include <common/memory.h>
+
+#include <core/fwd.h>
+
+#include <boost/property_tree/ptree.hpp>
+#include <vector>
+
+namespace caspar { namespace pipe {
+
+spl::shared_ptr<core::frame_consumer>
+create_consumer(const std::vector<std::wstring>&                         params,
+                const std::vector<spl::shared_ptr<core::video_channel>>& channels);
+spl::shared_ptr<core::frame_consumer>
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels);
+
+}} // namespace caspar::pipe

--- a/src/modules/pipe/packages.config
+++ b/src/modules/pipe/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="boost" version="1.66.0.0" targetFramework="native" />
+</packages>

--- a/src/modules/pipe/pipe.cpp
+++ b/src/modules/pipe/pipe.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Philip Starkey, https://github.com/philipstarkey
+ * Author: Robert Nagy, ronag89@gmail.com
+ */
+
+#include "pipe.h"
+
+#include "consumer/pipe_consumer.h"
+
+//#include <core/consumer/frame_consumer.h>
+
+namespace caspar { namespace pipe {
+
+void init(core::module_dependencies dependencies)
+{
+    dependencies.consumer_registry->register_consumer_factory(L"Pipe Consumer", create_consumer);
+    dependencies.consumer_registry->register_preconfigured_consumer_factory(L"pipe", create_preconfigured_consumer);
+}
+
+}} // namespace caspar::pipe

--- a/src/modules/pipe/pipe.h
+++ b/src/modules/pipe/pipe.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Philip Starkey, https://github.com/philipstarkey
+ * Author: Robert Nagy, ronag89@gmail.com
+ */
+
+#pragma once
+
+#include <core/module_dependencies.h>
+
+namespace caspar { namespace pipe {
+
+void init(core::module_dependencies dependencies);
+
+}} // namespace caspar::pipe

--- a/src/modules/pipe/pipe/CMakeLists.txt
+++ b/src/modules/pipe/pipe/CMakeLists.txt
@@ -1,0 +1,9 @@
+﻿# CMakeList.txt : CMake project for pipe, include source and define
+# project specific logic here.
+#
+cmake_minimum_required (VERSION 3.8)
+
+# Add source to this project's executable.
+add_executable (pipe "pipe.cpp" "pipe.h")
+
+# TODO: Add tests and install targets if needed.

--- a/src/modules/pipe/pipe/pipe.cpp
+++ b/src/modules/pipe/pipe/pipe.cpp
@@ -1,0 +1,12 @@
+﻿// pipe.cpp : Defines the entry point for the application.
+//
+
+#include "pipe.h"
+
+using namespace std;
+
+int main()
+{
+	cout << "Hello CMake." << endl;
+	return 0;
+}

--- a/src/modules/pipe/pipe/pipe.h
+++ b/src/modules/pipe/pipe/pipe.h
@@ -1,0 +1,8 @@
+﻿// pipe.h : Include file for standard system include files,
+// or project specific include files.
+
+#pragma once
+
+#include <iostream>
+
+// TODO: Reference additional headers your program requires here.

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -111,6 +111,14 @@
                 <path>[file|url]</path>
                 <args>[most ffmpeg arguments related to filtering and output codecs]</args>
             </ffmpeg>
+            <pipe>
+                <name>[custom name]</name>
+                <index>1 [1...]</index>
+                <video-pipe-name>\\.\pipe\CasparCGVideo [pipe path (optional)]</video-pipe-name>
+                <audio-pipe-name>\\.\pipe\CasparCGAudio [pipe path (optional)]</audio-pipe-name>
+                <single-pipe>false [true|false] (true = send both audio and video data down a single pipe)</single-pipe>
+                <buffer-size>3.0 (number of seconds to buffer before dropping frames)</buffer-size>
+            </pipe>
         </consumers>
     </channel>
 </channels>


### PR DESCRIPTION
This PR adds a new consumer to CasparCG that sends raw video and/or audio down a named pipe.

## Motivation
While CasparCG has an FFmpeg consumer, it is sometimes inefficient and accessing the latest FFmpeg features requires waiting for a new build of CasparCG (against the new FFmpeg) or building yourself. There are also instances where integration with a 3rd party tool is desired. Both of these requirements can be met if there is an easy way to get raw video/audio data out from CasparCG.

There current ways to get raw video/audio data out of CasparCG are:

* The NDI consumer which, while supporting BGRA, is obviously only compatible with other NDI supporting hardware/software that agreed to the proprietary (but royalty free) license in order to utilise the NDI SDK. A notable example of a rejection of this is FFmpeg, who removed support for NDI after NDI violated the FFmpeg license.

* The FFmpeg consumer via a stream. However the FFmpeg consumer appears to transcode to YUVA422p (which fortunately does not appear CPU intensive) and the act of sending 1080p60 down a socket appears to require a large amount of CPU (~15% on an i7-8700K). This CPU usage was consistent between UDP and TCP sockets, and even with the YUVA422p transcoding removed from the CasparCG source code. In addition, it is impossible to get synchronised raw video+audio down different sockets with the FFmpeg consumer (which is required if you want to ingest it into a standalone FFmpeg process)

Neither of these seemed ideal to me, hence the creation of the (named) pipe consumer.

## Implementation
This consumer uses windows named pipes in blocking mode (frame data must be read at the receiver before the next frame is sent). Raw video and audio data can be sent down separate pipes, or the same pipe (end user configurable). Frame data from CasparCG is buffered (size of buffer is configurable by end users) starting from the moment the pipe is opened from the external receiver. If separate pipes for audio and video are used, the buffering begins from the moment the first of the pipes is connected (to ensure audio/video synchronisation). If two pipes are used, they run in separate threads so that the receiver is *not* required to read one video frame, one audio frame, one video frame, etc. (necessary when receiving in FFmpeg - possibly FFmpeg codec dependent).

## Results
Initial tests outside of CasparCG showed that Windows named pipes were easily capable of streaming 1080p60. This has also proven the case when integrated with CasparCG. Streaming 1080p60 down a named pipe (using the code in this PR) to a standalone copy of FFmpeg appears to use 3% of my CPU (i7-8700K) on the CasparCG side. 

Receiving the raw stream from CasparCG using the named pipe, and then using standalone FFmpeg to encode and restream over tcp (equivalent to `ADD 1 STREAM tcp://...`) resulted in a marginal CPU benefit (cumulative "CasparCG pipe consumer + standalone FFmpeg" CPU usage reduced from about 15% to 11% over streaming just with the CasparCG FFmpeg consumer.)

## Example usage
Here are some basic examples. The FFmpeg examples can of course be modified to use any input frame rate/resolution and any output options supported by the FFmpeg binary you use. 

### Streaming just video to FFmpeg
CasparCG command: `ADD 1 PIPE 1 VIDEO_PIPE \\\\.\\pipe\\CasparCGVideo`

FFmpeg launched from terminal with: `ffmpeg -r 60 -s 1920x1080 -f rawvideo -pix_fmt bgra -i \\.\pipe\CasparCGVideo -r 60 -c:v libx264 -crf 23 -pix_fmt yuv420p caspar_pipe_test_1.mp4`

FFmpeg will ingest video from CasparCG and encode it an an H.264 mp4

### Streaming video + audio to FFmpeg
CasparCG command: `ADD 1 PIPE 1 VIDEO_PIPE \\\\.\\pipe\\CasparCGVideo AUDIO_PIPE \\\\.\\pipe\\CasparCGAudio`

FFmpeg launched from terminal with: `ffmpeg -r 60 -s 1920x1080 -f rawvideo -pix_fmt bgra -i \\.\pipe\CasparCGVideo -probesize 128000 -r 60 -sample_fmt s32 -acodec pcm_s32le -f s32le -ar 48000.0 -ac 8 -i \\.\pipe\CasparCGAudio -r 60 -c:v libx264 -crf 23 -pix_fmt yuv420p caspar_pipe_test_2.mp4`

FFmpeg will ingest video + audio from CasparCG and encode it an an H.264 mp4

### Other options
To send video+audio down a single pipe (cannot be ingested by FFmpeg but may be useful for custom software):

    ADD 1 PIPE 1 VIDEO_PIPE \\\\.\\pipe\\CasparCGVideo SINGLE_PIPE
Note: This sends 1 video frame followed by the audio for that frame down the pipe.

Send audio+video down a single pipe (cannot be ingested by FFmpeg but may be useful for custom software):

    ADD 1 PIPE 1 AUDIO_PIPE \\\\.\\pipe\\CasparCGAudio SINGLE_PIPE
Note: This sends 1 audio frame followed by the video for that frame down the pipe.

Change size of internal buffer to 4.5 seconds of data (buffer size=4.5*fps):

    ADD 1 PIPE 1 VIDEO_PIPE \\\\.\\pipe\\CasparCGVideo BUFFER_SIZE 4.5

Example casparcg.config consumer syntax is included in the casparcg.config file of this PR.

## Future enhancements
If this pull request is accepted, I hope to slowly add support for linux named pipes and also named pipe producers. Didn't want to put in the extra work for that initially though as I wanted to gauge support for the general concept first (also I don't have a linux OS set up at the moment!).

I'm also happy to create documentation for using this new consumer. That said, given this is obviously not currently part of 2.3.0 LTS, I'm a little wary of polluting the current documentation with information for development versions. I see from your [help wanted](https://github.com/CasparCG/announcements#help-wanted) page that you're looking to move documentation to gitbook. I'm more familiar with sphinx+readthedocs, but I'd be interested in helping with the documentation migration to gitbook if that solves the problem of polluting docs with information on development features!

------

Please let me know what you think of this PR. It's my first time working on the CasparCG source code and the first time I've done any meaningful work with C++ in the last decade, so I might be a little rusty!

I hope the file headers are also OK. I couldn't find any files with a different copyright owner so I assume you want to have copyright over contributions? I'm happy to accept transfer of copyright to you on acceptance of this PR.