### PR TITLE
Fix compiling with newer versions of boost

### DIFF
--- a/src/common/except.h
+++ b/src/common/except.h
@@ -145,7 +145,7 @@ struct not_supported : virtual user_error
 
 #define CASPAR_THROW_EXCEPTION(x)                                                                                      \
     ::boost::throw_exception(::boost::enable_error_info(x)                                                             \
-                             << ::boost::throw_function(BOOST_THROW_EXCEPTION_CURRENT_FUNCTION)                        \
+                             << ::boost::throw_function(BOOST_CURRENT_FUNCTION)                                        \
                              << ::boost::throw_file(__FILE__) << ::boost::throw_line((int)__LINE__)                    \
                              << stacktrace_info())
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -49,6 +49,8 @@ namespace src      = boost::log::sources;
 namespace sinks    = boost::log::sinks;
 namespace keywords = boost::log::keywords;
 
+using namespace boost::placeholders;
+
 namespace caspar { namespace log {
 
 std::string current_exception_diagnostic_information()


### PR DESCRIPTION
This fixes a couple of compatibility issues when compiling with newer boost versions (tested on 1.76.0). This doesn't change the default boost version, nor should it affect compatibility with older boost versions.