### PR TITLE
feat: decklink consumer "secondary" ports

### DIFF
--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -3,6 +3,8 @@ project (decklink)
 
 set(SOURCES
 		consumer/decklink_consumer.cpp
+		consumer/frame.cpp
+		consumer/config.cpp
 
 		producer/decklink_producer.cpp
 
@@ -10,6 +12,8 @@ set(SOURCES
 )
 set(HEADERS
 		consumer/decklink_consumer.h
+		consumer/frame.h
+		consumer/config.h
 
 		producer/decklink_producer.h
 

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
 		consumer/decklink_consumer.cpp
 		consumer/frame.cpp
 		consumer/config.cpp
+		consumer/monitor.cpp
 
 		producer/decklink_producer.cpp
 
@@ -14,6 +15,7 @@ set(HEADERS
 		consumer/decklink_consumer.h
 		consumer/frame.h
 		consumer/config.h
+		consumer/monitor.h
 
 		producer/decklink_producer.h
 

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "config.h"
+
+namespace caspar { namespace decklink {
+
+output_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
+                                         const core::video_format_repository& format_repository)
+{
+    output_configuration port_config;
+    port_config.device_index = ptree.get(L"device", -1);
+    port_config.key_only     = ptree.get(L"key-only", port_config.key_only);
+
+    auto format_desc_str = ptree.get(L"video-mode", L"");
+    if (!format_desc_str.empty()) {
+        auto format_desc = format_repository.find(format_desc_str);
+        if (format_desc.format == core::video_format::invalid || format_desc.format == core::video_format::custom)
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Invalid video-mode: " + format_desc_str));
+        port_config.format = format_desc;
+    }
+
+    auto subregion_tree = ptree.get_child_optional(L"subregion");
+    if (subregion_tree) {
+        port_config.src_x    = subregion_tree->get(L"src-x", port_config.src_x);
+        port_config.src_y    = subregion_tree->get(L"src-y", port_config.src_y);
+        port_config.dest_x   = subregion_tree->get(L"dest-x", port_config.dest_x);
+        port_config.dest_y   = subregion_tree->get(L"dest-y", port_config.dest_y);
+        port_config.region_w = subregion_tree->get(L"width", port_config.region_w);
+        port_config.region_h = subregion_tree->get(L"height", port_config.region_h);
+    }
+
+    return port_config;
+}
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -21,6 +21,9 @@
 
 #include "config.h"
 
+#include <common/param.h>
+#include <common/ptree.h>
+
 namespace caspar { namespace decklink {
 
 port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
@@ -49,6 +52,99 @@ port_configuration parse_output_config(const boost::property_tree::wptree&  ptre
     }
 
     return port_config;
+}
+
+configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
+                               const core::video_format_repository& format_repository)
+{
+    configuration config;
+
+    auto keyer = ptree.get(L"keyer", L"default");
+    if (keyer == L"external") {
+        config.keyer = configuration::keyer_t::external_keyer;
+    } else if (keyer == L"internal") {
+        config.keyer = configuration::keyer_t::internal_keyer;
+    } else if (keyer == L"external_separate_device") {
+        config.keyer = configuration::keyer_t::external_separate_device_keyer;
+    }
+
+    auto duplex = ptree.get(L"duplex", L"default");
+    if (duplex == L"full") {
+        config.duplex = configuration::duplex_t::full_duplex;
+    } else if (duplex == L"half") {
+        config.duplex = configuration::duplex_t::half_duplex;
+    }
+
+    auto latency = ptree.get(L"latency", L"default");
+    if (latency == L"low") {
+        config.latency = configuration::latency_t::low_latency;
+    } else if (latency == L"normal") {
+        config.latency = configuration::latency_t::normal_latency;
+    }
+
+    auto wait_for_reference = ptree.get(L"wait-for-reference", L"auto");
+    if (wait_for_reference == L"disable" || wait_for_reference == L"disabled") {
+        config.wait_for_reference = configuration::wait_for_reference_t::disabled;
+    } else if (wait_for_reference == L"enable" || wait_for_reference == L"enabled") {
+        config.wait_for_reference = configuration::wait_for_reference_t::enabled;
+    } else {
+        config.wait_for_reference = configuration::wait_for_reference_t::automatic;
+    }
+    config.wait_for_reference_duration = ptree.get(L"wait-for-reference-duration", config.wait_for_reference_duration);
+
+    config.primary = parse_output_config(ptree, format_repository);
+    if (config.primary.device_index == -1)
+        config.primary.device_index = 1;
+
+    config.key_device_idx    = ptree.get(L"key-device", config.key_device_idx);
+    config.embedded_audio    = ptree.get(L"embedded-audio", config.embedded_audio);
+    config.base_buffer_depth = ptree.get(L"buffer-depth", config.base_buffer_depth);
+
+    if (ptree.get_child_optional(L"ports")) {
+        for (auto& xml_port : ptree | witerate_children(L"ports") | welement_context_iteration) {
+            ptree_verify_element_name(xml_port, L"port");
+
+            port_configuration port_config = parse_output_config(xml_port.second, format_repository);
+
+            config.secondaries.push_back(port_config);
+        }
+    }
+
+    return config;
+}
+
+configuration parse_amcp_config(const std::vector<std::wstring>&     params,
+                                const core::video_format_repository& format_repository)
+{
+    configuration config;
+
+    if (params.size() > 1)
+        config.primary.device_index = std::stoi(params.at(1));
+
+    if (contains_param(L"INTERNAL_KEY", params)) {
+        config.keyer = configuration::keyer_t::internal_keyer;
+    } else if (contains_param(L"EXTERNAL_KEY", params)) {
+        config.keyer = configuration::keyer_t::external_keyer;
+    } else if (contains_param(L"EXTERNAL_SEPARATE_DEVICE_KEY", params)) {
+        config.keyer = configuration::keyer_t::external_separate_device_keyer;
+    } else {
+        config.keyer = configuration::keyer_t::default_keyer;
+    }
+
+    if (contains_param(L"FULL_DUPLEX", params)) {
+        config.duplex = configuration::duplex_t::full_duplex;
+    } else if (contains_param(L"HALF_DUPLEX", params)) {
+        config.duplex = configuration::duplex_t::half_duplex;
+    }
+
+    if (contains_param(L"LOW_LATENCY", params)) {
+        config.latency = configuration::latency_t::low_latency;
+    }
+
+    config.embedded_audio   = contains_param(L"EMBEDDED_AUDIO", params);
+    config.primary.key_only = contains_param(L"KEY_ONLY", params);
+
+    return config;
 }
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -23,10 +23,10 @@
 
 namespace caspar { namespace decklink {
 
-output_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
+port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
                                          const core::video_format_repository& format_repository)
 {
-    output_configuration port_config;
+    port_configuration port_config;
     port_config.device_index = ptree.get(L"device", -1);
     port_config.key_only     = ptree.get(L"key-only", port_config.key_only);
 

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -24,7 +24,7 @@
 namespace caspar { namespace decklink {
 
 port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
-                                         const core::video_format_repository& format_repository)
+                                       const core::video_format_repository& format_repository)
 {
     port_configuration port_config;
     port_config.device_index = ptree.get(L"device", -1);

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -50,7 +50,7 @@ struct configuration
     {
         internal_keyer,
         external_keyer,
-        external_separate_device_keyer, // TODO - remove?
+        external_separate_device_keyer, // @deprecated
         default_keyer = external_keyer
     };
 
@@ -76,8 +76,7 @@ struct configuration
         disabled,
     };
 
-    // int       device_index      = 1;
-    // int       key_device_idx    = 0;
+    int                  key_device_idx              = 0;
     bool                 embedded_audio              = false;
     keyer_t              keyer                       = keyer_t::default_keyer;
     duplex_t             duplex                      = duplex_t::default_duplex;
@@ -98,7 +97,10 @@ struct configuration
     // int key_device_index() const { return key_device_idx == 0 ? device_index + 1 : key_device_idx; }
 };
 
-port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
-                                       const core::video_format_repository& format_repository);
+configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
+                               const core::video_format_repository& format_repository);
+
+configuration parse_amcp_config(const std::vector<std::wstring>&     params,
+                                const core::video_format_repository& format_repository);
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -50,7 +50,6 @@ struct configuration
     {
         internal_keyer,
         external_keyer,
-        external_separate_device_keyer, // @deprecated
         default_keyer = external_keyer
     };
 
@@ -76,7 +75,6 @@ struct configuration
         disabled,
     };
 
-    int                  key_device_idx              = 0;
     bool                 embedded_audio              = false;
     keyer_t              keyer                       = keyer_t::default_keyer;
     duplex_t             duplex                      = duplex_t::default_duplex;

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -69,13 +69,22 @@ struct configuration
         default_latency = normal_latency
     };
 
+    enum class wait_for_reference_t
+    {
+        automatic,
+        enabled,
+        disabled,
+    };
+
     // int       device_index      = 1;
     // int       key_device_idx    = 0;
-    bool      embedded_audio    = false;
-    keyer_t   keyer             = keyer_t::default_keyer;
-    duplex_t  duplex            = duplex_t::default_duplex;
-    latency_t latency           = latency_t::default_latency;
-    int       base_buffer_depth = 3;
+    bool                 embedded_audio              = false;
+    keyer_t              keyer                       = keyer_t::default_keyer;
+    duplex_t             duplex                      = duplex_t::default_duplex;
+    latency_t            latency                     = latency_t::default_latency;
+    wait_for_reference_t wait_for_reference          = wait_for_reference_t::automatic;
+    int                  wait_for_reference_duration = 10; // seconds
+    int                  base_buffer_depth           = 3;
 
     port_configuration              primary;
     std::vector<port_configuration> secondaries;
@@ -90,6 +99,6 @@ struct configuration
 };
 
 port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
-                                         const core::video_format_repository& format_repository);
+                                       const core::video_format_repository& format_repository);
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -25,7 +25,7 @@
 
 namespace caspar { namespace decklink {
 
-struct output_configuration
+struct port_configuration
 {
     int  device_index = 1;
     bool key_only     = false;
@@ -77,8 +77,8 @@ struct configuration
     latency_t latency           = latency_t::default_latency;
     int       base_buffer_depth = 3;
 
-    output_configuration              main;
-    std::vector<output_configuration> children;
+    port_configuration              primary;
+    std::vector<port_configuration> secondaries;
 
     [[nodiscard]] int buffer_depth() const
     {
@@ -89,7 +89,7 @@ struct configuration
     // int key_device_index() const { return key_device_idx == 0 ? device_index + 1 : key_device_idx; }
 };
 
-output_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
+port_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
                                          const core::video_format_repository& format_repository);
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <core/video_format.h>
+
+namespace caspar { namespace decklink {
+
+struct output_configuration
+{
+    int  device_index = 1;
+    bool key_only     = false;
+
+    core::video_format_desc format;
+    int                     src_x    = 0;
+    int                     src_y    = 0;
+    int                     dest_x   = 0;
+    int                     dest_y   = 0;
+    int                     region_w = 0;
+    int                     region_h = 0;
+
+    [[nodiscard]] bool has_subregion_geometry() const
+    {
+        return src_x != 0 || src_y != 0 || region_w != 0 || region_h != 0 || dest_x != 0 || dest_y != 0;
+    }
+};
+
+struct configuration
+{
+    enum class keyer_t
+    {
+        internal_keyer,
+        external_keyer,
+        external_separate_device_keyer, // TODO - remove?
+        default_keyer = external_keyer
+    };
+
+    enum class duplex_t
+    {
+        none,
+        half_duplex,
+        full_duplex,
+        default_duplex = none
+    };
+
+    enum class latency_t
+    {
+        low_latency,
+        normal_latency,
+        default_latency = normal_latency
+    };
+
+    // int       device_index      = 1;
+    // int       key_device_idx    = 0;
+    bool      embedded_audio    = false;
+    keyer_t   keyer             = keyer_t::default_keyer;
+    duplex_t  duplex            = duplex_t::default_duplex;
+    latency_t latency           = latency_t::default_latency;
+    int       base_buffer_depth = 3;
+
+    output_configuration              main;
+    std::vector<output_configuration> children;
+
+    [[nodiscard]] int buffer_depth() const
+    {
+        return base_buffer_depth + (latency == latency_t::low_latency ? 0 : 1) +
+               (embedded_audio ? 1 : 0); // TODO: Do we need this?
+    }
+
+    // int key_device_index() const { return key_device_idx == 0 ? device_index + 1 : key_device_idx; }
+};
+
+output_configuration parse_output_config(const boost::property_tree::wptree&  ptree,
+                                         const core::video_format_repository& format_repository);
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -336,7 +336,7 @@ struct child_device_context
     void schedule_frame(core::const_frame frame)
     {
         bool isInterlaced = decklink_format_desc_.field_count != 1;
-        if (isInterlaced && !first_field_.has_value()) {
+        if (isInterlaced && !first_field_.is_initialized()) {
             // If this is interlaced it needs a pair of frames at a time
             first_field_ = frame;
             return;

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -22,7 +22,9 @@
 #include "../StdAfx.h"
 
 #include "common/os/thread.h"
+#include "config.h"
 #include "decklink_consumer.h"
+#include "frame.h"
 
 #include "../decklink.h"
 #include "../util/util.h"
@@ -37,8 +39,8 @@
 #include <common/diagnostics/graph.h>
 #include <common/except.h>
 #include <common/executor.h>
-#include <common/memshfl.h>
 #include <common/param.h>
+#include <common/ptree.h>
 #include <common/timer.h>
 
 #include <tbb/scalable_allocator.h>
@@ -56,62 +58,6 @@
 #include <utility>
 
 namespace caspar { namespace decklink {
-
-struct configuration
-{
-    enum class keyer_t
-    {
-        internal_keyer,
-        external_keyer,
-        external_separate_device_keyer,
-        default_keyer = external_keyer
-    };
-
-    enum class duplex_t
-    {
-        none,
-        half_duplex,
-        full_duplex,
-        default_duplex = none
-    };
-
-    enum class latency_t
-    {
-        low_latency,
-        normal_latency,
-        default_latency = normal_latency
-    };
-
-    int       device_index      = 1;
-    int       key_device_idx    = 0;
-    bool      embedded_audio    = false;
-    keyer_t   keyer             = keyer_t::default_keyer;
-    duplex_t  duplex            = duplex_t::default_duplex;
-    latency_t latency           = latency_t::default_latency;
-    bool      key_only          = false;
-    int       base_buffer_depth = 3;
-
-    core::video_format_desc format;
-    int                     src_x    = 0;
-    int                     src_y    = 0;
-    int                     dest_x   = 0;
-    int                     dest_y   = 0;
-    int                     region_w = 0;
-    int                     region_h = 0;
-
-    int buffer_depth() const
-    {
-        return base_buffer_depth + (latency == latency_t::low_latency ? 0 : 1) +
-               (embedded_audio ? 1 : 0); // TODO: Do we need this?
-    }
-
-    int key_device_index() const { return key_device_idx == 0 ? device_index + 1 : key_device_idx; }
-
-    bool has_subregion_geometry() const
-    {
-        return src_x != 0 || src_y != 0 || region_w != 0 || region_h != 0 || dest_x != 0 || dest_y != 0;
-    }
-};
 
 template <typename Configuration>
 void set_latency(const com_iface_ptr<Configuration>& config,
@@ -281,23 +227,87 @@ class decklink_frame : public IDeckLinkVideoFrame
     int nb_samples() const { return nb_samples_; }
 };
 
-struct key_video_context : public IDeckLinkVideoOutputCallback
+struct decklink_base
+{
+  public:
+    virtual std::wstring print() const = 0;
+
+    core::video_format_desc get_decklink_format(const output_configuration&    config,
+                                                const core::video_format_desc& fallback_format_desc)
+    {
+        if (config.format.format != core::video_format::invalid &&
+            config.format.format != fallback_format_desc.format) {
+            if (config.format.format != core::video_format::invalid &&
+                config.format.format != core::video_format::custom &&
+                config.format.framerate == fallback_format_desc.framerate) {
+                return config.format;
+            } else {
+                CASPAR_LOG(warning) << print() << L"Ignoring specified format for decklink";
+            }
+        }
+
+        if (fallback_format_desc.format == core::video_format::invalid ||
+            fallback_format_desc.format == core::video_format::custom)
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Decklink does not support the channel format"));
+
+        return fallback_format_desc;
+    }
+};
+
+struct child_device_context
+    : public IDeckLinkVideoOutputCallback
+    , public decklink_base
 {
     const configuration                       config_;
-    com_ptr<IDeckLink>                        decklink_      = get_device(config_.key_device_index());
+    const output_configuration                output_config_;
+    com_ptr<IDeckLink>                        decklink_      = get_device(output_config_.device_index);
     com_iface_ptr<IDeckLinkOutput>            output_        = iface_cast<IDeckLinkOutput>(decklink_);
     com_iface_ptr<IDeckLinkKeyer>             keyer_         = iface_cast<IDeckLinkKeyer>(decklink_, true);
     com_iface_ptr<IDeckLinkProfileAttributes> attributes_    = iface_cast<IDeckLinkProfileAttributes>(decklink_);
     com_iface_ptr<IDeckLinkConfiguration>     configuration_ = iface_cast<IDeckLinkConfiguration>(decklink_);
     std::atomic<int64_t>                      scheduled_frames_completed_ = {0};
+    const int                                 device_sync_group_;
+    boost::optional<core::const_frame>        first_field_;
 
-    key_video_context(const configuration& config, const std::wstring& print)
+    const std::wstring model_name_ = get_model_name(decklink_);
+
+    long long video_scheduled_ = 0;
+
+    const core::video_format_desc channel_format_desc_;
+    const core::video_format_desc decklink_format_desc_;
+    com_ptr<IDeckLinkDisplayMode> mode_ =
+        get_display_mode(output_, decklink_format_desc_.format, bmdFormat8BitBGRA, bmdSupportedVideoModeDefault);
+
+    child_device_context(const configuration&        config,
+                         const output_configuration& output_config,
+                         core::video_format_desc     channel_format_desc,
+                         core::video_format_desc     main_decklink_format_desc,
+                         const std::wstring&         print,
+                         int                         device_sync_group)
         : config_(config)
+        , output_config_(output_config)
+        , device_sync_group_(device_sync_group)
+        , channel_format_desc_(std::move(channel_format_desc))
+        , decklink_format_desc_(get_decklink_format(output_config_, main_decklink_format_desc))
     {
         scheduled_frames_completed_ = 0;
 
+        if (config.duplex != configuration::duplex_t::default_duplex) {
+            set_duplex(iface_cast<IDeckLinkAttributes_v10_11>(decklink_),
+                       iface_cast<IDeckLinkConfiguration_v10_11>(decklink_),
+                       config.duplex,
+                       print);
+        }
+
         set_latency(configuration_, config.latency, print);
         set_keyer(attributes_, keyer_, config.keyer, print);
+
+        if (device_sync_group > 0 &&
+            FAILED(configuration_->SetInt(bmdDeckLinkConfigPlaybackGroup, device_sync_group))) {
+            CASPAR_LOG(error) << print << L" Failed to enable sync group.";
+        } else {
+            CASPAR_LOG(trace) << print << L" Joined sync group " << device_sync_group;
+        }
 
         if (FAILED(output_->SetScheduledFrameCompletionCallback(this)))
             CASPAR_THROW_EXCEPTION(caspar_exception()
@@ -305,19 +315,65 @@ struct key_video_context : public IDeckLinkVideoOutputCallback
                                    << boost::errinfo_api_function("SetScheduledFrameCompletionCallback"));
     }
 
-    template <typename Print>
-    void enable_video(BMDDisplayMode display_mode, const Print& print)
+    std::wstring print_single() const
     {
-        if (FAILED(output_->EnableVideoOutput(display_mode, bmdVideoOutputFlagDefault)))
-            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Could not enable key video output."));
-
-        if (FAILED(output_->SetScheduledFrameCompletionCallback(this)))
-            CASPAR_THROW_EXCEPTION(caspar_exception()
-                                   << msg_info(print() + L" Failed to set key playback completion callback.")
-                                   << boost::errinfo_api_function("SetScheduledFrameCompletionCallback"));
+        return model_name_ + L" [" + std::to_wstring(output_config_.device_index) + L"|" + decklink_format_desc_.name +
+               L"]";
     }
 
-    ~key_video_context()
+    std::wstring print() const override { return L"TODO"; }
+
+    template <typename Print>
+    void enable_video(const Print& print)
+    {
+        if (FAILED(output_->EnableVideoOutput(mode_->GetDisplayMode(),
+                                              device_sync_group_ > 0 ? bmdVideoOutputSynchronizeToPlaybackGroup
+                                                                     : bmdVideoOutputFlagDefault)))
+            CASPAR_THROW_EXCEPTION(caspar_exception()
+                                   << msg_info(print() + L" Could not enable secondary video output."));
+    }
+
+    void schedule_frame(core::const_frame frame)
+    {
+        bool isInterlaced = decklink_format_desc_.field_count != 1;
+        if (isInterlaced && !first_field_.has_value()) {
+            // If this is interlaced it needs a pair of frames at a time
+            first_field_ = frame;
+            return;
+        }
+
+        // Figure out which frame is which
+        core::const_frame frame1;
+        core::const_frame frame2;
+        if (isInterlaced) {
+            frame1       = *first_field_;
+            first_field_ = boost::none;
+            frame2       = frame;
+        } else {
+            frame1 = frame;
+        }
+
+        auto image_data = convert_frame_pair(
+            channel_format_desc_, decklink_format_desc_, output_config_, frame1, frame2, mode_->GetFieldDominance());
+
+        schedule_next_video(image_data, 0);
+    }
+
+    void schedule_next_video(std::shared_ptr<void> image_data, int nb_samples)
+    {
+        auto packed_frame = wrap_raw<com_ptr, IDeckLinkVideoFrame>(
+            new decklink_frame(std::move(image_data), decklink_format_desc_, nb_samples));
+        if (FAILED(output_->ScheduleVideoFrame(get_raw(packed_frame),
+                                               video_scheduled_,
+                                               decklink_format_desc_.duration,
+                                               decklink_format_desc_.time_scale))) {
+            CASPAR_LOG(error) << print() << L" Failed to schedule primary video.";
+        }
+
+        video_scheduled_ += decklink_format_desc_.duration;
+    }
+
+    ~child_device_context()
     {
         if (output_) {
             output_->StopScheduledPlayback(0, nullptr, 0);
@@ -336,19 +392,20 @@ struct key_video_context : public IDeckLinkVideoOutputCallback
     {
         ++scheduled_frames_completed_;
 
-        // Let the fill callback keep the pace, so no scheduling here.
+        // Let the primary callback keep the pace, so no scheduling here.
 
         return S_OK;
     }
 };
 
-struct decklink_consumer : public IDeckLinkVideoOutputCallback
+struct decklink_consumer
+    : public IDeckLinkVideoOutputCallback
+    , public decklink_base
 {
-    const core::video_format_repository format_repository_;
-    const int                           channel_index_;
-    const configuration                 config_;
+    const int           channel_index_;
+    const configuration config_;
 
-    com_ptr<IDeckLink>                        decklink_      = get_device(config_.device_index);
+    com_ptr<IDeckLink>                        decklink_      = get_device(config_.main.device_index);
     com_iface_ptr<IDeckLinkOutput>            output_        = iface_cast<IDeckLinkOutput>(decklink_);
     com_iface_ptr<IDeckLinkConfiguration>     configuration_ = iface_cast<IDeckLinkConfiguration>(decklink_);
     com_iface_ptr<IDeckLinkKeyer>             keyer_         = iface_cast<IDeckLinkKeyer>(decklink_, true);
@@ -373,149 +430,25 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
 
     boost::circular_buffer<std::vector<int32_t>> audio_container_{static_cast<unsigned long>(buffer_size_ + 1)};
 
-    spl::shared_ptr<diagnostics::graph> graph_;
-    caspar::timer                       tick_timer_;
-    reference_signal_detector           reference_signal_detector_{output_};
-    std::atomic<int64_t>                scheduled_frames_completed_{0};
-    std::unique_ptr<key_video_context>  key_context_;
+    spl::shared_ptr<diagnostics::graph>                graph_;
+    caspar::timer                                      tick_timer_;
+    reference_signal_detector                          reference_signal_detector_{output_};
+    std::atomic<int64_t>                               scheduled_frames_completed_{0};
+    std::vector<std::unique_ptr<child_device_context>> child_device_contexts_;
+    int                                                device_sync_group_;
 
     com_ptr<IDeckLinkDisplayMode> mode_ =
         get_display_mode(output_, decklink_format_desc_.format, bmdFormat8BitBGRA, bmdSupportedVideoModeDefault);
 
     std::atomic<bool> abort_request_{false};
 
-    bool doFrame(std::shared_ptr<void>& image_data, std::vector<std::int32_t>& audio_data, bool topField)
-    {
-        core::const_frame frame = pop();
-        if (abort_request_)
-            return false;
-
-        // No point copying an empty frame
-        if (!frame)
-            return true;
-
-        int firstLine = topField ? 0 : 1;
-
-        if (channel_format_desc_.format == decklink_format_desc_.format && !config_.has_subregion_geometry()) {
-            // Fast path
-            size_t byte_count_line = (size_t)decklink_format_desc_.width * 4;
-            for (int y = firstLine; y < decklink_format_desc_.height; y += decklink_format_desc_.field_count) {
-                std::memcpy(reinterpret_cast<char*>(image_data.get()) + (long long)y * byte_count_line,
-                            frame.image_data(0).data() + (long long)y * byte_count_line,
-                            byte_count_line);
-            }
-        } else {
-            // Take a sub-region
-
-            // Some repetetive numbers
-            size_t byte_count_dest_line  = (size_t)decklink_format_desc_.width * 4;
-            size_t byte_count_src_line   = (size_t)channel_format_desc_.width * 4;
-            size_t byte_offset_src_line  = std::max(0, (config_.src_x * 4));
-            size_t byte_offset_dest_line = std::max(0, (config_.dest_x * 4));
-            int    y_skip_src_lines      = std::max(0, config_.src_y);
-            int    y_skip_dest_lines     = std::max(0, config_.dest_y);
-
-            size_t byte_copy_per_line =
-                std::min(byte_count_src_line - byte_offset_src_line, byte_count_dest_line - byte_offset_dest_line);
-            if (config_.region_w > 0) // If the user chose a width, respect that
-                byte_copy_per_line = std::min(byte_copy_per_line, (size_t)config_.region_w * 4);
-
-            size_t byte_pad_end_of_line = std::max(
-                ((size_t)decklink_format_desc_.width * 4) - byte_copy_per_line - byte_offset_dest_line, (size_t)0);
-
-            int copy_line_count = std::min(channel_format_desc_.height - y_skip_src_lines,
-                                           decklink_format_desc_.height - y_skip_dest_lines);
-            if (config_.region_h > 0) // If the user chose a height, respect that
-                copy_line_count = std::min(copy_line_count, config_.region_h);
-
-            for (int y = firstLine; y < y_skip_dest_lines; y += decklink_format_desc_.field_count) {
-                // Fill the line with black
-                std::memset(
-                    reinterpret_cast<char*>(image_data.get()) + (byte_count_dest_line * y), 0, byte_count_dest_line);
-            }
-
-            int firstFillLine = y_skip_dest_lines;
-            if (decklink_format_desc_.field_count != 1 && firstFillLine % 2 != firstLine)
-                firstFillLine += 1;
-            for (int y = firstFillLine; y < y_skip_dest_lines + copy_line_count;
-                 y += decklink_format_desc_.field_count) {
-                auto line_start_ptr   = reinterpret_cast<char*>(image_data.get()) + (long long)y * byte_count_dest_line;
-                auto line_content_ptr = line_start_ptr + byte_offset_dest_line; // Future
-
-                // Fill the start with black
-                if (byte_offset_dest_line > 0) {
-                    std::memset(line_start_ptr, 0, byte_offset_dest_line);
-                }
-
-                // Copy the pixels
-                std::memcpy(line_content_ptr,
-                            frame.image_data(0).data() + (long long)(y + y_skip_src_lines) * byte_count_src_line +
-                                byte_offset_src_line,
-                            byte_copy_per_line);
-
-                // Fill the end with black
-                if (byte_pad_end_of_line > 0) {
-                    std::memset(line_content_ptr + byte_copy_per_line, 0, byte_pad_end_of_line);
-                }
-            }
-
-            // Calculate the first line number to fill with black
-            int firstPadEndLine = y_skip_dest_lines + copy_line_count;
-            if (decklink_format_desc_.field_count != 1 && firstPadEndLine % 2 != firstLine)
-                firstPadEndLine += 1;
-            for (int y = firstPadEndLine; y < decklink_format_desc_.height; y += decklink_format_desc_.field_count) {
-                // Fill the line with black
-                std::memset(
-                    reinterpret_cast<char*>(image_data.get()) + (byte_count_dest_line * y), 0, byte_count_dest_line);
-            }
-        }
-        audio_data.insert(audio_data.end(), frame.audio_data().begin(), frame.audio_data().end());
-
-        return true;
-    }
-
-    core::video_format_desc get_decklink_format(const configuration&           config,
-                                                const core::video_format_desc& channel_format_desc)
-    {
-        if (config.format.format != core::video_format::invalid && config.format.format != channel_format_desc.format) {
-            if (config.format.format != core::video_format::invalid &&
-                config.format.format != core::video_format::custom &&
-                config.format.framerate == channel_format_desc.framerate) {
-                return config.format;
-            } else {
-                CASPAR_LOG(warning) << L"Ignoring specified format for decklink";
-            }
-        }
-
-        if (channel_format_desc.format == core::video_format::invalid ||
-            channel_format_desc.format == core::video_format::custom)
-            CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Decklink does not support the channel format"));
-
-        return channel_format_desc;
-    }
-
   public:
-    decklink_consumer(core::video_format_repository format_repository,
-                      const configuration&          config,
-                      core::video_format_desc       channel_format_desc,
-                      int                           channel_index)
-        : format_repository_(std::move(format_repository))
-        , channel_index_(channel_index)
+    decklink_consumer(const configuration& config, core::video_format_desc channel_format_desc, int channel_index)
+        : channel_index_(channel_index)
         , config_(config)
         , channel_format_desc_(std::move(channel_format_desc))
-        , decklink_format_desc_(get_decklink_format(config, channel_format_desc_))
+        , decklink_format_desc_(get_decklink_format(config.main, channel_format_desc_))
     {
-        if (config.duplex != configuration::duplex_t::default_duplex) {
-            set_duplex(iface_cast<IDeckLinkAttributes_v10_11>(decklink_),
-                       iface_cast<IDeckLinkConfiguration_v10_11>(decklink_),
-                       config.duplex,
-                       print());
-        }
-
-        if (config.keyer == configuration::keyer_t::external_separate_device_keyer) {
-            key_context_ = std::make_unique<key_video_context>(config, print());
-        }
-
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
         graph_->set_color("late-frame", diagnostics::color(0.6f, 0.3f, 0.3f));
         graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
@@ -523,14 +456,45 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         graph_->set_color("buffered-audio", diagnostics::color(0.9f, 0.9f, 0.5f));
         graph_->set_color("buffered-video", diagnostics::color(0.2f, 0.9f, 0.9f));
 
+        if (config.duplex != configuration::duplex_t::default_duplex) {
+            set_duplex(iface_cast<IDeckLinkAttributes_v10_11>(decklink_),
+                       iface_cast<IDeckLinkConfiguration_v10_11>(decklink_),
+                       config.duplex,
+                       print());
+        }
+
+        /*
         if (key_context_) {
             graph_->set_color("key-offset", diagnostics::color(1.0f, 0.0f, 0.0f));
         }
+        */
 
         graph_->set_text(print());
         diagnostics::register_graph(graph_);
 
-        enable_video(mode_->GetDisplayMode());
+        // If there are child devices, then
+        if (!config.children.empty() || config.keyer == configuration::keyer_t::external_separate_device_keyer) {
+            device_sync_group_ = 9; // TODO - random number
+            if (FAILED(configuration_->SetInt(bmdDeckLinkConfigPlaybackGroup, device_sync_group_))) {
+                device_sync_group_ = 0;
+                CASPAR_LOG(error) << print() << L" Failed to enable sync group.";
+            } else {
+                CASPAR_LOG(debug) << print() << L" Enabled sync group: " << device_sync_group_;
+            }
+        }
+
+        // create the child devices
+        for (auto& child_config : config_.children) {
+            child_device_contexts_.push_back(std::make_unique<child_device_context>(
+                config, child_config, channel_format_desc_, decklink_format_desc_, print(), device_sync_group_));
+        }
+        if (config.keyer == configuration::keyer_t::external_separate_device_keyer) {
+            // TODO - need to generate a config with a mangled id
+            // child_device_contexts_.push_back(
+            // std::make_unique<child_device_context>(config, child_config, print(), device_sync_group_));
+        }
+
+        enable_video();
 
         if (config.embedded_audio) {
             enable_audio();
@@ -554,6 +518,10 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
             std::shared_ptr<void> image_data(scalable_aligned_malloc(decklink_format_desc_.size, 64),
                                              scalable_aligned_free);
             schedule_next_video(image_data, nb_samples);
+
+            for (auto& context : child_device_contexts_) {
+                context->schedule_next_video(image_data, 0);
+            }
         }
 
         if (config.embedded_audio) {
@@ -589,32 +557,39 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         CASPAR_LOG(info) << print() << L" Enabled embedded-audio.";
     }
 
-    void enable_video(BMDDisplayMode display_mode)
+    void enable_video()
     {
-        if (FAILED(output_->EnableVideoOutput(display_mode, bmdVideoOutputFlagDefault))) {
-            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Could not enable fill video output."));
+        if (FAILED(output_->EnableVideoOutput(mode_->GetDisplayMode(),
+                                              device_sync_group_ > 0 ? bmdVideoOutputSynchronizeToPlaybackGroup
+                                                                     : bmdVideoOutputFlagDefault))) {
+            CASPAR_THROW_EXCEPTION(caspar_exception()
+                                   << msg_info(print() + L" Could not enable primary video output."));
         }
 
         if (FAILED(output_->SetScheduledFrameCompletionCallback(this))) {
             CASPAR_THROW_EXCEPTION(caspar_exception()
-                                   << msg_info(print() + L" Failed to set fill playback completion callback.")
+                                   << msg_info(print() + L" Failed to set primary playback completion callback.")
                                    << boost::errinfo_api_function("SetScheduledFrameCompletionCallback"));
         }
 
-        if (key_context_) {
-            key_context_->enable_video(display_mode, [this]() { return print(); });
+        for (auto& context : child_device_contexts_) {
+            context->enable_video([this]() { return print(); });
         }
     }
 
     void start_playback()
     {
         if (FAILED(output_->StartScheduledPlayback(0, decklink_format_desc_.time_scale, 1.0))) {
-            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to schedule fill playback."));
+            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to schedule primary playback."));
         }
 
-        if (key_context_ &&
-            FAILED(key_context_->output_->StartScheduledPlayback(0, decklink_format_desc_.time_scale, 1.0))) {
-            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to schedule key playback."));
+        if (device_sync_group_ == 0) {
+            for (auto& context : child_device_contexts_) {
+                if (FAILED(context->output_->StartScheduledPlayback(0, decklink_format_desc_.time_scale, 1.0))) {
+                    CASPAR_THROW_EXCEPTION(caspar_exception()
+                                           << msg_info(print() + L" Failed to schedule secondary playback."));
+                }
+            }
         }
     }
 
@@ -646,12 +621,14 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
             auto dframe = reinterpret_cast<decklink_frame*>(completed_frame);
             ++scheduled_frames_completed_;
 
+            /*
             if (key_context_) {
                 graph_->set_value(
                     "key-offset",
                     static_cast<double>(scheduled_frames_completed_ - key_context_->scheduled_frames_completed_) * 0.1 +
                         0.5);
             }
+            */
 
             if (result == bmdOutputFrameDisplayedLate) {
                 graph_->set_tag(diagnostics::tag_severity::WARNING, "late-frame");
@@ -677,28 +654,53 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
                 }
             }
 
-            std::shared_ptr<void>     image_data(scalable_aligned_malloc(decklink_format_desc_.size, 64),
-                                                 scalable_aligned_free);
-            std::vector<std::int32_t> audio_data;
+            core::const_frame frame1 = pop();
+            core::const_frame frame2;
 
+            bool isInterlaced = mode_->GetFieldDominance() != bmdProgressiveFrame;
             if (mode_->GetFieldDominance() != bmdProgressiveFrame) {
-                if (!doFrame(image_data, audio_data, mode_->GetFieldDominance() == bmdUpperFieldFirst))
-                    return E_FAIL;
-
-                if (!doFrame(image_data, audio_data, mode_->GetFieldDominance() != bmdUpperFieldFirst))
-                    return E_FAIL;
-            } else {
-                if (!doFrame(image_data, audio_data, true))
-                    return E_FAIL;
+                // If the main is not progressive, then pop the second frame
+                frame2 = pop();
             }
 
-            const auto nb_samples = static_cast<int>(audio_data.size()) / decklink_format_desc_.audio_channels;
+            if (abort_request_)
+                return E_FAIL;
 
-            schedule_next_video(image_data, nb_samples);
+            {
+                auto image_data = convert_frame_pair(channel_format_desc_,
+                                                     decklink_format_desc_,
+                                                     config_.main,
+                                                     frame1,
+                                                     frame2,
+                                                     mode_->GetFieldDominance());
+
+                const auto nb_samples = static_cast<int>(frame1.audio_data().size() + frame2.audio_data().size()) /
+                                        decklink_format_desc_.audio_channels;
+
+                schedule_next_video(image_data, nb_samples);
+            }
+
+            // Send frame to children
+            for (auto& context : child_device_contexts_) {
+                context->schedule_frame(frame1);
+                if (isInterlaced) {
+                    context->schedule_frame(frame2);
+                }
+            }
 
             if (config_.embedded_audio) {
+                std::vector<std::int32_t> audio_data;
+                audio_data.insert(audio_data.end(), frame1.audio_data().begin(), frame1.audio_data().end());
+                if (isInterlaced) {
+                    audio_data.insert(audio_data.end(), frame2.audio_data().begin(), frame2.audio_data().end());
+                }
+
+                // TODO: is this reliable?
+                const auto nb_samples = static_cast<int>(audio_data.size()) / decklink_format_desc_.audio_channels;
+
                 schedule_next_audio(std::move(audio_data), nb_samples);
             }
+
         } catch (...) {
             std::lock_guard<std::mutex> lock(exception_mutex_);
             exception_ = std::current_exception();
@@ -737,24 +739,14 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
             CASPAR_LOG(error) << print() << L" Failed to schedule audio.";
         }
 
-        audio_scheduled_ += nb_samples;
+        // TODO - audio to child devices?
+
+        audio_scheduled_ += nb_samples; // TODO - what if there are too many/few samples in this frame?
     }
 
-    void schedule_next_video(std::shared_ptr<void> fill, int nb_samples)
+    void schedule_next_video(std::shared_ptr<void> image_data, int nb_samples)
     {
-        std::shared_ptr<void> key;
-
-        if (key_context_ || config_.key_only) {
-            key = std::shared_ptr<void>(scalable_aligned_malloc(decklink_format_desc_.size, 64), scalable_aligned_free);
-
-            aligned_memshfl(
-                key.get(), fill.get(), decklink_format_desc_.size, 0x0F0F0F0F, 0x0B0B0B0B, 0x07070707, 0x03030303);
-
-            if (config_.key_only) {
-                fill = key;
-            }
-        }
-
+        /*
         if (key_context_) {
             auto key_frame =
                 wrap_raw<com_ptr, IDeckLinkVideoFrame>(new decklink_frame(key, decklink_format_desc_, nb_samples));
@@ -765,14 +757,15 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
                 CASPAR_LOG(error) << print() << L" Failed to schedule key video.";
             }
         }
+         */
 
-        auto fill_frame =
-            wrap_raw<com_ptr, IDeckLinkVideoFrame>(new decklink_frame(fill, decklink_format_desc_, nb_samples));
+        auto fill_frame = wrap_raw<com_ptr, IDeckLinkVideoFrame>(
+            new decklink_frame(std::move(image_data), decklink_format_desc_, nb_samples));
         if (FAILED(output_->ScheduleVideoFrame(get_raw(fill_frame),
                                                video_scheduled_,
                                                decklink_format_desc_.duration,
                                                decklink_format_desc_.time_scale))) {
-            CASPAR_LOG(error) << print() << L" Failed to schedule fill video.";
+            CASPAR_LOG(error) << print() << L" Failed to schedule primary video.";
         }
 
         video_scheduled_ += decklink_format_desc_.duration;
@@ -800,31 +793,32 @@ struct decklink_consumer : public IDeckLinkVideoOutputCallback
         return !abort_request_;
     }
 
-    std::wstring print() const
+    std::wstring print() const override
     {
-        if (config_.keyer == configuration::keyer_t::external_separate_device_keyer) {
-            return model_name_ + L" [" + std::to_wstring(channel_index_) + L"-" +
-                   std::to_wstring(config_.device_index) + L"&&" + std::to_wstring(config_.key_device_index()) + L"|" +
-                   decklink_format_desc_.name + L"]";
+        std::wstringstream buffer;
+
+        buffer << model_name_ << L" [" + std::to_wstring(channel_index_) << L"-"
+               << std::to_wstring(config_.main.device_index) << L"|" << decklink_format_desc_.name << L"]";
+
+        for (auto& context : child_device_contexts_) {
+            buffer << L" && " + context->print_single();
         }
-        return model_name_ + L" [" + std::to_wstring(channel_index_) + L"-" + std::to_wstring(config_.device_index) +
-               L"|" + decklink_format_desc_.name + L"]";
+
+        return buffer.str();
     }
 };
 
 struct decklink_consumer_proxy : public core::frame_consumer
 {
-    const core::video_format_repository format_repository_;
-    const configuration                 config_;
-    std::unique_ptr<decklink_consumer>  consumer_;
-    core::video_format_desc             format_desc_;
-    executor                            executor_;
+    const configuration                config_;
+    std::unique_ptr<decklink_consumer> consumer_;
+    core::video_format_desc            format_desc_;
+    executor                           executor_;
 
   public:
-    explicit decklink_consumer_proxy(core::video_format_repository format_repository, const configuration& config)
-        : format_repository_(std::move(format_repository))
-        , config_(config)
-        , executor_(L"decklink_consumer[" + std::to_wstring(config.device_index) + L"]")
+    explicit decklink_consumer_proxy(const configuration& config)
+        : config_(config)
+        , executor_(L"decklink_consumer[" + std::to_wstring(config.main.device_index) + L"]")
     {
         executor_.begin_invoke([=] { com_initialize(); });
     }
@@ -843,7 +837,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
         format_desc_ = format_desc;
         executor_.invoke([=] {
             consumer_.reset();
-            consumer_ = std::make_unique<decklink_consumer>(format_repository_, config_, format_desc, channel_index);
+            consumer_ = std::make_unique<decklink_consumer>(config_, format_desc, channel_index);
         });
     }
 
@@ -856,7 +850,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
 
     std::wstring name() const override { return L"decklink"; }
 
-    int index() const override { return 300 + config_.device_index; }
+    int index() const override { return 300 + config_.main.device_index; }
 
     bool has_synchronization_clock() const override { return true; }
 
@@ -864,14 +858,14 @@ struct decklink_consumer_proxy : public core::frame_consumer
     {
         core::monitor::state state;
 
-        state["decklink/index"]          = config_.device_index;
+        state["decklink/index"]          = config_.main.device_index;
         state["decklink/embedded-audio"] = config_.embedded_audio;
-        state["decklink/key-only"]       = config_.key_only;
+        state["decklink/key-only"]       = config_.main.key_only;
         state["decklink/buffer-depth"]   = config_.base_buffer_depth;
-        if (config_.format.format == core::video_format::invalid) {
+        if (config_.main.format.format == core::video_format::invalid) {
             state["decklink/video-mode"] = format_desc_.name;
         } else {
-            state["decklink/video-mode"] = config_.format.name;
+            state["decklink/video-mode"] = config_.main.format.name;
         }
 
         if (config_.keyer == configuration::keyer_t::external_keyer) {
@@ -888,13 +882,13 @@ struct decklink_consumer_proxy : public core::frame_consumer
             state["decklink/latency"] = std::wstring(L"normal");
         }
 
-        if (config_.has_subregion_geometry()) {
-            state["decklink/subregion/src-x"]  = config_.src_x;
-            state["decklink/subregion/src-y"]  = config_.src_y;
-            state["decklink/subregion/src-x"]  = config_.dest_x;
-            state["decklink/subregion/dest-y"] = config_.dest_y;
-            state["decklink/subregion/width"]  = config_.region_w;
-            state["decklink/subregion/height"] = config_.region_h;
+        if (config_.main.has_subregion_geometry()) {
+            state["decklink/subregion/src-x"]  = config_.main.src_x;
+            state["decklink/subregion/src-y"]  = config_.main.src_y;
+            state["decklink/subregion/src-x"]  = config_.main.dest_x;
+            state["decklink/subregion/dest-y"] = config_.main.dest_y;
+            state["decklink/subregion/width"]  = config_.main.region_w;
+            state["decklink/subregion/height"] = config_.main.region_h;
         }
 
         return state;
@@ -912,7 +906,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     configuration config;
 
     if (params.size() > 1)
-        config.device_index = std::stoi(params.at(1));
+        config.main.device_index = std::stoi(params.at(1));
 
     if (contains_param(L"INTERNAL_KEY", params)) {
         config.keyer = configuration::keyer_t::internal_keyer;
@@ -935,9 +929,9 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     }
 
     config.embedded_audio = contains_param(L"EMBEDDED_AUDIO", params);
-    config.key_only       = contains_param(L"KEY_ONLY", params);
+    config.main.key_only  = contains_param(L"KEY_ONLY", params);
 
-    return spl::make_shared<decklink_consumer_proxy>(format_repository, config);
+    return spl::make_shared<decklink_consumer_proxy>(config);
 }
 
 spl::shared_ptr<core::frame_consumer>
@@ -970,31 +964,24 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
         config.latency = configuration::latency_t::normal_latency;
     }
 
-    config.key_only          = ptree.get(L"key-only", config.key_only);
-    config.device_index      = ptree.get(L"device", config.device_index);
-    config.key_device_idx    = ptree.get(L"key-device", config.key_device_idx);
+    config.main = parse_output_config(ptree, format_repository);
+    if (config.main.device_index == -1)
+        config.main.device_index = 1;
+
     config.embedded_audio    = ptree.get(L"embedded-audio", config.embedded_audio);
     config.base_buffer_depth = ptree.get(L"buffer-depth", config.base_buffer_depth);
 
-    auto format_desc_str = ptree.get(L"video-mode", L"");
-    if (!format_desc_str.empty()) {
-        auto format_desc = format_repository.find(format_desc_str);
-        if (format_desc.format == core::video_format::invalid || format_desc.format == core::video_format::custom)
-            CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Invalid video-mode: " + format_desc_str));
-        config.format = format_desc;
+    if (ptree.get_child_optional(L"ports")) {
+        for (auto& xml_port : ptree | witerate_children(L"ports") | welement_context_iteration) {
+            ptree_verify_element_name(xml_port, L"port");
+
+            output_configuration port_config = parse_output_config(xml_port.second, format_repository);
+
+            config.children.push_back(port_config);
+        }
     }
 
-    auto subregion_tree = ptree.get_child_optional(L"subregion");
-    if (subregion_tree) {
-        config.src_x    = subregion_tree->get(L"src-x", config.src_x);
-        config.src_y    = subregion_tree->get(L"src-y", config.src_y);
-        config.dest_x   = subregion_tree->get(L"dest-x", config.dest_x);
-        config.dest_y   = subregion_tree->get(L"dest-y", config.dest_y);
-        config.region_w = subregion_tree->get(L"width", config.region_w);
-        config.region_h = subregion_tree->get(L"height", config.region_h);
-    }
-
-    return spl::make_shared<decklink_consumer_proxy>(format_repository, config);
+    return spl::make_shared<decklink_consumer_proxy>(config);
 }
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -471,7 +471,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         diagnostics::register_graph(graph_);
 
         // If there are additional ports devices, then enable the sync group
-        if (!config.secondaries.empty() || config.keyer == configuration::keyer_t::external_separate_device_keyer) {
+        if (!config.secondaries.empty()) {
             // A unique id is needed for this group, this is simpler than a random number
             device_sync_group_ = config.primary.device_index;
 
@@ -491,15 +491,6 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                                                                                          decklink_format_desc_,
                                                                                          print(),
                                                                                          device_sync_group_));
-        }
-        if (config.keyer == configuration::keyer_t::external_separate_device_keyer) {
-            port_configuration port_config = config_.primary; // Explicitly copy the config
-            port_config.device_index =
-                config.key_device_idx == 0 ? config_.primary.device_index + 1 : config.key_device_idx;
-            port_config.key_only = true;
-
-            secondary_port_contexts_.push_back(std::make_unique<decklink_secondary_port>(
-                config, port_config, channel_format_desc_, decklink_format_desc_, print(), device_sync_group_));
         }
 
         enable_video();
@@ -916,8 +907,6 @@ struct decklink_consumer_proxy : public core::frame_consumer
             state["decklink/keyer"] = std::wstring(L"external");
         } else if (config_.keyer == configuration::keyer_t::internal_keyer) {
             state["decklink/keyer"] = std::wstring(L"internal");
-        } else if (config_.keyer == configuration::keyer_t::external_separate_device_keyer) {
-            state["decklink/keyer"] = std::wstring(L"external_separate_device");
         }
 
         if (config_.latency == configuration::latency_t::low_latency) {
@@ -934,6 +923,8 @@ struct decklink_consumer_proxy : public core::frame_consumer
             state["decklink/subregion/width"]  = config_.primary.region_w;
             state["decklink/subregion/height"] = config_.primary.region_h;
         }
+
+        // TODO - include secondary ports
 
         return state;
     }

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -282,6 +282,11 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
         , channel_format_desc_(std::move(channel_format_desc))
         , decklink_format_desc_(get_decklink_format(output_config_, main_decklink_format_desc, print))
     {
+        if (main_decklink_format_desc.format != decklink_format_desc_.format) {
+            CASPAR_LOG(info) << print << L" Disabling sync group for output with different format.";
+            device_sync_group_ = 0;
+        }
+
         if (config.duplex != configuration::duplex_t::default_duplex) {
             set_duplex(iface_cast<IDeckLinkAttributes_v10_11>(decklink_),
                        iface_cast<IDeckLinkConfiguration_v10_11>(decklink_),

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -239,7 +239,8 @@ struct decklink_base
             config.format.format != fallback_format_desc.format) {
             if (config.format.format != core::video_format::invalid &&
                 config.format.format != core::video_format::custom &&
-                config.format.framerate == fallback_format_desc.framerate) {
+                config.format.framerate * config.format.field_count ==
+                    fallback_format_desc.framerate * fallback_format_desc.field_count) {
                 return config.format;
             } else {
                 CASPAR_LOG(warning) << print() << L"Ignoring specified format for decklink";

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -407,6 +407,8 @@ struct child_device_context
 
         // Let the primary callback keep the pace, so no scheduling here.
 
+        CASPAR_LOG(info) << print_single() << scheduled_frames_completed_ << " " << video_scheduled_;
+         
         return S_OK;
     }
 };
@@ -629,6 +631,8 @@ struct decklink_consumer
             auto dframe = reinterpret_cast<decklink_frame*>(completed_frame);
             ++scheduled_frames_completed_;
 
+            CASPAR_LOG(info) << print() << scheduled_frames_completed_ << " " << video_scheduled_;
+
             /*
             if (key_context_) {
                 graph_->set_value(
@@ -682,7 +686,12 @@ struct decklink_consumer
                                                      frame2,
                                                      mode_->GetFieldDominance());
 
-                const auto nb_samples = static_cast<int>(frame1.audio_data().size() + frame2.audio_data().size()) /
+                auto count = frame1.audio_data().size();
+                if (frame2) {
+                    count +=  frame2.audio_data().size();
+                }
+
+                const auto nb_samples = static_cast<int>(count) /
                                         decklink_format_desc_.audio_channels;
 
                 schedule_next_video(image_data, nb_samples);

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "decklink_consumer.h"
 #include "frame.h"
+#include "monitor.h"
 
 #include "../decklink.h"
 #include "../util/util.h"
@@ -889,45 +890,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
 
     [[nodiscard]] bool has_synchronization_clock() const override { return true; }
 
-    [[nodiscard]] core::monitor::state state() const override
-    {
-        core::monitor::state state;
-
-        state["decklink/index"]          = config_.primary.device_index;
-        state["decklink/embedded-audio"] = config_.embedded_audio;
-        state["decklink/key-only"]       = config_.primary.key_only;
-        state["decklink/buffer-depth"]   = config_.base_buffer_depth;
-        if (config_.primary.format.format == core::video_format::invalid) {
-            state["decklink/video-mode"] = format_desc_.name;
-        } else {
-            state["decklink/video-mode"] = config_.primary.format.name;
-        }
-
-        if (config_.keyer == configuration::keyer_t::external_keyer) {
-            state["decklink/keyer"] = std::wstring(L"external");
-        } else if (config_.keyer == configuration::keyer_t::internal_keyer) {
-            state["decklink/keyer"] = std::wstring(L"internal");
-        }
-
-        if (config_.latency == configuration::latency_t::low_latency) {
-            state["decklink/latency"] = std::wstring(L"low");
-        } else if (config_.latency == configuration::latency_t::normal_latency) {
-            state["decklink/latency"] = std::wstring(L"normal");
-        }
-
-        if (config_.primary.has_subregion_geometry()) {
-            state["decklink/subregion/src-x"]  = config_.primary.src_x;
-            state["decklink/subregion/src-y"]  = config_.primary.src_y;
-            state["decklink/subregion/src-x"]  = config_.primary.dest_x;
-            state["decklink/subregion/dest-y"] = config_.primary.dest_y;
-            state["decklink/subregion/width"]  = config_.primary.region_w;
-            state["decklink/subregion/height"] = config_.primary.region_h;
-        }
-
-        // TODO - include secondary ports
-
-        return state;
-    }
+    [[nodiscard]] core::monitor::state state() const override { return get_state_for_config(config_, format_desc_); }
 };
 
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -311,7 +311,7 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
                                    << boost::errinfo_api_function("SetScheduledFrameCompletionCallback"));
     }
 
-    ~decklink_secondary_port() override
+    ~decklink_secondary_port()
     {
         if (output_) {
             if (device_sync_group_ == 0) {
@@ -540,7 +540,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         start_playback();
     }
 
-    ~decklink_consumer() override
+    ~decklink_consumer()
     {
         abort_request_ = true;
         buffer_cond_.notify_all();

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -681,6 +681,7 @@ struct decklink_consumer
             }
 
             // Send frame to children
+            // TODO - parallel?
             for (auto& context : child_device_contexts_) {
                 context->schedule_frame(frame1);
                 if (isInterlaced) {

--- a/src/modules/decklink/consumer/frame.cpp
+++ b/src/modules/decklink/consumer/frame.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "../StdAfx.h"
+
+#include "frame.h"
+
+#include <common/memshfl.h>
+
+#include <tbb/scalable_allocator.h>
+
+namespace caspar { namespace decklink {
+
+std::shared_ptr<void> convert_to_key_only(const std::shared_ptr<void>& image_data, std::size_t byte_count)
+{
+    auto key_data = std::shared_ptr<void>(scalable_aligned_malloc(byte_count, 64), scalable_aligned_free);
+
+    aligned_memshfl(key_data.get(), image_data.get(), byte_count, 0x0F0F0F0F, 0x0B0B0B0B, 0x07070707, 0x03030303);
+
+    return key_data;
+}
+
+void convert_frame(const core::video_format_desc& channel_format_desc,
+                   const core::video_format_desc& decklink_format_desc,
+                   const output_configuration&    config,
+                   std::shared_ptr<void>&         image_data,
+                   bool                           topField,
+                   const core::const_frame&       frame)
+{
+    // No point copying an empty frame
+    if (!frame)
+        return;
+
+    int firstLine = topField ? 0 : 1;
+
+    if (channel_format_desc.format == decklink_format_desc.format && config.src_x == 0 && config.src_y == 0 &&
+        config.region_w == 0 && config.region_h == 0 && config.dest_x == 0 && config.dest_y == 0) {
+        // Fast path
+        size_t byte_count_line = (size_t)decklink_format_desc.width * 4;
+        for (int y = firstLine; y < decklink_format_desc.height; y += decklink_format_desc.field_count) {
+            std::memcpy(reinterpret_cast<char*>(image_data.get()) + (long long)y * byte_count_line,
+                        frame.image_data(0).data() + (long long)y * byte_count_line,
+                        byte_count_line);
+        }
+    } else {
+        // Take a sub-region
+
+        // Some repetetive numbers
+        size_t byte_count_dest_line  = (size_t)decklink_format_desc.width * 4;
+        size_t byte_count_src_line   = (size_t)channel_format_desc.width * 4;
+        size_t byte_offset_src_line  = std::max(0, (config.src_x * 4));
+        size_t byte_offset_dest_line = std::max(0, (config.dest_x * 4));
+        int    y_skip_src_lines      = std::max(0, config.src_y);
+        int    y_skip_dest_lines     = std::max(0, config.dest_y);
+
+        size_t byte_copy_per_line =
+            std::min(byte_count_src_line - byte_offset_src_line, byte_count_dest_line - byte_offset_dest_line);
+        if (config.region_w > 0) // If the user chose a width, respect that
+            byte_copy_per_line = std::min(byte_copy_per_line, (size_t)config.region_w * 4);
+
+        size_t byte_pad_end_of_line =
+            std::max(((size_t)decklink_format_desc.width * 4) - byte_copy_per_line - byte_offset_dest_line, (size_t)0);
+
+        int copy_line_count =
+            std::min(channel_format_desc.height - y_skip_src_lines, decklink_format_desc.height - y_skip_dest_lines);
+        if (config.region_h > 0) // If the user chose a height, respect that
+            copy_line_count = std::min(copy_line_count, config.region_h);
+
+        for (int y = firstLine; y < y_skip_dest_lines; y += decklink_format_desc.field_count) {
+            // Fill the line with black
+            std::memset(
+                reinterpret_cast<char*>(image_data.get()) + (byte_count_dest_line * y), 0, byte_count_dest_line);
+        }
+
+        int firstFillLine = y_skip_dest_lines;
+        if (decklink_format_desc.field_count != 1 && firstFillLine % 2 != firstLine)
+            firstFillLine += 1;
+        for (int y = firstFillLine; y < y_skip_dest_lines + copy_line_count; y += decklink_format_desc.field_count) {
+            auto line_start_ptr   = reinterpret_cast<char*>(image_data.get()) + (long long)y * byte_count_dest_line;
+            auto line_content_ptr = line_start_ptr + byte_offset_dest_line; // Future
+
+            // Fill the start with black
+            if (byte_offset_dest_line > 0) {
+                std::memset(line_start_ptr, 0, byte_offset_dest_line);
+            }
+
+            // Copy the pixels
+            std::memcpy(line_content_ptr,
+                        frame.image_data(0).data() + (long long)(y + y_skip_src_lines) * byte_count_src_line +
+                            byte_offset_src_line,
+                        byte_copy_per_line);
+
+            // Fill the end with black
+            if (byte_pad_end_of_line > 0) {
+                std::memset(line_content_ptr + byte_copy_per_line, 0, byte_pad_end_of_line);
+            }
+        }
+
+        // Calculate the first line number to fill with black
+        int firstPadEndLine = y_skip_dest_lines + copy_line_count;
+        if (decklink_format_desc.field_count != 1 && firstPadEndLine % 2 != firstLine)
+            firstPadEndLine += 1;
+        for (int y = firstPadEndLine; y < decklink_format_desc.height; y += decklink_format_desc.field_count) {
+            // Fill the line with black
+            std::memset(
+                reinterpret_cast<char*>(image_data.get()) + (byte_count_dest_line * y), 0, byte_count_dest_line);
+        }
+    }
+}
+
+std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
+                                         const core::video_format_desc& decklink_format_desc,
+                                         const output_configuration&    config,
+                                         const core::const_frame&       frame1,
+                                         const core::const_frame&       frame2,
+                                         BMDFieldDominance              field_dominance)
+{
+    std::shared_ptr<void> image_data(scalable_aligned_malloc(decklink_format_desc.size, 64), scalable_aligned_free);
+
+    if (field_dominance != bmdProgressiveFrame) {
+        convert_frame(channel_format_desc,
+                      decklink_format_desc,
+                      config,
+                      image_data,
+                      field_dominance == bmdUpperFieldFirst,
+                      frame1);
+
+        convert_frame(channel_format_desc,
+                      decklink_format_desc,
+                      config,
+                      image_data,
+                      field_dominance != bmdUpperFieldFirst,
+                      frame2);
+
+    } else {
+        convert_frame(channel_format_desc, decklink_format_desc, config, image_data, true, frame1);
+    }
+
+    if (config.key_only) {
+        image_data = convert_to_key_only(image_data, decklink_format_desc.size);
+    }
+
+    return image_data;
+}
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/frame.cpp
+++ b/src/modules/decklink/consumer/frame.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<void> convert_to_key_only(const std::shared_ptr<void>& image_dat
 
 void convert_frame(const core::video_format_desc& channel_format_desc,
                    const core::video_format_desc& decklink_format_desc,
-                   const output_configuration&    config,
+                   const port_configuration&    config,
                    std::shared_ptr<void>&         image_data,
                    bool                           topField,
                    const core::const_frame&       frame)
@@ -128,7 +128,7 @@ void convert_frame(const core::video_format_desc& channel_format_desc,
 
 std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
                                          const core::video_format_desc& decklink_format_desc,
-                                         const output_configuration&    config,
+                                         const port_configuration&    config,
                                          const core::const_frame&       frame1,
                                          const core::const_frame&       frame2,
                                          BMDFieldDominance              field_dominance)

--- a/src/modules/decklink/consumer/frame.cpp
+++ b/src/modules/decklink/consumer/frame.cpp
@@ -126,7 +126,7 @@ void convert_frame(const core::video_format_desc& channel_format_desc,
     }
 }
 
-std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
+std::shared_ptr<void> convert_frame_for_port(const core::video_format_desc& channel_format_desc,
                                          const core::video_format_desc& decklink_format_desc,
                                          const port_configuration&    config,
                                          const core::const_frame&       frame1,

--- a/src/modules/decklink/consumer/frame.h
+++ b/src/modules/decklink/consumer/frame.h
@@ -34,18 +34,9 @@
 
 namespace caspar { namespace decklink {
 
-std::shared_ptr<void> convert_to_key_only(const std::shared_ptr<void>& image_data, std::size_t byte_count);
-
-void convert_frame(const core::video_format_desc& channel_format_desc,
-                   const core::video_format_desc& decklink_format_desc,
-                   const port_configuration&    config,
-                   std::shared_ptr<void>&         image_data,
-                   bool                           topField,
-                   const core::const_frame&       frame);
-
-std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
+std::shared_ptr<void> convert_frame_for_port(const core::video_format_desc& channel_format_desc,
                                          const core::video_format_desc& decklink_format_desc,
-                                         const port_configuration&    config,
+                                         const port_configuration&      config,
                                          const core::const_frame&       frame1,
                                          const core::const_frame&       frame2,
                                          BMDFieldDominance              field_dominance);

--- a/src/modules/decklink/consumer/frame.h
+++ b/src/modules/decklink/consumer/frame.h
@@ -38,14 +38,14 @@ std::shared_ptr<void> convert_to_key_only(const std::shared_ptr<void>& image_dat
 
 void convert_frame(const core::video_format_desc& channel_format_desc,
                    const core::video_format_desc& decklink_format_desc,
-                   const output_configuration&    config,
+                   const port_configuration&    config,
                    std::shared_ptr<void>&         image_data,
                    bool                           topField,
                    const core::const_frame&       frame);
 
 std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
                                          const core::video_format_desc& decklink_format_desc,
-                                         const output_configuration&    config,
+                                         const port_configuration&    config,
                                          const core::const_frame&       frame1,
                                          const core::const_frame&       frame2,
                                          BMDFieldDominance              field_dominance);

--- a/src/modules/decklink/consumer/frame.h
+++ b/src/modules/decklink/consumer/frame.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include "../StdAfx.h"
+
+#include "config.h"
+
+#include "../decklink_api.h"
+
+#include <core/frame/frame.h>
+#include <core/video_format.h>
+
+#include <memory>
+
+namespace caspar { namespace decklink {
+
+std::shared_ptr<void> convert_to_key_only(const std::shared_ptr<void>& image_data, std::size_t byte_count);
+
+void convert_frame(const core::video_format_desc& channel_format_desc,
+                   const core::video_format_desc& decklink_format_desc,
+                   const output_configuration&    config,
+                   std::shared_ptr<void>&         image_data,
+                   bool                           topField,
+                   const core::const_frame&       frame);
+
+std::shared_ptr<void> convert_frame_pair(const core::video_format_desc& channel_format_desc,
+                                         const core::video_format_desc& decklink_format_desc,
+                                         const output_configuration&    config,
+                                         const core::const_frame&       frame1,
+                                         const core::const_frame&       frame2,
+                                         BMDFieldDominance              field_dominance);
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/monitor.cpp
+++ b/src/modules/decklink/consumer/monitor.cpp
@@ -23,8 +23,34 @@
 
 namespace caspar { namespace decklink {
 
+core::monitor::state get_state_for_port(const port_configuration&      port_config,
+                                        const core::video_format_desc& channel_format)
+{
+    core::monitor::state state;
 
-core::monitor::state get_state_for_config(const configuration& config, const core::video_format_desc& channel_format){
+    state["index"]    = port_config.device_index;
+    state["key-only"] = port_config.key_only;
+
+    if (port_config.format.format == core::video_format::invalid) {
+        state["video-mode"] = channel_format.name;
+    } else {
+        state["video-mode"] = port_config.format.name;
+    }
+
+    if (port_config.has_subregion_geometry()) {
+        state["subregion/src-x"]  = port_config.src_x;
+        state["subregion/src-y"]  = port_config.src_y;
+        state["subregion/src-x"]  = port_config.dest_x;
+        state["subregion/dest-y"] = port_config.dest_y;
+        state["subregion/width"]  = port_config.region_w;
+        state["subregion/height"] = port_config.region_h;
+    }
+
+    return state;
+}
+
+core::monitor::state get_state_for_config(const configuration& config, const core::video_format_desc& channel_format)
+{
     core::monitor::state state;
 
     state["decklink"] = get_state_for_port(config.primary, channel_format);
@@ -51,30 +77,5 @@ core::monitor::state get_state_for_config(const configuration& config, const cor
 
     return state;
 }
-core::monitor::state get_state_for_port(const port_configuration& port_config, const core::video_format_desc& channel_format)
-{
-    core::monitor::state state;
-
-    state["index"]    = port_config.device_index;
-    state["key-only"] = port_config.key_only;
-
-    if (port_config.format.format == core::video_format::invalid) {
-        state["video-mode"] = channel_format.name;
-    } else {
-        state["video-mode"] = port_config.format.name;
-    }
-
-    if (port_config.has_subregion_geometry()) {
-        state["subregion/src-x"]  = port_config.src_x;
-        state["subregion/src-y"]  = port_config.src_y;
-        state["subregion/src-x"]  = port_config.dest_x;
-        state["subregion/dest-y"] = port_config.dest_y;
-        state["subregion/width"]  = port_config.region_w;
-        state["subregion/height"] = port_config.region_h;
-    }
-
-    return state;
-}
-
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/monitor.cpp
+++ b/src/modules/decklink/consumer/monitor.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "monitor.h"
+
+namespace caspar { namespace decklink {
+
+
+core::monitor::state get_state_for_config(const configuration& config, const core::video_format_desc& channel_format){
+    core::monitor::state state;
+
+    state["decklink"] = get_state_for_port(config.primary, channel_format);
+
+    state["decklink/embedded-audio"] = config.embedded_audio;
+    state["decklink/buffer-depth"]   = config.base_buffer_depth;
+
+    if (config.keyer == configuration::keyer_t::external_keyer) {
+        state["decklink/keyer"] = std::wstring(L"external");
+    } else if (config.keyer == configuration::keyer_t::internal_keyer) {
+        state["decklink/keyer"] = std::wstring(L"internal");
+    }
+
+    if (config.latency == configuration::latency_t::low_latency) {
+        state["decklink/latency"] = std::wstring(L"low");
+    } else if (config.latency == configuration::latency_t::normal_latency) {
+        state["decklink/latency"] = std::wstring(L"normal");
+    }
+
+    int index = 0;
+    for (auto& port_config : config.secondaries) {
+        state["decklink/ports"][index++] = get_state_for_port(port_config, channel_format);
+    }
+
+    return state;
+}
+core::monitor::state get_state_for_port(const port_configuration& port_config, const core::video_format_desc& channel_format)
+{
+    core::monitor::state state;
+
+    state["index"]    = port_config.device_index;
+    state["key-only"] = port_config.key_only;
+
+    if (port_config.format.format == core::video_format::invalid) {
+        state["video-mode"] = channel_format.name;
+    } else {
+        state["video-mode"] = port_config.format.name;
+    }
+
+    if (port_config.has_subregion_geometry()) {
+        state["subregion/src-x"]  = port_config.src_x;
+        state["subregion/src-y"]  = port_config.src_y;
+        state["subregion/src-x"]  = port_config.dest_x;
+        state["subregion/dest-y"] = port_config.dest_y;
+        state["subregion/width"]  = port_config.region_w;
+        state["subregion/height"] = port_config.region_h;
+    }
+
+    return state;
+}
+
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/monitor.h
+++ b/src/modules/decklink/consumer/monitor.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include "config.h"
+
+#include <core/monitor/monitor.h>
+
+namespace caspar { namespace decklink {
+
+core::monitor::state get_state_for_config(const configuration& config, const core::video_format_desc& channel_format);
+
+}} // namespace caspar::decklink

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -96,6 +96,9 @@
                     <height>0 (height of the region to copy. 0 means no-limit)</height>
                 </subregion>
 
+                <wait-for-reference>auto [auto|enable|disable]</wait-for-reference>
+                <wait-for-reference-duration>10 (seconds)</wait-for-reference-duration>
+
                 <ports>
                     (Add secondary ports to be run in sync with the primary. This allows for splitting a wide channel across multiple decklinks, with sync across the outputs guaranteed by the driver on supported cards)
                     <port>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -80,7 +80,7 @@
         <consumers>
             <decklink>
                 <device>[1..]</device>
-                <key-device>device + 1 [1..]</key-device>
+                <key-device>device + 1 [1..] (This is only used with the external_separate_device mode)</key-device>
                 <embedded-audio>false [true|false]</embedded-audio>
                 <latency>normal [normal|low|default]</latency>
                 <keyer>external [external|external_separate_device|internal|default]</keyer>
@@ -95,6 +95,23 @@
                     <width>0 (width of the region to copy. 0 means no-limit)</width>
                     <height>0 (height of the region to copy. 0 means no-limit)</height>
                 </subregion>
+
+                <ports>
+                    (Add secondary ports to be run in sync with the primary. This allows for splitting a wide channel across multiple decklinks, with sync across the outputs guaranteed by the driver on supported cards)
+                    <port>
+                        <device>[1..]</device>
+                        <key-only>false [true|false]</key-only>
+                        <video-mode>(Run the decklink at a different video-mode. Note: the framerate must match that of the channel)</video-mode>
+                        <subregion>
+                            <src-x>0 (x offset into the channel)</src-x>
+                            <src-y>0 (y offset into the channel)</src-y>
+                            <dest-x>0 (x offset of the video onto the output)</dest-x>
+                            <dest-y>0 (y offset of the video onto the output)</dest-y>
+                            <width>0 (width of the region to copy. 0 means no-limit)</width>
+                            <height>0 (height of the region to copy. 0 means no-limit)</height>
+                        </subregion>
+                    </port>
+                </ports>
             </decklink>
       	    <bluefish>
                 <device>[1..]</device>


### PR DESCRIPTION
This work was sponsored by the BBC.

Testing build: https://builds.julusian.dev/casparcg/casparcg-server--pr-1493-80f8ee76b3bc43efa6a6ed78f5bdb95ec7e355c6-windows.zip

This expands upon #1433, to resolve some synchronisation issues that were observed on the output when splitting a channel up over multiple decklink outputs.
Since v11.0 of the Decklink SDK, some cards support a concept of 'playback groups'. This is currently supported by the Duo2, Quad2 and 8K Pro (I expect any newer multi-channel cards will also support it). By adding outputs to a playback group, the driver/card will ensure that they are run in sync with each other with the same playback timings used across each.  
We can use this new functionality to allow for grouping multiple ports on a card in combination with subregions, to allow for slicing up a channel across the ports on card.

To utilise this, the decklink consumer configuration has been expanded, to allow for defining these secondary ports:
```
<decklink>
    <device>[1..]</device>
    <key-device>device + 1 [1..] (This is only used with the external_separate_device mode)</key-device>
    <embedded-audio>false [true|false]</embedded-audio>
    <latency>normal [normal|low|default]</latency>
    <keyer>external [external|external_separate_device|internal|default]</keyer>
    <key-only>false [true|false]</key-only>
    <buffer-depth>3 [1..]</buffer-depth>
    <video-mode>(Run the decklink at a different video-mode. Note: the framerate must match that of the channel)</video-mode>
    <subregion>
        <src-x>0 (x offset into the channel)</src-x>
        <src-y>0 (y offset into the channel)</src-y>
        <dest-x>0 (x offset of the video onto the output)</dest-x>
        <dest-y>0 (y offset of the video onto the output)</dest-y>
        <width>0 (width of the region to copy. 0 means no-limit)</width>
        <height>0 (height of the region to copy. 0 means no-limit)</height>
    </subregion>

    <wait-for-reference>auto [auto|enable|disable]</wait-for-reference>
    <wait-for-reference-duration>10 (seconds)</wait-for-reference-duration>

    <ports>
        (Add secondary ports to be run in sync with the primary. This allows for splitting a wide channel across multiple decklinks, with sync across the outputs guaranteed by the driver on supported cards)
        <port>
            <device>[1..]</device>
            <key-only>false [true|false]</key-only>
            <video-mode>(Run the decklink at a different video-mode. Note: the framerate must match that of the channel)</video-mode>
            <subregion>
                <src-x>0 (x offset into the channel)</src-x>
                <src-y>0 (y offset into the channel)</src-y>
                <dest-x>0 (x offset of the video onto the output)</dest-x>
                <dest-y>0 (y offset of the video onto the output)</dest-y>
                <width>0 (width of the region to copy. 0 means no-limit)</width>
                <height>0 (height of the region to copy. 0 means no-limit)</height>
            </subregion>
        </port>
    </ports>
</decklink>
```

The additional ports block defines the secondary ports to run. The SDK requires them to be the same video-mode for the driver level synchronisation, but it is possible to use different modes (with the same framerate) with less guarantees on the timing.  

It is also possible to manually define a key-only output as a secondary port against a fill output, internally the `external_separate_device` has been rewritten to use this same flow. If one of the outputs used does not support the playback group functionality, it will still be run but will have less guarantees on the timing. It should run as well as the `external_separate_device` used to.

For this to guarantee the accuracy, most cards (except the 8K pro) require a reference to be provided and for lock to be aquired before CasparCG starts playback. When running with these secondary ports, the default configuration will wait for reference (in my setup this takes 3.5 seconds) with a max wait of 10s. If no secondary ports are defined, no wait will be done by default. Both the max wait, and whether to wait are configurable.

Example usages:
3x1080p wide videowall
```
<?xml version="1.0" encoding="utf-8"?>

<configuration>
    <paths>
        <media-path>media/</media-path>
        <log-path disable="false">log/</log-path>
        <data-path>data/</data-path>
        <template-path>template/</template-path>
    </paths>
    <lock-clear-phrase>secret</lock-clear-phrase>
    <video-modes>
        <video-mode>
            <id>wide</id>
            <width>5760</width>
            <height>1080</height>
            <time-scale>50000</time-scale>
            <duration>1000</duration>
            <cadence>960</cadence>
        </video-mode>
    </video-modes>
    <channels>
        <channel>
            <video-mode>wide</video-mode>
            <consumers>
                <decklink>
                    <device>5</device>
                    <video-mode>1080p5000</video-mode>

                    <ports>
                        <port>
                            <device>6</device>
                            <video-mode>1080p5000</video-mode>
                            <subregion>
                                <src-x>1920</src-x>
                            </subregion>
                        </port>
                        <port>
                            <device>9</device>
                            <video-mode>1080p5000</video-mode>
                            <subregion>
                                <src-x>3840</src-x>
                            </subregion>
                        </port>
                    </ports>
                </decklink>
            </consumers>
        </channel>
    </channels>
    <controllers>
        <tcp>
            <port>5250</port>
            <protocol>AMCP</protocol>
        </tcp>
    </controllers>
    <amcp>
        <media-server>
            <host>localhost</host>
            <port>8000</port>
        </media-server>
    </amcp>
</configuration>
```

Manual key output:
```
<?xml version="1.0" encoding="utf-8"?>

<configuration>
    <paths>
        <media-path>media/</media-path>
        <log-path disable="false">log/</log-path>
        <data-path>data/</data-path>
        <template-path>template/</template-path>
    </paths>
    <lock-clear-phrase>secret</lock-clear-phrase>
    <channels>
        <channel>
            <video-mode>1080p5000</video-mode>
            <consumers>
                <decklink>
                    <device>5</device>

                    <ports>
                        <port>
                            <device>6</device>
                            <key-only>true</key-only>
                        </port>
                    </ports>
                </decklink>
            </consumers>
        </channel>
    </channels>
    <controllers>
        <tcp>
            <port>5250</port>
            <protocol>AMCP</protocol>
        </tcp>
    </controllers>
    <amcp>
        <media-server>
            <host>localhost</host>
            <port>8000</port>
        </media-server>
    </amcp>
</configuration>
```