### PR TITLE
Set casparcg project as the default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,6 @@ option(ENABLE_HTML "Enable HTML module, require CEF" ON)
 LIST (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules)
 
 if (MSVC)
-    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT casparcg)
 	INCLUDE (Bootstrap_Windows)
 else ()
 	INCLUDE (Bootstrap_Linux)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ option(ENABLE_HTML "Enable HTML module, require CEF" ON)
 LIST (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules)
 
 if (MSVC)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT casparcg)
 	INCLUDE (Bootstrap_Windows)
 else ()
 	INCLUDE (Bootstrap_Linux)

--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -185,6 +185,7 @@ if (ENABLE_HTML)
 endif ()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT casparcg)
 
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)


### PR DESCRIPTION
In VS the default project currently is ALL_BUILD which in fact will not build. This will set the current project to casparcg which is the project we would want built when hitting build solution.

Not sure if this can go withing the Boostrap Windows script, the cmake documentation seems to indicate it must go in the same directory as a project call. [https://cmake.org/cmake/help/latest/prop_dir/VS_STARTUP_PROJECT.html](https://cmake.org/cmake/help/latest/prop_dir/VS_STARTUP_PROJECT.html)