### PR TITLE
feat: CLEAR_ON_404 param and LOAD without params

### DIFF
--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -45,17 +45,23 @@ struct layer::impl
 
     void resume() { paused_ = false; }
 
-    void load(spl::shared_ptr<frame_producer> producer, bool preview, bool auto_play)
+    void load(spl::shared_ptr<frame_producer> producer, bool preview_producer, bool auto_play)
     {
         background_ = std::move(producer);
         auto_play_  = auto_play;
 
         if (auto_play_ && foreground_ == frame_producer::empty()) {
             play();
-        } else if (preview) {
-            foreground_ = std::move(background_);
-            background_ = frame_producer::empty();
-            paused_     = true;
+        } else if (preview_producer) {
+            preview(true);
+        }
+    }
+
+    void preview(bool force)
+    {
+        if (force || background_ != frame_producer::empty()) {
+            play();
+            paused_ = true;
         }
     }
 
@@ -160,6 +166,7 @@ void layer::load(spl::shared_ptr<frame_producer> frame_producer, bool preview, b
     return impl_->load(std::move(frame_producer), preview, auto_play);
 }
 void       layer::play() { impl_->play(); }
+void       layer::preview() { impl_->preview(false); }
 void       layer::pause() { impl_->pause(); }
 void       layer::resume() { impl_->resume(); }
 void       layer::stop() { impl_->stop(); }

--- a/src/core/producer/layer.h
+++ b/src/core/producer/layer.h
@@ -45,6 +45,7 @@ class layer final
 
     void load(spl::shared_ptr<frame_producer> producer, bool preview, bool auto_play = false);
     void play();
+    void preview();
     void pause();
     void resume();
     void stop();

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -230,6 +230,11 @@ struct stage::impl : public std::enable_shared_from_this<impl>
     {
         return executor_.begin_invoke([=] { get_layer(index).load(producer, preview, auto_play); });
     }
+    
+	std::future<void> preview(int index)
+    {
+        return executor_.begin_invoke([=] { get_layer(index).preview(); });
+    }
 
     std::future<void> pause(int index)
     {
@@ -369,6 +374,7 @@ std::future<void> stage::load(int index, const spl::shared_ptr<frame_producer>& 
 {
     return impl_->load(index, producer, preview, auto_play);
 }
+std::future<void> stage::preview(int index) { return impl_->preview(index); }
 std::future<void> stage::pause(int index) { return impl_->pause(index); }
 std::future<void> stage::resume(int index) { return impl_->resume(index); }
 std::future<void> stage::play(int index) { return impl_->play(index); }

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -71,6 +71,7 @@ class stage final
     std::future<frame_transform> get_current_transform(int index);
     std::future<void>
                               load(int index, const spl::shared_ptr<frame_producer>& producer, bool preview = false, bool auto_play = false);
+    std::future<void>         preview(int index);
     std::future<void>         pause(int index);
     std::future<void>         resume(int index);
     std::future<void>         play(int index);


### PR DESCRIPTION
Adds two features:

- Adds `CLEAR_ON_404` parameter to LOAD/LOADBG/PLAY commands, which results in loading an empty producer in case the command ends with 404
- `LOAD` command with no parameters puts the background clip in the 'preview' state, as if `LOAD` with that clip was done