### PR TITLE
Bump cmake minimim to 3.16 and move lanuage version to targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 
 # Project settings
 PROJECT ("CasparCG Server")

--- a/src/CMakeModules/Bootstrap_Linux.cmake
+++ b/src/CMakeModules/Bootstrap_Linux.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required (VERSION 3.16)
+
 # Determine build (target) platform
 INCLUDE (PlatformIntrospection)
 _DETERMINE_PLATFORM (CONFIG_PLATFORM)
@@ -80,7 +82,6 @@ endif()
 IF (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
 	ADD_COMPILE_OPTIONS (-O3) # Needed for precompiled headers to work
 endif()
-ADD_COMPILE_OPTIONS (-std=c++14) # Needed for precompiled headers to work
 IF (CONFIG_ARCH MATCHES "(i[3-6]86|x64|x86_64|amd64|e2k)")
     ADD_COMPILE_OPTIONS (-msse3)
     ADD_COMPILE_OPTIONS (-mssse3)

--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 
 find_package(Git)
 

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (accelerator)
 
 set(SOURCES
@@ -49,15 +49,18 @@ bin2c("ogl/image/shader.vert" "ogl_image_vertex.h" "caspar::accelerator::ogl" "v
 bin2c("ogl/image/shader.frag" "ogl_image_fragment.h" "caspar::accelerator::ogl" "fragment_shader")
 
 add_library(accelerator ${SOURCES} ${HEADERS} ${WIN32_SPECIFIC_SOURCES} ${WIN32_SPECIFIC_HEADERS})
+target_compile_features(accelerator PRIVATE cxx_std_14)
+target_include_directories(accelerator PRIVATE
+    ..
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${GLEW_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    ${SFML_INCLUDE_PATH}
+    )
 add_precompiled_header(accelerator StdAfx.h FORCEINCLUDE)
 
-include_directories(..)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${GLEW_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
-include_directories(${SFML_INCLUDE_PATH})
 
 source_group(sources ./.*)
 source_group(sources\\cpu\\image cpu/image/.*)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (common)
 
 set(SOURCES
@@ -63,13 +63,16 @@ set(HEADERS
 )
 
 add_library(common ${SOURCES} ${HEADERS} ${OS_SPECIFIC_SOURCES})
+target_compile_features(common PRIVATE cxx_std_14)
+target_include_directories(common PRIVATE
+    ..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${GLEW_INCLUDE_PATH}
+    )
 add_precompiled_header(common stdafx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
 
-include_directories(..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${GLEW_INCLUDE_PATH})
 
 source_group(sources ./*)
 source_group(sources\\gl gl/*)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (core)
 
 set(SOURCES
@@ -75,14 +75,16 @@ set(HEADERS
 )
 
 add_library(core ${SOURCES} ${HEADERS})
+target_compile_features(core PRIVATE cxx_std_14)
+target_include_directories(core PRIVATE
+    ..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${SFML_INCLUDE_PATH}
+    ${GLEW_INCLUDE_PATH}
+    )
 add_precompiled_header(core StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${SFML_INCLUDE_PATH})
-include_directories(${GLEW_INCLUDE_PATH})
 
 source_group(sources ./*)
 source_group(sources\\consumer consumer/*)
@@ -98,12 +100,4 @@ source_group(sources\\producer\\route producer/route/*)
 source_group(sources\\producer\\transition producer/transition/*)
 source_group(sources\\producer\\separated producer/separated/*)
 
-if (MSVC)
-	target_link_libraries(core
-			common
-	)
-else()
-	target_link_libraries(core
-			common
-	)
-endif()
+target_link_libraries(core common)

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project("modules")
 
 add_subdirectory(image)

--- a/src/modules/bluefish/CMakeLists.txt
+++ b/src/modules/bluefish/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (bluefish)
 
 set(SOURCES
@@ -18,14 +18,16 @@ set(HEADERS
 )
 
 add_library(bluefish ${SOURCES} ${HEADERS})
+target_compile_features(bluefish PRIVATE cxx_std_14)
+target_include_directories(bluefish PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    )
 add_precompiled_header(bluefish StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
 
 set_target_properties(bluefish PROPERTIES FOLDER modules)
 source_group(sources ./*)
@@ -34,9 +36,9 @@ source_group(sources\\producer producer/*)
 source_group(sources\\util util/*)
 source_group(sources\\interop interop/*)
 
-target_link_libraries(  bluefish 
-                        common 
-                        core 
+target_link_libraries(  bluefish
+                        common
+                        core
                         ffmpeg)
 
 casparcg_add_include_statement("modules/bluefish/bluefish.h")

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (decklink)
 
 set(SOURCES
@@ -52,14 +52,16 @@ else()
 endif ()
 
 add_library(decklink ${SOURCES} ${HEADERS} ${OS_SPECIFIC_SOURCES})
+target_compile_features(decklink PRIVATE cxx_std_14)
+target_include_directories(decklink PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    )
 add_precompiled_header(decklink StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
 
 set_target_properties(decklink PROPERTIES FOLDER modules)
 source_group(sources ./*)

--- a/src/modules/ffmpeg/CMakeLists.txt
+++ b/src/modules/ffmpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (ffmpeg)
 
 set(SOURCES
@@ -24,14 +24,16 @@ set(HEADERS
 )
 
 add_library(ffmpeg ${SOURCES} ${HEADERS})
+target_compile_features(ffmpeg PRIVATE cxx_std_14)
+target_include_directories(ffmpeg PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    )
 add_precompiled_header(ffmpeg StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
 
 set_target_properties(ffmpeg PROPERTIES FOLDER modules)
 source_group(sources ./*)

--- a/src/modules/flash/CMakeLists.txt
+++ b/src/modules/flash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (flash)
 
 set(SOURCES
@@ -27,14 +27,17 @@ set(HEADERS
 )
 
 add_library(flash ${SOURCES} ${HEADERS})
+target_compile_features(flash PRIVATE cxx_std_14)
+target_include_directories(flash PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${ZLIB_INCLUDE_PATH}
+    )
 add_precompiled_header(flash StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
 
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${ZLIB_INCLUDE_PATH})
 
 set_target_properties(flash PROPERTIES FOLDER modules)
 source_group(sources\\interop interop/*)

--- a/src/modules/html/CMakeLists.txt
+++ b/src/modules/html/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (html)
 
 set(SOURCES
@@ -15,13 +15,16 @@ set(HEADERS
 )
 
 add_library(html ${SOURCES} ${HEADERS})
+target_compile_features(html PRIVATE cxx_std_14)
+target_include_directories(html PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${CEF_INCLUDE_PATH}
+    )
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
 
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${CEF_INCLUDE_PATH})
 
 set_target_properties(html PROPERTIES FOLDER modules)
 source_group(sources\\producer producer/*)

--- a/src/modules/image/CMakeLists.txt
+++ b/src/modules/image/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (image)
 
 set(SOURCES
@@ -28,13 +28,15 @@ set(HEADERS
 )
 
 add_library(image ${SOURCES} ${HEADERS})
+target_compile_features(image PRIVATE cxx_std_14)
+target_include_directories(image PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${FREEIMAGE_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    )
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${FREEIMAGE_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
 
 set_target_properties(image PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)

--- a/src/modules/newtek/CMakeLists.txt
+++ b/src/modules/newtek/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (newtek)
 
 set(SOURCES
@@ -44,14 +44,16 @@ if (MSVC)
 endif()
 
 add_library(newtek ${SOURCES} ${HEADERS})
+target_compile_features(newtek PRIVATE cxx_std_14)
+target_include_directories(newtek PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    )
 add_precompiled_header(newtek StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
 
 set_target_properties(newtek PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)

--- a/src/modules/oal/CMakeLists.txt
+++ b/src/modules/oal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (oal)
 
 set(SOURCES
@@ -13,14 +13,16 @@ set(HEADERS
 )
 
 add_library(oal ${SOURCES} ${HEADERS})
+target_compile_features(oal PRIVATE cxx_std_14)
+target_include_directories(oal PRIVATE
+    ..
+    ../..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    ${OPENAL_INCLUDE_PATH}
+    )
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
-include_directories(${OPENAL_INCLUDE_PATH})
 
 set_target_properties(oal PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)

--- a/src/modules/screen/CMakeLists.txt
+++ b/src/modules/screen/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (screen)
 
 set(SOURCES
@@ -29,16 +29,18 @@ else ()
 endif ()
 
 add_library(screen ${SOURCES} ${OS_SPECIFIC_SOURCES} ${HEADERS} ${OS_SPECIFIC_HEADERS})
+target_compile_features(screen PRIVATE cxx_std_14)
+target_include_directories(screen PRIVATE
+    ..
+    ../..
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    ${GLEW_INCLUDE_PATH}
+    ${SFML_INCLUDE_PATH}
+    ${FFMPEG_INCLUDE_PATH}
+    )
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(../..)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
-include_directories(${GLEW_INCLUDE_PATH})
-include_directories(${SFML_INCLUDE_PATH})
-include_directories(${FFMPEG_INCLUDE_PATH})
 
 set_target_properties(screen PROPERTIES FOLDER modules)
 source_group(sources\\consumer consumer/*)

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (protocol)
 
 set(SOURCES
@@ -75,12 +75,14 @@ set(HEADERS
 )
 
 add_library(protocol ${SOURCES} ${HEADERS})
+target_compile_features(protocol PRIVATE cxx_std_14)
+target_include_directories(protocol  PRIVATE
+    ..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    )
 add_precompiled_header(protocol StdAfx.h FORCEINCLUDE)
 configure_file("${PROJECT_SOURCE_DIR}/packages.config" "${CMAKE_CURRENT_BINARY_DIR}/packages.config")
-
-include_directories(..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
 
 source_group(sources\\amcp amcp/*)
 source_group(sources\\cii cii/*)

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (shell)
 
 join_list("${CASPARCG_MODULE_INCLUDE_STATEMENTS}" "\n" CASPARCG_MODULE_INCLUDE_STATEMENTS)
@@ -31,10 +31,12 @@ set(HEADERS
 )
 
 add_executable(casparcg ${SOURCES} ${HEADERS} ${OS_SPECIFIC_SOURCES})
-
-include_directories(..)
-include_directories(${BOOST_INCLUDE_PATH})
-include_directories(${TBB_INCLUDE_PATH})
+target_compile_features(casparcg PRIVATE cxx_std_14)
+target_include_directories(casparcg PRIVATE
+    ..
+    ${BOOST_INCLUDE_PATH}
+    ${TBB_INCLUDE_PATH}
+    )
 
 source_group(sources ./*)
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 
-include_directories(..)
 add_executable(bin2c bin2c.cpp)
+target_compile_features(bin2c PRIVATE cxx_std_14)
+
+target_include_directories(bin2c PRIVATE ..)
 
 function(bin2c source_file dest_file namespace obj_name)
     ADD_CUSTOM_COMMAND(
@@ -10,4 +12,3 @@ function(bin2c source_file dest_file namespace obj_name)
         DEPENDS bin2c ${CMAKE_CURRENT_SOURCE_DIR}/${source_file}
     )
 endfunction()
-


### PR DESCRIPTION
This is in preparation for moving to the cmake target_precompile_headers and removing the custom solution here.