### PR TITLE
fix: compat with boost 1.81

### DIFF
--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -124,7 +124,11 @@ std::wstring read_latin1_file(const boost::filesystem::path& file)
 {
     boost::locale::generator gen;
     gen.locale_cache_enabled(true);
+#if BOOST_VERSION >= 108100
+    gen.categories(boost::locale::category_t::codepage);
+#else
     gen.categories(boost::locale::codepage_facet);
+#endif
 
     std::stringstream           result_stream;
     boost::filesystem::ifstream filestream(file);

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -62,7 +62,11 @@ namespace caspar {
 void setup_global_locale()
 {
     boost::locale::generator gen;
+#if BOOST_VERSION >= 108100
+    gen.categories(boost::locale::category_t::codepage);
+#else
     gen.categories(boost::locale::codepage_facet);
+#endif
 
     std::locale::global(gen(""));
 


### PR DESCRIPTION
Boost 1.81 changes various constants in boost::locale to enums which is a breaking change, so we need separate code for each version.