### PR TITLE
fix: add missing <fstream> include

### DIFF
--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -39,6 +39,7 @@
 #include <boost/logic/tribool.hpp>
 
 #include <cstdint>
+#include <fstream>
 
 #pragma warning(push, 1)
 


### PR DESCRIPTION
This is needed for std::ifstream.

I assume this is included transitively somewhere on some GCC/Boost versions, but doesn't work with GCC 12/Boost 1.79.