### PR TITLE
Update decklink_producer.cpp

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -606,12 +606,12 @@ class decklink_producer : public IDeckLinkInputCallback
                                 static_cast<double>(av_audio->pts * video_tb.num) / audio_tb.den;
 
                 if (std::abs(in_sync - in_sync_) > 0.01) {
-                    CASPAR_LOG(warning) << print() << " in-sync changed: " << in_sync;
+                    CASPAR_LOG(trace) << print() << " in-sync changed: " << in_sync;
                 }
                 in_sync_ = in_sync;
 
                 if (std::abs(out_sync - out_sync_) > 0.01) {
-                    CASPAR_LOG(warning) << print() << " out-sync changed: " << out_sync;
+                    CASPAR_LOG(trace) << print() << " out-sync changed: " << out_sync;
                 }
                 out_sync_ = out_sync;
 


### PR DESCRIPTION
When decklink is without reference it produces an exaggerated amount of log messages generating around 700MB of log per day. I don't see any harm in having it set to "trace", since when activated it makes any possibility of analyzing the log due to excessive messages unfeasible.

