### PR TITLE
fix: missing <thread> includes

### DIFF
--- a/src/core/diagnostics/osd_graph.cpp
+++ b/src/core/diagnostics/osd_graph.cpp
@@ -43,6 +43,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <tuple>
 
 namespace caspar { namespace core { namespace diagnostics { namespace osd {

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -51,6 +51,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <future>
+#include <thread>
 #include <mutex>
 #include <queue>
 

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -52,6 +52,7 @@
 
 #include <atomic>
 #include <future>
+#include <thread>
 
 #include <clocale>
 #include <csignal>


### PR DESCRIPTION
These are needed for std::this_thread::{sleep_for,sleep_until}

This is needed to compile with GCC 11 on Arch Linux