### PR TITLE
fix: Replace deprecated texture2D GLSL function

### DIFF
--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -468,7 +468,7 @@ vec4 ycbcra_to_rgba(float y, float cb, float cr, float a)
 
 vec4 get_sample(sampler2D sampler, vec2 coords)
 {
-    return texture2D(sampler, coords);
+    return texture(sampler, coords);
 }
 
 vec4 get_rgba_color()


### PR DESCRIPTION
`texture2D` has been deprecated since OpenGL 3.0 and isn't supported by
recent Mesa versions on Linux (tested with Mesa 21.3.6 on AMD RX 6800
XT).