### PR TITLE
fix(ffmpeg_producer): Prevent loading unreadable files

### DIFF
--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -235,8 +235,23 @@ bool has_invalid_protocol(const std::wstring& filename)
     return false;
 }
 
+bool is_readable(const std::wstring& filename)
+{
+    auto u8filename = u8(filename);
+
+    std::ifstream file(u8filename);
+    if (file) {
+        return true;
+    }
+    return false;
+}
+
 bool is_valid_file(const std::wstring& filename)
 {
+    if (!is_readable(filename)) {
+        return false;
+    }
+
     const auto valid_ext = has_valid_extension(filename);
     if (valid_ext) {
         return true;


### PR DESCRIPTION
Adds additional check if the file is readable while checking if it's valid. This prevents loading a file that is locked due to pending copy etc. 
Currently, an FFmpeg exception would be thrown, and even though it is handled gracefully, `202` is returned, making clients unaware of the failure. After the fix, `404` will be returned in such cases.