### PR TITLE
feat: sting transition audio fade

### DIFF
--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -30,6 +30,7 @@
 
 #include <common/param.h>
 #include <common/scope_exit.h>
+#include <protocol/amcp/amcp_args.h>
 
 #include <future>
 
@@ -238,14 +239,35 @@ bool try_match_sting(const std::vector<std::wstring>& params, sting_info& stingI
         return false;
     }
 
-    stingInfo.mask_filename = params.at(start_ind + 1);
+    auto params_token = params.at(start_ind + 1);
+    if (protocol::amcp::is_args_token(params_token)) {
+        auto args = protocol::amcp::tokenize_args(params_token);
 
-    if (params.size() > start_ind + 2) {
-        stingInfo.trigger_point = std::stoi(params.at(start_ind + 2));
-    }
+        std::wstring val;
+        if (!protocol::amcp::get_arg_value(args, L"MASK", val)) {
+            // TODO - throw error?
+            // No mask filename
+            return false;
+        }
+        stingInfo.mask_filename = val;
 
-    if (params.size() > start_ind + 3) {
-        stingInfo.overlay_filename = params.at(start_ind + 3);
+        if (protocol::amcp::get_arg_value(args, L"trigger_point", val)) {
+            stingInfo.trigger_point = boost::lexical_cast<int>(val);
+        }
+        if (protocol::amcp::get_arg_value(args, L"overlay", val)) {
+            stingInfo.overlay_filename = val;
+        }
+
+    } else {
+        stingInfo.mask_filename = params.at(start_ind + 1);
+
+        if (params.size() > start_ind + 2) {
+            stingInfo.trigger_point = boost::lexical_cast<int>(params.at(start_ind + 2));
+        }
+
+        if (params.size() > start_ind + 3) {
+            stingInfo.overlay_filename = params.at(start_ind + 3);
+        }
     }
 
     return true;

--- a/src/core/producer/transition/sting_producer.h
+++ b/src/core/producer/transition/sting_producer.h
@@ -34,7 +34,9 @@ struct sting_info
 {
     std::wstring mask_filename    = L"";
     std::wstring overlay_filename = L"";
-    uint32_t     trigger_point    = 0;
+    uint32_t     trigger_point       = 0;
+    uint32_t     audio_fade_start    = 0;
+    uint32_t     audio_fade_duration = UINT32_MAX;
 };
 
 bool try_match_sting(const std::vector<std::wstring>& params, sting_info& stingInfo);

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
 		amcp/AMCPCommandsImpl.cpp
 		amcp/AMCPProtocolStrategy.cpp
 		amcp/amcp_command_repository.cpp
+		amcp/amcp_args.cpp
 
 		cii/CIICommandsImpl.cpp
 		cii/CIIProtocolStrategy.cpp
@@ -36,6 +37,7 @@ set(HEADERS
 		amcp/AMCPProtocolStrategy.h
 		amcp/amcp_command_repository.h
 		amcp/amcp_shared.h
+		amcp/amcp_args.h
 
 		cii/CIICommand.h
 		cii/CIICommandsImpl.h

--- a/src/protocol/amcp/amcp_args.cpp
+++ b/src/protocol/amcp/amcp_args.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "amcp_args.h"
+
+namespace caspar { namespace protocol { namespace amcp {
+
+std::map<std::wstring, std::wstring> tokenize_args(const std::wstring& message)
+{
+    std::map<std::wstring, std::wstring> pTokenMap;
+
+    std::wstring currentName;
+    std::wstring currentValue;
+
+    bool inValue        = false;
+    bool inQuote        = false;
+    bool getSpecialCode = false;
+
+    for (unsigned int charIndex = 1; charIndex < message.size() - 1; ++charIndex) {
+        if (!inValue) {
+            if (message[charIndex] == L' ') {
+                pTokenMap[currentName] = L"";
+                currentName.clear();
+                currentValue.clear();
+            } else if (message[charIndex] == L'=') {
+                boost::to_upper(currentName);
+                inValue = true;
+            } else {
+                currentName += message[charIndex];
+            }
+            continue;
+        }
+
+        if (getSpecialCode) {
+            // insert code-handling here
+            switch (message[charIndex]) {
+                case L'\\':
+                    currentValue += L"\\";
+                    break;
+                case L'\"':
+                    currentValue += L"\"";
+                    break;
+                case L'n':
+                    currentValue += L"\n";
+                    break;
+                default:
+                    break;
+            };
+            getSpecialCode = false;
+            continue;
+        }
+
+        if (message[charIndex] == L'\\') {
+            getSpecialCode = true;
+            continue;
+        }
+
+        if (message[charIndex] == L' ' && inQuote == false) {
+            if (!currentValue.empty()) {
+                pTokenMap[currentName] = currentValue;
+                currentName.clear();
+                currentValue.clear();
+                inValue = false;
+            }
+            continue;
+        }
+
+        if (message[charIndex] == L'\"') {
+            inQuote = !inQuote;
+
+            if (!currentValue.empty() || !inQuote) {
+                pTokenMap[currentName] = currentValue;
+                currentName.clear();
+                currentValue.clear();
+                inValue = false;
+            }
+            continue;
+        }
+
+        currentValue += message[charIndex];
+    }
+
+    if (!currentValue.empty()) {
+        pTokenMap[currentName] = currentValue;
+        currentName.clear();
+        currentValue.clear();
+    }
+
+    return pTokenMap;
+}
+
+}}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/amcp_args.h
+++ b/src/protocol/amcp/amcp_args.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include <map>
+#include <vector>
+
+namespace caspar { namespace protocol { namespace amcp {
+
+inline bool is_args_token(const std::wstring& message)
+{
+    return (message[0] == L'(' && message[message.size() - 1] == L')');
+}
+
+inline bool
+get_arg_value(const std::map<std::wstring, std::wstring>& args, const std::wstring& key, std::wstring& value)
+{
+    auto it = args.find(boost::to_upper_copy(key));
+    if (it != args.end()) {
+        value = it->second;
+        return true;
+    }
+    return false;
+}
+
+inline bool get_bool_arg(const std::map<std::wstring, std::wstring>& args, const std::wstring& key)
+{
+    std::wstring value;
+    if (get_arg_value(args, key, value)) {
+        return (value != L"0" && boost::to_upper_copy(value) != L"FALSE");
+    }
+    return false;
+}
+
+std::map<std::wstring, std::wstring> tokenize_args(const std::wstring& message);
+
+}}} // namespace caspar::protocol::amcp

--- a/src/protocol/util/tokenize.cpp
+++ b/src/protocol/util/tokenize.cpp
@@ -30,6 +30,7 @@ std::size_t tokenize(const std::wstring& message, std::list<std::wstring>& pToke
     std::wstring currentToken;
 
     bool inQuote        = false;
+    int  inParamList    = 0;
     bool getSpecialCode = false;
 
     for (unsigned int charIndex = 0; charIndex < message.size(); ++charIndex) {
@@ -57,22 +58,34 @@ std::size_t tokenize(const std::wstring& message, std::list<std::wstring>& pToke
             continue;
         }
 
-        if (message[charIndex] == L' ' && inQuote == false) {
+        if (message[charIndex] == L' ' && inQuote == false && inParamList == 0) {
             if (!currentToken.empty()) {
                 pTokenVector.push_back(currentToken);
                 currentToken.clear();
             }
             continue;
-        }
-
-        if (message[charIndex] == L'\"') {
-            inQuote = !inQuote;
-
-            if (!currentToken.empty() || !inQuote) {
+        } else if (!inQuote && message[charIndex] == L'(') {
+            inParamList++;
+            // continue;
+        } else if (!inQuote && message[charIndex] == L')') {
+            inParamList--;
+            if (inParamList == 0) {
+                currentToken += message[charIndex];
                 pTokenVector.push_back(currentToken);
                 currentToken.clear();
+                continue;
             }
-            continue;
+            // continue;
+        } else if (message[charIndex] == L'\"') {
+            inQuote = !inQuote;
+
+            if (inParamList == 0) {
+				if (!inQuote) {
+					pTokenVector.push_back(currentToken);
+					currentToken.clear();
+				}
+				continue;
+			}
         }
 
         currentToken += message[charIndex];


### PR DESCRIPTION
This adds a new AMCP syntax, solely used by the STING transition for now, to define key&value pairs rather than relying on parameter order, or special keywords that are not guaranteed to be unique. eg `STING (MASK=wipe_mask OVERLAY=wipe_over TRIGGER_POINT=0)

Additionally, it adds 2 more parameters to the sting transition to define when/how the audio should fade.