### PR TITLE
Added dependencies to Dockerfile required for running CasparCG inside container

### DIFF
--- a/src/shell/run.sh
+++ b/src/shell/run.sh
@@ -4,7 +4,7 @@ RET=5
 
 while [ $RET -eq 5 ]
 do
-  bin/casparcg "$@"
+  LD_LIBRARY_PATH=lib bin/casparcg "$@"
   RET=$?
 done
 

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -39,13 +39,43 @@ FROM nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
 	COPY --from=build-casparcg /staging /opt/casparcg
 
 	RUN set -ex; \
-		apt-get update; \
+		apt-get update; \    
+		DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends tzdata; \
 		apt-get install -y --no-install-recommends \
 			libc++1 \
 			libnss3 \
 			fontconfig \
-		; \
-		rm -rf /var/lib/apt/lists/*
+			libxrandr2 \
+			libogg-dev \
+			libcairo-dev \
+			libnuma1 \
+			libgomp1 \      
+			libvorbisfile3 \
+			libxinerama1 \
+			libxi6 \
+			libxss1 \
+			libwayland-egl1-mesa \
+			libwayland-cursor0 \
+			libxkbcommon-dev \
+			libfribidi-dev \
+			libharfbuzz-dev \
+			libicu66 \
+			libjxr-dev \
+			libjpeg-dev \
+			libraw-dev \
+			libtiff-dev \
+			libopenexr24 \
+			libxcomposite-dev \
+			libxdamage1 \
+			libxtst-dev \
+			libpango-1.0-0 \
+			libpangocairo-1.0-0 \
+			libatk1.0-0 \
+			libatk-bridge2.0-0 \
+			libxcursor1 \ 
+			mpg123 \
+			; \
+			rm -rf /var/lib/apt/lists/*
 
 	WORKDIR /opt/casparcg
 

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -32,7 +32,7 @@ FROM ${IMAGE_BASE} as build-casparcg
 
 	# Find a better way to copy deps
 	RUN ln -s /build/staging /staging && \
-		/source/shell/copy_deps.sh shell/casparcg /staging/lib
+			/source/shell/copy_deps.sh /staging/bin/casparcg /staging/lib
 
 FROM nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
 	COPY --from=build-casparcg /staging /opt/casparcg

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -7,13 +7,12 @@ FROM ${IMAGE_BOOST} as boost
 FROM ${IMAGE_FFMPEG} as ffmpeg
 FROM ${IMAGE_CEF} as cef
 
-
 FROM ${IMAGE_BASE} as build-casparcg
 	COPY --from=boost /opt/boost /opt/boost
 	COPY --from=ffmpeg /opt/ffmpeg /opt/ffmpeg
 	COPY --from=cef /opt/cef /opt/cef
 
-    ARG PROC_COUNT=8
+	ARG PROC_COUNT=8
 
 	RUN mkdir /source && mkdir /build && mkdir /install
 
@@ -24,8 +23,8 @@ FROM ${IMAGE_BASE} as build-casparcg
 	ENV BOOST_ROOT=/opt/boost
 	ENV PKG_CONFIG_PATH=/opt/ffmpeg/lib/pkgconfig
 
-    ARG CC
-    ARG CXX
+	ARG CC
+	ARG CXX
 	ARG GIT_HASH
 
 	RUN cmake /source
@@ -39,41 +38,12 @@ FROM nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
 	COPY --from=build-casparcg /staging /opt/casparcg
 
 	RUN set -ex; \
-		apt-get update; \    
-		DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends tzdata; \
-		apt-get install -y --no-install-recommends \
+			apt-get update; \
+			DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends tzdata; \
+			apt-get install -y --no-install-recommends \
 			libc++1 \
 			libnss3 \
 			fontconfig \
-			libxrandr2 \
-			libogg-dev \
-			libcairo-dev \
-			libnuma1 \
-			libgomp1 \      
-			libvorbisfile3 \
-			libxinerama1 \
-			libxi6 \
-			libxss1 \
-			libwayland-egl1-mesa \
-			libwayland-cursor0 \
-			libxkbcommon-dev \
-			libfribidi-dev \
-			libharfbuzz-dev \
-			libicu66 \
-			libjxr-dev \
-			libjpeg-dev \
-			libraw-dev \
-			libtiff-dev \
-			libopenexr24 \
-			libxcomposite-dev \
-			libxdamage1 \
-			libxtst-dev \
-			libpango-1.0-0 \
-			libpangocairo-1.0-0 \
-			libatk1.0-0 \
-			libatk-bridge2.0-0 \
-			libxcursor1 \ 
-			mpg123 \
 			; \
 			rm -rf /var/lib/apt/lists/*
 

--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -32,15 +32,15 @@ FROM ${IMAGE_BASE} as build-casparcg
 
 	# Find a better way to copy deps
 	RUN ln -s /build/staging /staging && \
-			/source/shell/copy_deps.sh /staging/bin/casparcg /staging/lib
+		/source/shell/copy_deps.sh /staging/bin/casparcg /staging/lib
 
 FROM nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
 	COPY --from=build-casparcg /staging /opt/casparcg
 
 	RUN set -ex; \
 			apt-get update; \
-			DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends tzdata; \
-			apt-get install -y --no-install-recommends \
+			DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
+            tzdata \
 			libc++1 \
 			libnss3 \
 			fontconfig \


### PR DESCRIPTION
The final docker image build by the 'build in docker' process provided from the main CasparCG repo misses dependencies needed by CasparCG at runtime. 

Trying to run CasparCG in a container spawned from this image therefore doesn't work at the moment.

This pull request adds the required lib installs to the main Dockerfile to remedy that.