### PR TITLE
fix: incorrect variable name in FindFFmpeg

### DIFF
--- a/src/CMakeModules/FindFFmpeg.cmake
+++ b/src/CMakeModules/FindFFmpeg.cmake
@@ -63,7 +63,7 @@ macro(find_component _component _pkgconfig _library _header)
      # in the FIND_PATH() and FIND_LIBRARY() calls
      find_package(PkgConfig)
      if (PKG_CONFIG_FOUND)
-       pkg_check_modules(${_component} ${_pkgconfig})
+       pkg_check_modules(PC_LIB${_component} ${_pkgconfig})
      endif ()
   endif (NOT WIN32)
 


### PR DESCRIPTION
It seems like the prefix passed into `pkg_check_modules` is a mistake:
later calls expect `PC_LIB${_component}_*` to be set by
`pkg_check_modules`, not `${_component}_*`

Before this change, pkg_check_modules would set the
`${_component}_INCLUDE_DIRS` variable. The later call to `find_path`
also expects to set this variable, but doesn't if it has already been
set. On some systems, (e.g. Arch Linux), `pkg_check_modules` sets this
variable to an empty string as the header files are in the default
include directory. Since `find_path` won't overwrite the variable with
the correct value, it will appear like the include directories weren't
found, even if they do exist.