### PR TITLE
fix: `video_channel` ownership #1511

### DIFF
--- a/src/core/consumer/frame_consumer.cpp
+++ b/src/core/consumer/frame_consumer.cpp
@@ -161,9 +161,9 @@ class print_consumer_proxy : public frame_consumer
 };
 
 spl::shared_ptr<core::frame_consumer>
-frame_consumer_registry::create_consumer(const std::vector<std::wstring>&            params,
-                                         const core::video_format_repository&        format_repository,
-                                         std::vector<spl::shared_ptr<video_channel>> channels) const
+frame_consumer_registry::create_consumer(const std::vector<std::wstring>&                         params,
+                                         const core::video_format_repository&                     format_repository,
+                                         const std::vector<spl::shared_ptr<core::video_channel>>& channels) const
 {
     if (params.empty())
         CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("params cannot be empty"));
@@ -186,10 +186,10 @@ frame_consumer_registry::create_consumer(const std::vector<std::wstring>&       
 }
 
 spl::shared_ptr<frame_consumer>
-frame_consumer_registry::create_consumer(const std::wstring&                         element_name,
-                                         const boost::property_tree::wptree&         element,
-                                         const core::video_format_repository&        format_repository,
-                                         std::vector<spl::shared_ptr<video_channel>> channels) const
+frame_consumer_registry::create_consumer(const std::wstring&                                      element_name,
+                                         const boost::property_tree::wptree&                      element,
+                                         const core::video_format_repository&                     format_repository,
+                                         const std::vector<spl::shared_ptr<core::video_channel>>& channels) const
 {
     auto& preconfigured_consumer_factories = impl_->preconfigured_consumer_factories;
     auto  found                            = preconfigured_consumer_factories.find(element_name);

--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -60,13 +60,13 @@ class frame_consumer
 };
 
 using consumer_factory_t =
-    std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&            params,
-                                                  const core::video_format_repository&        format_repository,
-                                                  std::vector<spl::shared_ptr<video_channel>> channels)>;
+    std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&     params,
+                                                  const core::video_format_repository& format_repository,
+                                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels)>;
 using preconfigured_consumer_factory_t =
-    std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&         element,
-                                                  const core::video_format_repository&        format_repository,
-                                                  std::vector<spl::shared_ptr<video_channel>> channels)>;
+    std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&  element,
+                                                  const core::video_format_repository& format_repository,
+                                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels)>;
 
 class frame_consumer_registry
 {
@@ -75,13 +75,15 @@ class frame_consumer_registry
     void register_consumer_factory(const std::wstring& name, const consumer_factory_t& factory);
     void register_preconfigured_consumer_factory(const std::wstring&                     element_name,
                                                  const preconfigured_consumer_factory_t& factory);
-    spl::shared_ptr<frame_consumer> create_consumer(const std::vector<std::wstring>&            params,
-                                                    const core::video_format_repository&        format_repository,
-                                                    std::vector<spl::shared_ptr<video_channel>> channels) const;
-    spl::shared_ptr<frame_consumer> create_consumer(const std::wstring&                         element_name,
-                                                    const boost::property_tree::wptree&         element,
-                                                    const core::video_format_repository&        format_repository,
-                                                    std::vector<spl::shared_ptr<video_channel>> channels) const;
+    spl::shared_ptr<frame_consumer>
+    create_consumer(const std::vector<std::wstring>&                         params,
+                    const core::video_format_repository&                     format_repository,
+                    const std::vector<spl::shared_ptr<core::video_channel>>& channels) const;
+    spl::shared_ptr<frame_consumer>
+    create_consumer(const std::wstring&                                      element_name,
+                    const boost::property_tree::wptree&                      element,
+                    const core::video_format_repository&                     format_repository,
+                    const std::vector<spl::shared_ptr<core::video_channel>>& channels) const;
 
   private:
     struct impl;

--- a/src/core/producer/frame_producer.cpp
+++ b/src/core/producer/frame_producer.cpp
@@ -24,8 +24,6 @@
 #include "cg_proxy.h"
 #include "frame_producer.h"
 
-#include "../frame/draw_frame.h"
-
 #include "color/color_producer.h"
 #include "route/route_producer.h"
 #include "separated/separated_producer.h"

--- a/src/core/producer/route/route_producer.cpp
+++ b/src/core/producer/route/route_producer.cpp
@@ -30,7 +30,6 @@
 #include <core/video_channel.h>
 
 #include <boost/optional.hpp>
-#include <boost/range/algorithm/find_if.hpp>
 #include <boost/regex.hpp>
 #include <boost/signals2.hpp>
 
@@ -188,8 +187,10 @@ spl::shared_ptr<core::frame_producer> create_route_producer(const core::frame_pr
             mode = core::route_mode::next;
     }
 
-    auto channel_it = boost::find_if(
-        dependencies.channels, [=](const spl::shared_ptr<core::video_channel>& ch) { return ch->index() == channel; });
+    auto channel_it =
+        std::find_if(dependencies.channels.begin(),
+                     dependencies.channels.end(),
+                     [=](const spl::shared_ptr<core::video_channel>& ch) { return ch->index() == channel; });
 
     if (channel_it == dependencies.channels.end()) {
         CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"No channel with id " + std::to_wstring(channel)));

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -309,9 +309,9 @@ std::vector<fixture> get_fixtures_ptree(const boost::property_tree::wptree& ptre
 }
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels)
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     configuration config;
 

--- a/src/modules/artnet/consumer/artnet_consumer.h
+++ b/src/modules/artnet/consumer/artnet_consumer.h
@@ -33,7 +33,7 @@
 namespace caspar { namespace artnet {
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels);
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 }} // namespace caspar::artnet

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -884,7 +884,7 @@ struct bluefish_consumer_proxy : public core::frame_consumer
 
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels)
+                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"BLUEFISH")) {
         return core::frame_consumer::empty();
@@ -937,9 +937,9 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 }
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels)
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     configuration config;
     auto          device_index = ptree.get(L"device", 1);

--- a/src/modules/bluefish/consumer/bluefish_consumer.h
+++ b/src/modules/bluefish/consumer/bluefish_consumer.h
@@ -25,18 +25,20 @@
 #include <boost/property_tree/ptree_fwd.hpp>
 #include <common/memory.h>
 #include <core/fwd.h>
+
 #include <string>
 #include <vector>
 
 namespace caspar { namespace bluefish {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels);
+spl::shared_ptr<core::frame_consumer>
+create_consumer(const std::vector<std::wstring>&                         params,
+                const core::video_format_repository&                     format_repository,
+                const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels);
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
 }} // namespace caspar::bluefish

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -901,7 +901,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
 
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels)
+                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"DECKLINK")) {
         return core::frame_consumer::empty();
@@ -913,9 +913,9 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 }
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels)
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     configuration config = parse_xml_config(ptree, format_repository);
 

--- a/src/modules/decklink/consumer/decklink_consumer.h
+++ b/src/modules/decklink/consumer/decklink_consumer.h
@@ -32,12 +32,13 @@
 
 namespace caspar { namespace decklink {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels);
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels);
+create_consumer(const std::vector<std::wstring>&                         params,
+                const core::video_format_repository&                     format_repository,
+                const std::vector<spl::shared_ptr<core::video_channel>>& channels);
+spl::shared_ptr<core::frame_consumer>
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
 }} // namespace caspar::decklink

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -715,7 +715,7 @@ struct ffmpeg_consumer : public core::frame_consumer
 
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels)
+                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     if (params.size() < 2 || (!boost::iequals(params.at(0), L"STREAM") && !boost::iequals(params.at(0), L"FILE")))
         return core::frame_consumer::empty();
@@ -729,9 +729,9 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 }
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&               ptree,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels)
+create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     return spl::make_shared<ffmpeg_consumer>(u8(ptree.get<std::wstring>(L"path", L"")),
                                              u8(ptree.get<std::wstring>(L"args", L"")),

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
@@ -32,12 +32,13 @@
 
 namespace caspar { namespace ffmpeg {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
-                                                      std::vector<spl::shared_ptr<core::video_channel>> channels);
+spl::shared_ptr<core::frame_consumer>
+create_consumer(const std::vector<std::wstring>&                         params,
+                const core::video_format_repository&                     format_repository,
+                const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
-                              const core::video_format_repository&              format_repository,
-                              std::vector<spl::shared_ptr<core::video_channel>> channels);
+                              const core::video_format_repository&                     format_repository,
+                              const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
 }} // namespace caspar::ffmpeg

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -254,9 +254,10 @@ struct newtek_ndi_consumer : public core::frame_consumer
 
 std::atomic<int> newtek_ndi_consumer::instances_(0);
 
-spl::shared_ptr<core::frame_consumer> create_ndi_consumer(const std::vector<std::wstring>&     params,
-                                                          const core::video_format_repository& format_repository,
-                                                          std::vector<spl::shared_ptr<core::video_channel>> channels)
+spl::shared_ptr<core::frame_consumer>
+create_ndi_consumer(const std::vector<std::wstring>&                         params,
+                    const core::video_format_repository&                     format_repository,
+                    const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"NDI"))
         return core::frame_consumer::empty();
@@ -266,9 +267,9 @@ spl::shared_ptr<core::frame_consumer> create_ndi_consumer(const std::vector<std:
 }
 
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_ndi_consumer(const boost::property_tree::wptree&               ptree,
-                                  const core::video_format_repository&              format_repository,
-                                  std::vector<spl::shared_ptr<core::video_channel>> channels)
+create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
+                                  const core::video_format_repository&                     format_repository,
+                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels)
 {
     auto name         = ptree.get(L"name", L"");
     bool allow_fields = ptree.get(L"allow-fields", false);

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.h
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.h
@@ -32,12 +32,13 @@
 
 namespace caspar { namespace newtek {
 
-spl::shared_ptr<core::frame_consumer> create_ndi_consumer(const std::vector<std::wstring>&     params,
-                                                          const core::video_format_repository& format_repository,
-                                                          std::vector<spl::shared_ptr<core::video_channel>> channels);
 spl::shared_ptr<core::frame_consumer>
-create_preconfigured_ndi_consumer(const boost::property_tree::wptree&               ptree,
-                                  const core::video_format_repository&              format_repository,
-                                  std::vector<spl::shared_ptr<core::video_channel>> channels);
+create_ndi_consumer(const std::vector<std::wstring>&                         params,
+                    const core::video_format_repository&                     format_repository,
+                    const std::vector<spl::shared_ptr<core::video_channel>>& channels);
+spl::shared_ptr<core::frame_consumer>
+create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
+                                  const core::video_format_repository&                     format_repository,
+                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels);
 
 }} // namespace caspar::newtek

--- a/src/protocol/amcp/AMCPCommand.cpp
+++ b/src/protocol/amcp/AMCPCommand.cpp
@@ -26,7 +26,7 @@
 
 namespace caspar { namespace protocol { namespace amcp {
 
-std::future<std::wstring> AMCPCommand::Execute(const std::vector<channel_context>& channels)
+std::future<std::wstring> AMCPCommand::Execute(const spl::shared_ptr<std::vector<channel_context>>& channels)
 {
     return command_(ctx_, channels);
 }

--- a/src/protocol/amcp/AMCPCommand.h
+++ b/src/protocol/amcp/AMCPCommand.h
@@ -49,7 +49,7 @@ class AMCPCommand
 
     using ptr_type = std::shared_ptr<AMCPCommand>;
 
-    std::future<std::wstring> Execute(const std::vector<channel_context>& channels);
+    std::future<std::wstring> Execute(const spl::shared_ptr<std::vector<channel_context>>& channels);
 
     void SendReply(const std::wstring& str, bool reply_without_req_id) const;
 

--- a/src/protocol/amcp/AMCPCommandQueue.h
+++ b/src/protocol/amcp/AMCPCommandQueue.h
@@ -33,15 +33,15 @@ class AMCPCommandQueue
   public:
     using ptr_type = spl::shared_ptr<AMCPCommandQueue>;
 
-    AMCPCommandQueue(const std::wstring& name, const std::vector<channel_context>& channels);
+    AMCPCommandQueue(const std::wstring& name, const spl::shared_ptr<std::vector<channel_context>>& channels);
     ~AMCPCommandQueue();
 
     void AddCommand(std::shared_ptr<AMCPGroupCommand> command);
     void Execute(std::shared_ptr<AMCPGroupCommand> cmd) const;
 
   private:
-    executor                            executor_;
-    const std::vector<channel_context>& channels_;
+    executor                                            executor_;
+    const spl::shared_ptr<std::vector<channel_context>> channels_;
 };
 
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -99,13 +99,11 @@ class AMCPProtocolStrategy
     {
         commandQueues_.push_back(spl::make_shared<AMCPCommandQueue>(L"General Queue for " + name, repo_->channels()));
 
-        int i = 0;
-        for (const auto& ch : repo_->channels()) {
-            auto queue = spl::make_shared<AMCPCommandQueue>(L"Channel " + std::to_wstring(i + 1) + L" for " + name,
-                                                            repo_->channels());
+        for (auto& ch : *repo_->channels()) {
+            auto queue = spl::make_shared<AMCPCommandQueue>(
+                L"Channel " + std::to_wstring(ch.raw_channel->index()) + L" for " + name, repo_->channels());
             std::weak_ptr<AMCPCommandQueue> queue_weak = queue;
             commandQueues_.push_back(queue);
-            i++;
         }
     }
 

--- a/src/protocol/amcp/amcp_command_context.h
+++ b/src/protocol/amcp/amcp_command_context.h
@@ -73,22 +73,22 @@ struct amcp_command_static_context
 
 struct command_context
 {
-    std::shared_ptr<amcp_command_static_context> static_context;
-    const std::vector<channel_context>           channels;
-    const IO::ClientInfoPtr                      client;
-    const channel_context                        channel;
-    const int                                    channel_index;
-    const int                                    layer_id;
-    std::vector<std::wstring>                    parameters;
+    std::shared_ptr<amcp_command_static_context>        static_context;
+    const spl::shared_ptr<std::vector<channel_context>> channels;
+    const IO::ClientInfoPtr                             client;
+    const channel_context                               channel;
+    const int                                           channel_index;
+    const int                                           layer_id;
+    std::vector<std::wstring>                           parameters;
 
     int layer_index(int default_ = 0) const { return layer_id == -1 ? default_ : layer_id; }
 
-    command_context(std::shared_ptr<amcp_command_static_context> static_context,
-                    std::vector<channel_context>                 channels,
-                    const IO::ClientInfoPtr&                     client,
-                    channel_context                              channel,
-                    int                                          channel_index,
-                    int                                          layer_id)
+    command_context(std::shared_ptr<amcp_command_static_context>        static_context,
+                    const spl::shared_ptr<std::vector<channel_context>> channels,
+                    const IO::ClientInfoPtr&                            client,
+                    channel_context                                     channel,
+                    int                                                 channel_index,
+                    int                                                 layer_id)
         : static_context(std::move(static_context))
         , channels(std::move(channels))
         , client(client)

--- a/src/protocol/amcp/amcp_command_repository.h
+++ b/src/protocol/amcp/amcp_command_repository.h
@@ -33,13 +33,13 @@ namespace caspar { namespace protocol { namespace amcp {
 class amcp_command_repository
 {
   public:
-    amcp_command_repository(const std::vector<channel_context>& channels);
+    amcp_command_repository(const spl::shared_ptr<std::vector<channel_context>>& channels);
 
     std::shared_ptr<AMCPCommand>
          parse_command(IO::ClientInfoPtr client, std::list<std::wstring> tokens, const std::wstring& request_id) const;
     bool check_channel_lock(IO::ClientInfoPtr client, int channel_index) const;
 
-    const std::vector<channel_context>& channels() const;
+    const spl::shared_ptr<std::vector<channel_context>>& channels() const;
 
     void register_command(std::wstring category, std::wstring name, amcp_command_func command, int min_num_params);
 

--- a/src/protocol/amcp/amcp_command_repository_wrapper.cpp
+++ b/src/protocol/amcp/amcp_command_repository_wrapper.cpp
@@ -31,8 +31,8 @@ void amcp_command_repository_wrapper::register_command(std::wstring             
                                                        int                           min_num_params)
 {
     std::weak_ptr<command_context_factory> weak_context_factory = context_factory_;
-    auto                                   func = [weak_context_factory, command](const command_context_simple&       ctx,
-                                                const std::vector<channel_context>& channels) {
+    auto                                   func = [weak_context_factory, command](const command_context_simple&                        ctx,
+                                                const spl::shared_ptr<std::vector<channel_context>>& channels) {
         auto context_factory = weak_context_factory.lock();
         if (!context_factory)
             return make_ready_future<std::wstring>(L"");
@@ -50,8 +50,8 @@ void amcp_command_repository_wrapper::register_command(std::wstring           ca
                                                        int                    min_num_params)
 {
     std::weak_ptr<command_context_factory> weak_context_factory = context_factory_;
-    auto                                   func = [weak_context_factory, command](const command_context_simple&       ctx,
-                                                const std::vector<channel_context>& channels) {
+    auto                                   func = [weak_context_factory, command](const command_context_simple&                        ctx,
+                                                const spl::shared_ptr<std::vector<channel_context>>& channels) {
         auto context_factory = weak_context_factory.lock();
         if (!context_factory)
             return make_ready_future<std::wstring>(L"");
@@ -69,8 +69,8 @@ void amcp_command_repository_wrapper::register_channel_command(std::wstring     
                                                                int                           min_num_params)
 {
     std::weak_ptr<command_context_factory> weak_context_factory = context_factory_;
-    auto                                   func = [weak_context_factory, command](const command_context_simple&       ctx,
-                                                const std::vector<channel_context>& channels) {
+    auto                                   func = [weak_context_factory, command](const command_context_simple&                        ctx,
+                                                const spl::shared_ptr<std::vector<channel_context>>& channels) {
         auto context_factory = weak_context_factory.lock();
         if (!context_factory)
             return make_ready_future<std::wstring>(L"");
@@ -88,8 +88,8 @@ void amcp_command_repository_wrapper::register_channel_command(std::wstring     
                                                                int                    min_num_params)
 {
     std::weak_ptr<command_context_factory> weak_context_factory = context_factory_;
-    auto                                   func = [weak_context_factory, command](const command_context_simple&       ctx,
-                                                const std::vector<channel_context>& channels) {
+    auto                                   func = [weak_context_factory, command](const command_context_simple&                        ctx,
+                                                const spl::shared_ptr<std::vector<channel_context>>& channels) {
         auto context_factory = weak_context_factory.lock();
         if (!context_factory)
             return make_ready_future<std::wstring>(L"");

--- a/src/protocol/amcp/amcp_command_repository_wrapper.h
+++ b/src/protocol/amcp/amcp_command_repository_wrapper.h
@@ -36,14 +36,15 @@ class command_context_factory
     {
     }
 
-    command_context create(const command_context_simple& simple_ctx, const std::vector<channel_context>& channels) const
+    command_context create(const command_context_simple&                        simple_ctx,
+                           const spl::shared_ptr<std::vector<channel_context>>& channels) const
     {
         const channel_context channel =
-            simple_ctx.channel_index >= 0 ? channels.at(simple_ctx.channel_index) : channel_context();
+            simple_ctx.channel_index >= 0 ? channels->at(simple_ctx.channel_index) : channel_context();
         auto ctx = command_context(
             static_context_, channels, simple_ctx.client, channel, simple_ctx.channel_index, simple_ctx.layer_id);
         ctx.parameters = std::move(simple_ctx.parameters);
-        return std::move(ctx);
+        return ctx;
     }
 
   private:

--- a/src/protocol/amcp/amcp_shared.h
+++ b/src/protocol/amcp/amcp_shared.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../util/ClientInfo.h"
 #include "../util/lock_container.h"
 #include <core/producer/stage.h>
 #include <core/video_channel.h>
@@ -47,8 +48,8 @@ struct command_context_simple
     }
 };
 
-typedef std::function<std::future<std::wstring>(const command_context_simple&       args,
-                                                const std::vector<channel_context>& channels)>
+typedef std::function<std::future<std::wstring>(const command_context_simple&                        args,
+                                                const spl::shared_ptr<std::vector<channel_context>>& channels)>
     amcp_command_func;
 
 }}} // namespace caspar::protocol::amcp


### PR DESCRIPTION
There is some bad ownership handling of the channels. When creating amcp_command_repository it holds a copy of the pointer for each channel.
This class is not being destroyed correctly, because the main loop holds a reference for the console amcp client, causing it to not be destoyed when expected.

This then crashes because once caspar thinks it has destroyed everything, it tells cef to shutdown which causes the crash as the renderers are still active (as are all the channels, producers and consumers).

This fixes that by swapping out the root channels vector to contain the type needed by amcp_command_repository, which avoids the ownership issues