### PR TITLE
cmake: Fix compatibility with TBB >= 2021.1

### DIFF
--- a/src/CMakeModules/FindTBB.cmake
+++ b/src/CMakeModules/FindTBB.cmake
@@ -10,13 +10,6 @@
 #  TBB_LIBRARIES - TBB libraries to be lined, doesn't include malloc or
 #                  malloc proxy
 #
-#  TBB_VERSION_MAJOR - Major Product Version Number
-#  TBB_VERSION_MINOR - Minor Product Version Number
-#  TBB_INTERFACE_VERSION - Engineering Focused Version Number
-#  TBB_COMPATIBLE_INTERFACE_VERSION - The oldest major interface version
-#                                     still supported. This uses the engineering
-#                                     focused interface version numbers.
-#
 #  TBB_MALLOC_FOUND - system has TBB malloc library
 #  TBB_MALLOC_INCLUDE_DIRS - the TBB malloc include directories
 #  TBB_MALLOC_LIBRARIES - The TBB malloc libraries to be lined
@@ -328,32 +321,3 @@ find_library(TBB_MALLOC_PROXY_LIBRARY_DEBUG
 make_library_set(TBB_MALLOC_PROXY_LIBRARY)
 
 findpkg_finish(TBB_MALLOC_PROXY)
-
-
-#=============================================================================
-#parse all the version numbers from tbb
-if(NOT TBB_VERSION)
-
- #only read the start of the file
- file(READ
-      "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h"
-      TBB_VERSION_CONTENTS
-      LIMIT 2048)
-
-  string(REGEX REPLACE
-    ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
-    TBB_VERSION_MAJOR "${TBB_VERSION_CONTENTS}")
-
-  string(REGEX REPLACE
-    ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
-    TBB_VERSION_MINOR "${TBB_VERSION_CONTENTS}")
-
-  string(REGEX REPLACE
-        ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
-        TBB_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
-
-  string(REGEX REPLACE
-        ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
-        TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
-
-endif()


### PR DESCRIPTION
The version detection fails with TBB 2021.1 or later due to header file
changes. Since the the version number isn't actually used anywhere, it
seems easier to remove this code rather than try to maintain
compatibility with different TBB versions.