### PR TITLE
fix: Set relative RPATH on linux

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -96,6 +96,8 @@ else ()
 		z
 		pthread
 	)
+
+    set_target_properties(casparcg PROPERTIES INSTALL_RPATH "$ORIGIN/../lib" BUILD_WITH_INSTALL_RPATH ON)
 endif ()
 
 add_custom_target(casparcg_copy_dependencies ALL)

--- a/src/shell/run.sh
+++ b/src/shell/run.sh
@@ -4,7 +4,7 @@ RET=5
 
 while [ $RET -eq 5 ]
 do
-  LD_LIBRARY_PATH=lib bin/casparcg "$@"
+  bin/casparcg "$@"
   RET=$?
 done
 


### PR DESCRIPTION
This means that bundled libraries will always be loaded from a path
relative to the exectuable. This removes the need for setting
LD_LIBRARY_PATH in run.sh, and also means that we do not depend on the
current working directory to load libraries.