### PR TITLE
fix(ffmpeg_producer): crash on seek with some formats

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -153,11 +153,7 @@ class Decoder
                             packet = std::move(input.front());
                             input.pop();
                         }
-                        try {
-                            FF(avcodec_send_packet(ctx.get(), packet.get()));
-                        } catch (ffmpeg::ffmpeg_error_t) {
-                            // Do nothing...
-                        }
+                        avcodec_send_packet(ctx.get(), packet.get());
                     } else if (ret == AVERROR_EOF) {
                         avcodec_flush_buffers(ctx.get());
                         av_frame->pts = next_pts;

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -153,7 +153,11 @@ class Decoder
                             packet = std::move(input.front());
                             input.pop();
                         }
-                        FF(avcodec_send_packet(ctx.get(), packet.get()));
+                        try {
+                            FF(avcodec_send_packet(ctx.get(), packet.get()));
+                        } catch (ffmpeg::ffmpeg_error_t) {
+                            // Do nothing...
+                        }
                     } else if (ret == AVERROR_EOF) {
                         avcodec_flush_buffers(ctx.get());
                         av_frame->pts = next_pts;


### PR DESCRIPTION
With some formats, CasparCG would crash when attempting to seek. #1451