### PR TITLE
Cause flash files to be loaded by url

### DIFF
--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -580,12 +580,8 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
     if (!boost::filesystem::exists(filename))
         CASPAR_THROW_EXCEPTION(file_not_found() << msg_info(L"Could not open flash movie " + filename));
 
-    CASPAR_LOG(info) << L"Loading template host: " + url_from_path(filename);
-    return create_destroy_proxy(spl::make_shared<flash_producer>(dependencies.frame_factory,
-                                                                 dependencies.format_desc,
-                                                                 url_from_path(filename),
-                                                                 template_host.width,
-                                                                 template_host.height));
+    const url = url_from_path(filename);
+    return create_destroy_proxy(spl::make_shared<flash_producer>(dependencies.frame_factory, dependencies.format_desc, url, template_host.width, template_host.height));
 }
 
 spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_producer_dependencies& dependencies,
@@ -598,12 +594,9 @@ spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_prod
 
     swf_t::header_t header(filename);
 
-    CASPAR_LOG(info) << L"Loading flash media: " + url_from_path(filename);
-    auto producer = spl::make_shared<flash_producer>(dependencies.frame_factory,
-                                                     dependencies.format_desc,
-                                                     url_from_path(filename),
-                                                     header.frame_width,
-                                                     header.frame_height);
+    const url = url_from_path(filename);
+    auto producer = spl::make_shared<flash_producer>(
+            dependencies.frame_factory, dependencies.format_desc, url, header.frame_width, header.frame_height);
 
     producer->call({L"start_rendering"}).get();
 

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -164,9 +164,8 @@ std::wstring url_from_path(std::wstring in)
     PWSTR        out_buf = (PWSTR)malloc(out_length + 4);
     CASPAR_SCOPE_EXIT { free(out_buf); };
     HRESULT      ret     = UrlCreateFromPathW(in.c_str(), out_buf, &out_length, NULL);
-    std::wstring out;
     if (SUCCEEDED(ret)) {
-        return out_buf;
+        return std::wstring(out_buf);
     } else {
         return in;
     }
@@ -579,7 +578,7 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
     if (!boost::filesystem::exists(filename))
         CASPAR_THROW_EXCEPTION(file_not_found() << msg_info(L"Could not open flash movie " + filename));
 
-    const url = url_from_path(filename);
+    const auto url = url_from_path(filename);
     return create_destroy_proxy(spl::make_shared<flash_producer>(
         dependencies.frame_factory, dependencies.format_desc, url, template_host.width, template_host.height));
 }
@@ -594,9 +593,9 @@ spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_prod
 
     swf_t::header_t header(filename);
 
-    const url = url_from_path(filename);
+    const auto url = url_from_path(filename);
     auto producer = spl::make_shared<flash_producer>(
-            dependencies.frame_factory, dependencies.format_desc, url, header.frame_width, header.frame_height);
+        dependencies.frame_factory, dependencies.format_desc, url, header.frame_width, header.frame_height);
 
     producer->call({L"start_rendering"}).get();
 

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -159,8 +159,8 @@ std::mutex& get_global_init_destruct_mutex()
 
 std::wstring url_from_path(std::wstring in)
 {
-    DWORD        out_length = INTERNET_MAX_URL_LENGTH * 2 + 4;
-    PWSTR        out_buf = (PWSTR)malloc(out_length);
+    DWORD        out_length = INTERNET_MAX_URL_LENGTH * 2;
+    PWSTR        out_buf = (PWSTR)malloc(out_length + 4);
     HRESULT      ret     = UrlCreateFromPathW(in.c_str(), out_buf, &out_length, NULL);
     std::wstring out;
     if (SUCCEEDED(ret)) {

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -581,7 +581,8 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
         CASPAR_THROW_EXCEPTION(file_not_found() << msg_info(L"Could not open flash movie " + filename));
 
     const url = url_from_path(filename);
-    return create_destroy_proxy(spl::make_shared<flash_producer>(dependencies.frame_factory, dependencies.format_desc, url, template_host.width, template_host.height));
+    return create_destroy_proxy(spl::make_shared<flash_producer>(
+        dependencies.frame_factory, dependencies.format_desc, url, template_host.width, template_host.height));
 }
 
 spl::shared_ptr<core::frame_producer> create_swf_producer(const core::frame_producer_dependencies& dependencies,

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -49,6 +49,7 @@
 #include <common/env.h>
 #include <common/executor.h>
 #include <common/future.h>
+#include <common/scope_exit.h>
 #include <common/prec_timer.h>
 #include <common/timer.h>
 
@@ -161,14 +162,12 @@ std::wstring url_from_path(std::wstring in)
 {
     DWORD        out_length = INTERNET_MAX_URL_LENGTH * 2;
     PWSTR        out_buf = (PWSTR)malloc(out_length + 4);
+    CASPAR_SCOPE_EXIT { free(out_buf); };
     HRESULT      ret     = UrlCreateFromPathW(in.c_str(), out_buf, &out_length, NULL);
     std::wstring out;
     if (SUCCEEDED(ret)) {
-        out = out_buf;
-        free(out_buf);
-        return out;
+        return out_buf;
     } else {
-        free(out_buf);
         return in;
     }
 }


### PR DESCRIPTION
This will fix https://github.com/CasparCG/server/issues/1352 

Part of the flash eol workflow allows the loading of white listed urls.
System paths cannot be white listed so this PR causes the system path to be converted to a URL.

This should ideally be retrospectively fitted to 2.3, 2.0 and other versions in active use.