### PR TITLE
fix: compatibility with ffmpeg 5.0

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -58,6 +58,7 @@ extern "C" {
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -57,6 +57,7 @@ extern "C" {
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>

--- a/src/modules/ffmpeg/ffmpeg.cpp
+++ b/src/modules/ffmpeg/ffmpeg.cpp
@@ -114,10 +114,7 @@ void init(core::module_dependencies dependencies)
 {
     av_log_set_callback(log_for_thread);
 
-    avfilter_register_all();
-    av_register_all();
     avformat_network_init();
-    avcodec_register_all();
     avdevice_register_all();
 
     // mpegts demuxer does not seek acture with binary search.

--- a/src/modules/ffmpeg/ffmpeg.cpp
+++ b/src/modules/ffmpeg/ffmpeg.cpp
@@ -117,11 +117,13 @@ void init(core::module_dependencies dependencies)
     avformat_network_init();
     avdevice_register_all();
 
+#if LIBAVFORMAT_VERSION_MAJOR < 59
     // mpegts demuxer does not seek acture with binary search.
     const auto ts_demuxer = av_find_input_format("mpegts");
     if (ts_demuxer) {
         ts_demuxer->flags = AVFMT_SHOW_IDS | AVFMT_TS_DISCONT | AVFMT_NOBINSEARCH | AVFMT_GENERIC_INDEX;
     }
+#endif
 
     dependencies.consumer_registry->register_consumer_factory(L"FFmpeg Consumer", create_consumer);
     dependencies.consumer_registry->register_preconfigured_consumer_factory(L"ffmpeg", create_preconfigured_consumer);

--- a/src/modules/ffmpeg/ffmpeg.cpp
+++ b/src/modules/ffmpeg/ffmpeg.cpp
@@ -49,37 +49,6 @@ extern "C" {
 }
 
 namespace caspar { namespace ffmpeg {
-int ffmpeg_lock_callback(void** mutex, enum AVLockOp op)
-{
-    if (mutex == nullptr)
-        return 0;
-
-    auto my_mutex = reinterpret_cast<std::recursive_mutex*>(*mutex);
-
-    switch (op) {
-        case AV_LOCK_CREATE: {
-            *mutex = new std::recursive_mutex();
-            break;
-        }
-        case AV_LOCK_OBTAIN: {
-            if (my_mutex != nullptr)
-                my_mutex->lock();
-            break;
-        }
-        case AV_LOCK_RELEASE: {
-            if (my_mutex != nullptr)
-                my_mutex->unlock();
-            break;
-        }
-        case AV_LOCK_DESTROY: {
-            delete my_mutex;
-            *mutex = nullptr;
-            break;
-        }
-    }
-    return 0;
-}
-
 static void sanitize(uint8_t* line)
 {
     while (*line != 0u) {
@@ -143,7 +112,6 @@ void log_for_thread(void* ptr, int level, const char* fmt, va_list vl) { log_cal
 
 void init(core::module_dependencies dependencies)
 {
-    av_lockmgr_register(ffmpeg_lock_callback);
     av_log_set_callback(log_for_thread);
 
     avfilter_register_all();
@@ -168,6 +136,5 @@ void uninit()
 {
     // avfilter_uninit();
     avformat_network_deinit();
-    av_lockmgr_register(nullptr);
 }
 }} // namespace caspar::ffmpeg

--- a/src/modules/ffmpeg/producer/av_input.cpp
+++ b/src/modules/ffmpeg/producer/av_input.cpp
@@ -126,7 +126,11 @@ void Input::internal_reset()
 
     static const std::set<std::wstring> PROTOCOLS_TREATED_AS_FORMATS = {L"dshow", L"v4l2", L"iec61883"};
 
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+    const AVInputFormat* input_format = nullptr;
+#else
     AVInputFormat* input_format = nullptr;
+#endif
     auto           url_parts    = caspar::protocol_split(u16(filename_));
     if (url_parts.first == L"http" || url_parts.first == L"https") {
         FF(av_dict_set(&options, "multiple_requests", "1", 0)); // NOTE https://trac.ffmpeg.org/ticket/7034#comment:3

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -37,6 +37,7 @@ extern "C" {
 #include <libavfilter/buffersrc.h>
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/error.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -116,8 +116,6 @@ class Decoder
 
         FF(avcodec_parameters_to_context(ctx.get(), stream->codecpar));
 
-        FF(av_opt_set_int(ctx.get(), "refcounted_frames", 1, 0));
-
         int thread_count = env::properties().get(L"configuration.ffmpeg.producer.threads", 0);
         FF(av_opt_set_int(ctx.get(), "threads", thread_count, 0));
 

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include <libavfilter/avfilter.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
 #include <libavutil/pixfmt.h>
 }
 #if defined(_MSC_VER)
@@ -125,47 +126,60 @@ core::pixel_format get_pixel_format(AVPixelFormat pix_fmt)
 core::pixel_format_desc pixel_format_desc(AVPixelFormat pix_fmt, int width, int height, std::vector<int>& data_map)
 {
     // Get linesizes
-    AVPicture dummy_pict;
-    avpicture_fill(&dummy_pict, nullptr, pix_fmt, width, height);
+    int linesizes[4];
+    av_image_fill_linesizes(linesizes, pix_fmt, width);
 
     core::pixel_format_desc desc = get_pixel_format(pix_fmt);
 
     switch (desc.format) {
         case core::pixel_format::gray:
         case core::pixel_format::luma: {
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0], height, 1));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0], height, 1));
             return desc;
         }
         case core::pixel_format::bgr:
         case core::pixel_format::rgb: {
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0] / 3, height, 3));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0] / 3, height, 3));
             return desc;
         }
         case core::pixel_format::bgra:
         case core::pixel_format::argb:
         case core::pixel_format::rgba:
         case core::pixel_format::abgr: {
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0] / 4, height, 4));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0] / 4, height, 4));
             return desc;
         }
         case core::pixel_format::ycbcr:
         case core::pixel_format::ycbcra: {
             // Find chroma height
-            auto size2 = static_cast<int>(dummy_pict.data[2] - dummy_pict.data[1]);
-            auto h2    = size2 / dummy_pict.linesize[1];
+            // av_image_fill_plane_sizes is not available until ffmpeg 4.4, but we still need to support ffmpeg 4.2, so
+            // we fall back to calling av_image_fill_pointers with a NULL image buffer. We can't unconditionally use
+            // av_image_fill_pointers because it will not accept a NULL buffer on ffmpeg >= 5.0.
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(56, 56, 100)
+            size_t sizes[4];
+            ptrdiff_t linesizes1[4];
+            for (int i = 0; i < 4; i++) linesizes1[i] = linesizes[i];
+            av_image_fill_plane_sizes(sizes, pix_fmt, height, linesizes1);
+            auto size2 = static_cast<int>(sizes[1]);
+#else
+            uint8_t* dummy_pict_data[4];
+            av_image_fill_pointers(dummy_pict_data, pix_fmt, height, NULL, linesizes);
+            auto size2 = static_cast<int>(dummy_pict_data[2] - dummy_pict_data[1]);
+#endif
+            auto h2    = size2 / linesizes[1];
 
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0], height, 1));
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[1], h2, 1));
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[2], h2, 1));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0], height, 1));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[1], h2, 1));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[2], h2, 1));
 
             if (desc.format == core::pixel_format::ycbcra)
-                desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[3], height, 1));
+                desc.planes.push_back(core::pixel_format_desc::plane(linesizes[3], height, 1));
 
             return desc;
         }
         case core::pixel_format::uyvy: {
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0] / 2, height, 2));
-            desc.planes.push_back(core::pixel_format_desc::plane(dummy_pict.linesize[0] / 4, height, 4));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0] / 2, height, 2));
+            desc.planes.push_back(core::pixel_format_desc::plane(linesizes[0] / 4, height, 4));
 
             data_map.clear();
             data_map.push_back(0);

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -9,6 +9,7 @@
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/frame.h>
 #include <libavutil/pixfmt.h>
 }


### PR DESCRIPTION
See individual commits for what each change is.

The final commit does effectively revert 7ac31ee94f810a41c931e2000f11c874b7da7930 for ffmpeg >= 5.0. I'm not sure exactly what this is doing or why it's necessary, but it doesn't seem to be possible anymore in ffmpeg 5.0. I don't know if there's another way of doing something equivalent. I've added a condition to keep the old behaviour on ffmpeg 4.x, but this doesn't seem like a very good long-term solution, so any suggestions here are appreciated.

None of these changes should affect behaviour on ffmpeg 4.x.