### PR TITLE
feat: CEF use dirty rectangles

### DIFF
--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
 	ogl/image/image_kernel.cpp
 	ogl/image/image_mixer.cpp
 	ogl/image/image_shader.cpp
+	ogl/image/frame_pool.cpp
 
 	ogl/util/buffer.cpp
 	ogl/util/device.cpp
@@ -17,6 +18,7 @@ set(HEADERS
 	ogl/image/image_kernel.h
 	ogl/image/image_mixer.h
 	ogl/image/image_shader.h
+	ogl/image/frame_pool.h
 
 	ogl/util/buffer.h
 	ogl/util/device.h

--- a/src/accelerator/ogl/image/frame_pool.cpp
+++ b/src/accelerator/ogl/image/frame_pool.cpp
@@ -23,7 +23,7 @@
 
 #include <utility>
 
-namespace caspar { namespace accelerator { namespace ogl {
+namespace caspar::accelerator::ogl {
 
 frame_pool::frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, core::pixel_format_desc desc)
     : frame_factory_(std::move(frame_factory))
@@ -34,8 +34,6 @@ frame_pool::frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const vo
 
 std::pair<core::mutable_frame, std::any&> frame_pool::create_frame()
 {
-    // TODO - ensure width and height match. If not then empty the pool?
-
     // TODO - is there risk of order issues with the atomics?
 
     std::shared_ptr<pooled_buffer> frame;
@@ -84,4 +82,13 @@ void frame_pool::for_each(const std::function<void(std::any& data)>& fn)
     }
 }
 
-}}} // namespace caspar::accelerator::ogl
+void frame_pool::pixel_format(core::pixel_format_desc desc)
+{
+    desc_ = desc;
+
+    pool_.clear();
+}
+
+const core::pixel_format_desc& frame_pool::pixel_format() const { return desc_; }
+
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/frame_pool.cpp
+++ b/src/accelerator/ogl/image/frame_pool.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "frame_pool.h"
+
+namespace caspar { namespace accelerator { namespace ogl {
+
+frame_pool::frame_pool(std::shared_ptr<core::frame_factory> frame_factory,
+                       const void*                          tag,
+                       const core::pixel_format_desc&       desc)
+    : frame_factory_(std::move(frame_factory))
+    , tag_(tag)
+    , desc_(desc)
+{
+    // TODO
+}
+
+frame_pool::~frame_pool()
+{
+    // TODO
+}
+
+core::mutable_frame frame_pool::create_frame() { return frame_factory_->create_frame(tag_, desc_); }
+
+}}} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/frame_pool.cpp
+++ b/src/accelerator/ogl/image/frame_pool.cpp
@@ -32,16 +32,11 @@ frame_pool::frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const vo
 {
 }
 
-frame_pool::~frame_pool()
-{
-    // TODO
-}
-
 std::pair<core::mutable_frame, std::any&> frame_pool::create_frame()
 {
     // TODO - ensure width and height match. If not then empty the pool?
 
-    // TODO - is there risk of order issues with the atomics
+    // TODO - is there risk of order issues with the atomics?
 
     std::shared_ptr<pooled_buffer> frame;
 

--- a/src/accelerator/ogl/image/frame_pool.cpp
+++ b/src/accelerator/ogl/image/frame_pool.cpp
@@ -66,7 +66,7 @@ std::pair<core::mutable_frame, std::any&> frame_pool::create_frame()
     }
 
     auto drop_hook = std::shared_ptr<void>(nullptr, [frame](void*) {
-        // Mark as no longer in use, once the buffers are freed
+        // This means the copy of each buffer has completed, and is no longer in use
         frame->in_use = false;
     });
 

--- a/src/accelerator/ogl/image/frame_pool.h
+++ b/src/accelerator/ogl/image/frame_pool.h
@@ -34,19 +34,23 @@ namespace caspar { namespace accelerator { namespace ogl {
 struct pooled_buffer {
     std::vector<caspar::array<std::uint8_t>> buffers;
     std::atomic<bool> in_use;
+
+    std::any data;
 };
 
 class frame_pool : public core::frame_pool
 {
   public:
-    frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, const core::pixel_format_desc& desc);
+    frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, core::pixel_format_desc  desc);
     frame_pool(const frame_pool&) = delete;
 
     ~frame_pool();
 
     frame_pool& operator=(const frame_pool&) = delete;
 
-    core::mutable_frame create_frame() override;
+    std::pair<core::mutable_frame, std::any&> create_frame() override;
+
+    void for_each(const std::function<void(std::any& data)>& fn) override;
 
   private:
     const std::shared_ptr<frame_factory_gl> frame_factory_;

--- a/src/accelerator/ogl/image/frame_pool.h
+++ b/src/accelerator/ogl/image/frame_pool.h
@@ -29,7 +29,7 @@
 
 #include "image_mixer.h"
 
-namespace caspar { namespace accelerator { namespace ogl {
+namespace caspar::accelerator::ogl {
 
 struct pooled_buffer
 {
@@ -45,7 +45,7 @@ class frame_pool : public core::frame_pool
     frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, core::pixel_format_desc desc);
     frame_pool(const frame_pool&) = delete;
 
-    ~frame_pool() = default;
+    ~frame_pool() override = default;
 
     frame_pool& operator=(const frame_pool&) = delete;
 
@@ -53,12 +53,15 @@ class frame_pool : public core::frame_pool
 
     void for_each(const std::function<void(std::any& data)>& fn) override;
 
+    void                                         pixel_format(core::pixel_format_desc desc) override;
+    [[nodiscard]] const core::pixel_format_desc& pixel_format() const override;
+
   private:
     const std::shared_ptr<frame_factory_gl> frame_factory_;
     const void*                             tag_;
-    const core::pixel_format_desc           desc_;
+    core::pixel_format_desc                 desc_;
 
     std::vector<std::shared_ptr<pooled_buffer>> pool_;
 };
 
-}}} // namespace caspar::accelerator::ogl
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/frame_pool.h
+++ b/src/accelerator/ogl/image/frame_pool.h
@@ -1,0 +1,50 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+*
+* This file is part of CasparCG (www.casparcg.com).
+*
+* CasparCG is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* CasparCG is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+*
+* Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <core/frame/frame.h>
+#include <core/frame/frame_transform.h>
+#include <core/frame/geometry.h>
+#include <core/frame/pixel_format.h>
+#include <core/video_format.h>
+
+namespace caspar { namespace accelerator { namespace ogl {
+
+class frame_pool : public core::frame_pool
+{
+  public:
+    frame_pool(std::shared_ptr<core::frame_factory> frame_factory, const void* tag, const core::pixel_format_desc& desc);
+    frame_pool(const frame_pool&) = delete;
+
+    ~frame_pool();
+
+    frame_pool& operator=(const frame_pool&) = delete;
+
+    core::mutable_frame create_frame() override;
+
+  private:
+    const std::shared_ptr<core::frame_factory> frame_factory_;
+    const void* tag_;
+    const core::pixel_format_desc& desc_;
+};
+
+}}}

--- a/src/accelerator/ogl/image/frame_pool.h
+++ b/src/accelerator/ogl/image/frame_pool.h
@@ -27,12 +27,19 @@
 #include <core/frame/pixel_format.h>
 #include <core/video_format.h>
 
+#include "image_mixer.h"
+
 namespace caspar { namespace accelerator { namespace ogl {
+
+struct pooled_buffer {
+    std::vector<caspar::array<std::uint8_t>> buffers;
+    std::atomic<bool> in_use;
+};
 
 class frame_pool : public core::frame_pool
 {
   public:
-    frame_pool(std::shared_ptr<core::frame_factory> frame_factory, const void* tag, const core::pixel_format_desc& desc);
+    frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, const core::pixel_format_desc& desc);
     frame_pool(const frame_pool&) = delete;
 
     ~frame_pool();
@@ -42,9 +49,11 @@ class frame_pool : public core::frame_pool
     core::mutable_frame create_frame() override;
 
   private:
-    const std::shared_ptr<core::frame_factory> frame_factory_;
+    const std::shared_ptr<frame_factory_gl> frame_factory_;
     const void* tag_;
-    const core::pixel_format_desc& desc_;
+    const core::pixel_format_desc desc_;
+
+    std::vector<std::shared_ptr<pooled_buffer>> pool_;
 };
 
 }}}

--- a/src/accelerator/ogl/image/frame_pool.h
+++ b/src/accelerator/ogl/image/frame_pool.h
@@ -1,22 +1,22 @@
 /*
-* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
-*
-* This file is part of CasparCG (www.casparcg.com).
-*
-* CasparCG is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* CasparCG is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
-*
-* Author: Julian Waller, julian@superfly.tv
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
  */
 
 #pragma once
@@ -31,9 +31,10 @@
 
 namespace caspar { namespace accelerator { namespace ogl {
 
-struct pooled_buffer {
+struct pooled_buffer
+{
     std::vector<caspar::array<std::uint8_t>> buffers;
-    std::atomic<bool> in_use;
+    std::atomic<bool>                        in_use;
 
     std::any data;
 };
@@ -41,10 +42,10 @@ struct pooled_buffer {
 class frame_pool : public core::frame_pool
 {
   public:
-    frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, core::pixel_format_desc  desc);
+    frame_pool(std::shared_ptr<frame_factory_gl> frame_factory, const void* tag, core::pixel_format_desc desc);
     frame_pool(const frame_pool&) = delete;
 
-    ~frame_pool();
+    ~frame_pool() = default;
 
     frame_pool& operator=(const frame_pool&) = delete;
 
@@ -54,10 +55,10 @@ class frame_pool : public core::frame_pool
 
   private:
     const std::shared_ptr<frame_factory_gl> frame_factory_;
-    const void* tag_;
-    const core::pixel_format_desc desc_;
+    const void*                             tag_;
+    const core::pixel_format_desc           desc_;
 
     std::vector<std::shared_ptr<pooled_buffer>> pool_;
 };
 
-}}}
+}}} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/image_mixer.cpp
+++ b/src/accelerator/ogl/image/image_mixer.cpp
@@ -21,6 +21,7 @@
 #include "image_mixer.h"
 
 #include "image_kernel.h"
+#include "frame_pool.h"
 
 #include "../util/buffer.h"
 #include "../util/device.h"
@@ -340,8 +341,7 @@ struct image_mixer::impl
 
 
     std::unique_ptr<core::frame_pool> create_frame_pool(const void* tag, const core::pixel_format_desc& desc) override {
-        // TODO
-        return nullptr;
+        return std::make_unique<frame_pool>(shared_from_this(), tag, desc);
     }
 };
 

--- a/src/accelerator/ogl/image/image_mixer.h
+++ b/src/accelerator/ogl/image/image_mixer.h
@@ -44,7 +44,11 @@ class image_mixer final : public core::image_mixer
     image_mixer& operator=(const image_mixer&) = delete;
 
     std::future<array<const std::uint8_t>> operator()(const core::video_format_desc& format_desc) override;
+    caspar::array<std::uint8_t> create_buffer(int size)override;
+    core::mutable_frame import_buffers(const void* tag, const core::pixel_format_desc& desc, std::vector<caspar::array<std::uint8_t>> buffers) override;
     core::mutable_frame                    create_frame(const void* tag, const core::pixel_format_desc& desc) override;
+
+    std::unique_ptr<core::frame_pool> create_frame_pool(const void* tag, const core::pixel_format_desc& desc) override;
 
     // core::image_mixer
 

--- a/src/accelerator/ogl/image/image_mixer.h
+++ b/src/accelerator/ogl/image/image_mixer.h
@@ -33,6 +33,12 @@
 
 namespace caspar { namespace accelerator { namespace ogl {
 
+class frame_factory_gl: public core::frame_factory {
+  public:
+    virtual caspar::array<std::uint8_t> create_buffer(int size) = 0;
+    virtual core::mutable_frame import_buffers(const void* tag, const core::pixel_format_desc& desc, std::vector<caspar::array<std::uint8_t>> buffers, std::shared_ptr<void> drop_hook) = 0;
+};
+
 class image_mixer final : public core::image_mixer
 {
   public:
@@ -44,8 +50,6 @@ class image_mixer final : public core::image_mixer
     image_mixer& operator=(const image_mixer&) = delete;
 
     std::future<array<const std::uint8_t>> operator()(const core::video_format_desc& format_desc) override;
-    caspar::array<std::uint8_t> create_buffer(int size)override;
-    core::mutable_frame import_buffers(const void* tag, const core::pixel_format_desc& desc, std::vector<caspar::array<std::uint8_t>> buffers) override;
     core::mutable_frame                    create_frame(const void* tag, const core::pixel_format_desc& desc) override;
 
     std::unique_ptr<core::frame_pool> create_frame_pool(const void* tag, const core::pixel_format_desc& desc) override;

--- a/src/accelerator/ogl/util/device.cpp
+++ b/src/accelerator/ogl/util/device.cpp
@@ -222,9 +222,9 @@ struct device::impl : public std::enable_shared_from_this<impl>
     }
 
     std::future<std::shared_ptr<texture>>
-    copy_async(const array<const uint8_t>& source, int width, int height, int stride)
+    copy_async(const array<const uint8_t>& source, int width, int height, int stride, std::shared_ptr<void> drop_hook)
     {
-        return dispatch_async([=] {
+        return dispatch_async([=, drop_hook = std::move(drop_hook)] {
             std::shared_ptr<buffer> buf;
 
             auto tmp = source.storage<std::shared_ptr<buffer>>();
@@ -427,11 +427,14 @@ std::shared_ptr<texture> device::create_texture(int width, int height, int strid
 {
     return impl_->create_texture(width, height, stride, true);
 }
-array<uint8_t> device::create_array(int size) { return impl_->create_array(size); }
-std::future<std::shared_ptr<texture>>
-device::copy_async(const array<const uint8_t>& source, int width, int height, int stride)
+array<uint8_t>                        device::create_array(int size) { return impl_->create_array(size); }
+std::future<std::shared_ptr<texture>> device::copy_async(const array<const uint8_t>& source,
+                                                         int                         width,
+                                                         int                         height,
+                                                         int                         stride,
+                                                         std::shared_ptr<void>       drop_hook)
 {
-    return impl_->copy_async(source, width, height, stride);
+    return impl_->copy_async(source, width, height, stride, drop_hook);
 }
 std::future<array<const uint8_t>> device::copy_async(const std::shared_ptr<texture>& source)
 {

--- a/src/accelerator/ogl/util/device.h
+++ b/src/accelerator/ogl/util/device.h
@@ -49,7 +49,7 @@ class device final
     array<uint8_t>                 create_array(int size);
 
     std::future<std::shared_ptr<class texture>>
-                                      copy_async(const array<const uint8_t>& source, int width, int height, int stride);
+    copy_async(const array<const uint8_t>& source, int width, int height, int stride, std::shared_ptr<void> drop_hook);
     std::future<array<const uint8_t>> copy_async(const std::shared_ptr<class texture>& source);
     template <typename Func>
     auto dispatch_async(Func&& func)

--- a/src/common/array.h
+++ b/src/common/array.h
@@ -70,6 +70,15 @@ class array final
         return *this;
     }
 
+    // Explicitly make a copy of the array, with shared backing storage
+    array<T> clone() const {
+        caspar::array<T> cloned;
+        cloned.ptr_ = ptr_;
+        cloned.size_ = size_;
+        cloned.storage_ = storage_; // TODO - does this get freed correctly?
+        return cloned;
+    }
+
     T*          begin() const { return ptr_; }
     T*          data() const { return ptr_; }
     T*          end() const { return ptr_ + size_; }

--- a/src/common/array.h
+++ b/src/common/array.h
@@ -75,7 +75,7 @@ class array final
         caspar::array<T> cloned;
         cloned.ptr_ = ptr_;
         cloned.size_ = size_;
-        cloned.storage_ = storage_; // TODO - does this get freed correctly?
+        cloned.storage_ = storage_;
         return cloned;
     }
 

--- a/src/core/frame/frame_factory.h
+++ b/src/core/frame/frame_factory.h
@@ -25,23 +25,27 @@
 
 namespace caspar { namespace core {
 
-class frame_pool {
+class frame_pool
+{
   public:
-    frame_pool()                                = default;
+    frame_pool()        = default;
     frame_pool& operator=(const frame_pool&) = delete;
-    virtual ~frame_pool()                       = default;
+    virtual ~frame_pool()                    = default;
 
     frame_pool(const frame_pool&) = delete;
 
     virtual std::pair<class mutable_frame, std::any&> create_frame() = 0;
 
     virtual void for_each(const std::function<void(std::any& data)>& fn) = 0;
+
+    virtual void                                         pixel_format(core::pixel_format_desc desc) = 0;
+    [[nodiscard]] virtual const core::pixel_format_desc& pixel_format() const                       = 0;
 };
 
 class frame_factory
 {
   public:
-    frame_factory()                                = default;
+    frame_factory()        = default;
     frame_factory& operator=(const frame_factory&) = delete;
     virtual ~frame_factory()                       = default;
 
@@ -49,7 +53,8 @@ class frame_factory
 
     virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
 
-    virtual std::unique_ptr<frame_pool> create_frame_pool(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
+    virtual std::unique_ptr<frame_pool> create_frame_pool(const void*                     video_stream_tag,
+                                                          const struct pixel_format_desc& desc) = 0;
 };
 
 }} // namespace caspar::core

--- a/src/core/frame/frame_factory.h
+++ b/src/core/frame/frame_factory.h
@@ -43,8 +43,6 @@ class frame_factory
 
     frame_factory(const frame_factory&) = delete;
 
-    virtual class caspar::array<std::uint8_t> create_buffer (int size) = 0;
-    virtual class mutable_frame import_buffers(const void* video_stream_tag, const struct pixel_format_desc& desc, std::vector<class caspar::array<std::uint8_t>> buffers) = 0;
     virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
 
     virtual std::unique_ptr<frame_pool> create_frame_pool(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;

--- a/src/core/frame/frame_factory.h
+++ b/src/core/frame/frame_factory.h
@@ -31,7 +31,7 @@ class frame_pool {
 
     frame_pool(const frame_pool&) = delete;
 
-    virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
+    virtual class mutable_frame create_frame() = 0;
 };
 
 class frame_factory

--- a/src/core/frame/frame_factory.h
+++ b/src/core/frame/frame_factory.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <any>
+
 namespace caspar { namespace core {
 
 class frame_pool {
@@ -31,7 +33,9 @@ class frame_pool {
 
     frame_pool(const frame_pool&) = delete;
 
-    virtual class mutable_frame create_frame() = 0;
+    virtual std::pair<class mutable_frame, std::any&> create_frame() = 0;
+
+    virtual void for_each(const std::function<void(std::any& data)>& fn) = 0;
 };
 
 class frame_factory

--- a/src/core/frame/frame_factory.h
+++ b/src/core/frame/frame_factory.h
@@ -23,6 +23,17 @@
 
 namespace caspar { namespace core {
 
+class frame_pool {
+  public:
+    frame_pool()                                = default;
+    frame_pool& operator=(const frame_pool&) = delete;
+    virtual ~frame_pool()                       = default;
+
+    frame_pool(const frame_pool&) = delete;
+
+    virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
+};
+
 class frame_factory
 {
   public:
@@ -32,7 +43,11 @@ class frame_factory
 
     frame_factory(const frame_factory&) = delete;
 
+    virtual class caspar::array<std::uint8_t> create_buffer (int size) = 0;
+    virtual class mutable_frame import_buffers(const void* video_stream_tag, const struct pixel_format_desc& desc, std::vector<class caspar::array<std::uint8_t>> buffers) = 0;
     virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
+
+    virtual std::unique_ptr<frame_pool> create_frame_pool(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
 };
 
 }} // namespace caspar::core

--- a/src/core/mixer/image/image_mixer.h
+++ b/src/core/mixer/image/image_mixer.h
@@ -47,7 +47,11 @@ class image_mixer
 
     virtual std::future<array<const uint8_t>> operator()(const struct video_format_desc& format_desc) = 0;
 
+    caspar::array<std::uint8_t> create_buffer(int size)override = 0;
+    class mutable_frame import_buffers(const void* video_stream_tag, const struct pixel_format_desc& desc, std::vector<class caspar::array<std::uint8_t>> buffers) override = 0;
     class mutable_frame create_frame(const void* tag, const struct pixel_format_desc& desc) override = 0;
+
+    std::unique_ptr<frame_pool> create_frame_pool(const void* video_stream_tag, const struct pixel_format_desc& desc) override = 0;
 };
 
 }} // namespace caspar::core

--- a/src/core/mixer/image/image_mixer.h
+++ b/src/core/mixer/image/image_mixer.h
@@ -47,8 +47,6 @@ class image_mixer
 
     virtual std::future<array<const uint8_t>> operator()(const struct video_format_desc& format_desc) = 0;
 
-    caspar::array<std::uint8_t> create_buffer(int size)override = 0;
-    class mutable_frame import_buffers(const void* video_stream_tag, const struct pixel_format_desc& desc, std::vector<class caspar::array<std::uint8_t>> buffers) override = 0;
     class mutable_frame create_frame(const void* tag, const struct pixel_format_desc& desc) override = 0;
 
     std::unique_ptr<frame_pool> create_frame_pool(const void* video_stream_tag, const struct pixel_format_desc& desc) override = 0;

--- a/src/modules/html/CMakeLists.txt
+++ b/src/modules/html/CMakeLists.txt
@@ -4,12 +4,14 @@ project (html)
 set(SOURCES
 		producer/html_cg_proxy.cpp
 		producer/html_producer.cpp
+		producer/rectangles.cpp
 
 		html.cpp
 )
 set(HEADERS
 		producer/html_cg_proxy.h
 		producer/html_producer.h
+		producer/rectangles.h
 
 		html.h
 )

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -67,16 +67,6 @@
 
 namespace caspar { namespace html {
 
-class pooled_buffer
-{
-  public:
-    pooled_buffer(caspar::array<std::uint8_t> buffer) : buffer(std::move(buffer)){}
-
-
-    const caspar::array<std::uint8_t> buffer;
-    std::atomic<bool>   in_use = {false};
-};
-
 class html_client
     : public CefClient
     , public CefRenderHandler
@@ -293,7 +283,6 @@ class html_client
         std::memcpy(dst, src, width * height * 4);
 #endif
     }
-
 
     void OnPaint(CefRefPtr<CefBrowser> browser,
                  PaintElementType      type,

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -271,7 +271,7 @@ class html_client
         rect = CefRect(0, 0, format_desc_.square_width, format_desc_.square_height);
     }
 
-    static inline void copy_whole_frame(char* src, char* dst, int width, int height)
+    inline void copy_whole_frame(char* src, char* dst, int width, int height)
     {
 #ifdef WIN32
         if (gpu_enabled_) {

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -292,7 +292,7 @@ class html_client
             std::memcpy(dst, src, width * height * 4);
         }
 #else
-        // On my one test linux machine, doing a single memcpy doesn't have the same cost as windows,
+        // In my linux tests, doing a single memcpy doesn't have the same cost as windows,
         // making using tbb excessive
         std::memcpy(dst, src, width * height * 4);
 #endif

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -372,7 +372,7 @@ class html_client
         {
             std::lock_guard<std::mutex> lock(frames_mutex_);
 
-            frames_.push(std::make_pair(now(), core::draw_frame(std::move(frame))));
+            frames_.push(std::make_pair(now(), core::draw_frame(std::move(frame.first))));
             while (frames_.size() > frames_max_size_) {
                 frames_.pop();
                 graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -86,6 +86,7 @@ class html_client
     spl::shared_ptr<core::frame_factory>                        frame_factory_;
     core::video_format_desc                                     format_desc_;
     bool                                                        gpu_enabled_;
+    const bool                                                  use_dirty_regions_;
     tbb::concurrent_queue<std::wstring>                         javascript_before_load_;
     std::atomic<bool>                                           loaded_;
     std::queue<std::pair<std::int_least64_t, core::draw_frame>> frames_;
@@ -105,12 +106,14 @@ class html_client
                 const spl::shared_ptr<diagnostics::graph>& graph,
                 core::video_format_desc                    format_desc,
                 bool                                       gpu_enabled,
+                bool                                       use_dirty_regions,
                 std::wstring                               url)
         : url_(std::move(url))
         , graph_(graph)
         , frame_factory_(std::move(frame_factory))
         , format_desc_(std::move(format_desc))
         , gpu_enabled_(gpu_enabled)
+        , use_dirty_regions_(use_dirty_regions)
     {
         graph_->set_color("browser-tick-time", diagnostics::color(0.1f, 1.0f, 0.1f));
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
@@ -268,7 +271,7 @@ class html_client
         rect = CefRect(0, 0, format_desc_.square_width, format_desc_.square_height);
     }
 
-    inline void copy_whole_frame(char* src, char* dst, int width, int height)
+    static inline void copy_whole_frame(char* src, char* dst, int width, int height)
     {
 #ifdef WIN32
         if (gpu_enabled_) {
@@ -301,22 +304,24 @@ class html_client
         if (type != PET_VIEW)
             return;
 
-        // Update the dirty rectangles for each frame in the pool
-        frame_pool_->for_each([&](std::any& data) {
-            if (!data.has_value()) {
-                std::vector<Rectangle> rects;
-                for (const auto& rect : dirtyRects) {
-                    rects.emplace_back(rect);
+        if (use_dirty_regions_) {
+            // Update the dirty rectangles for each frame in the pool
+            frame_pool_->for_each([&](std::any& data) {
+                if (!data.has_value()) {
+                    std::vector<Rectangle> rects;
+                    for (const auto& rect : dirtyRects) {
+                        rects.emplace_back(rect);
+                    }
+                    data.emplace<std::vector<Rectangle>>(std::move(rects));
+                } else {
+                    auto& rects = std::any_cast<std::vector<Rectangle>&>(data);
+                    for (const auto& rect : dirtyRects) {
+                        rects.emplace_back(rect);
+                    }
+                    merge_rectangles(rects, width, height);
                 }
-                data.emplace<std::vector<Rectangle>>(std::move(rects));
-            } else {
-                auto& rects = std::any_cast<std::vector<Rectangle>&>(data);
-                for (const auto& rect : dirtyRects) {
-                    rects.emplace_back(rect);
-                }
-                merge_rectangles(rects, width, height);
-            }
-        });
+            });
+        }
 
         // Ensure the pool is using the correct format
         auto pool_pixel_format = frame_pool_->pixel_format();
@@ -332,7 +337,7 @@ class html_client
         char*                                     dst   = reinterpret_cast<char*>(frame.first.image_data(0).begin());
         test_timer_.restart();
 
-        if (frame.second.has_value()) {
+        if (use_dirty_regions_ && frame.second.has_value()) {
             // The frame has dirty rectangles, so selectively copy those portions
             auto& rects = std::any_cast<std::vector<Rectangle>&>(frame.second);
 
@@ -506,9 +511,10 @@ class html_producer : public core::frame_producer
         , url_(url)
     {
         html::invoke([&] {
-            const bool enable_gpu = env::properties().get(L"configuration.html.enable-gpu", false);
+            const bool enable_gpu        = env::properties().get(L"configuration.html.enable-gpu", false);
+            const bool use_dirty_regions = env::properties().get(L"configuration.html.use-dirty-regions", false);
 
-            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, url_);
+            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, use_dirty_regions, url_);
 
             CefWindowInfo window_info;
             window_info.bounds.width                 = format_desc.square_width;

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -63,6 +63,7 @@
 #include <vector>
 
 #include "../html.h"
+#include "rectangles.h"
 
 namespace caspar { namespace html {
 
@@ -278,9 +279,19 @@ class html_client
         rect = CefRect(0, 0, format_desc_.square_width, format_desc_.square_height);
     }
 
-
-    void combine_rectangles(RectList& my_rects, const RectList& new_rects, int width, int height) {
-        // TODO
+    inline void copy_whole_frame(char* src, char* dst, int width, int height) {
+#ifdef WIN32
+        if (gpu_enabled_) {
+            int chunksize = height * width;
+            tbb::parallel_for(0, 4, [&](int y) { std::memcpy(dst + y * chunksize, src + y * chunksize, chunksize); });
+        } else {
+            std::memcpy(dst, src, width * height * 4);
+        }
+#else
+        // In my linux tests, doing a single memcpy doesn't have the same cost as windows,
+        // making using tbb excessive
+        std::memcpy(dst, src, width * height * 4);
+#endif
     }
 
 
@@ -301,12 +312,21 @@ class html_client
         if (type != PET_VIEW)
             return;
 
+        // Update the dirty rectangles for each frame in the pool
         frame_pool_->for_each([&](std::any& data) {
             if (!data.has_value()) {
-                data.emplace<RectList>();
+                std::vector<Rectangle> rects;
+                for (const auto &rect :dirtyRects) {
+                    rects.emplace_back(rect);
+                }
+                data.emplace<std::vector<Rectangle>>(std::move(rects));
+            } else {
+                auto& rects = std::any_cast<std::vector<Rectangle>&>(data);
+                for (const auto &rect :dirtyRects) {
+                    rects.emplace_back(rect);
+                }
+                merge_rectangles(rects, width, height);
             }
-            auto rects = std::any_cast<RectList>(data);
-            combine_rectangles(rects, dirtyRects, width, height);
         });
 
         std::pair<core::mutable_frame, std::any&> frame = frame_pool_->create_frame();
@@ -315,24 +335,40 @@ class html_client
         test_timer_.restart();
 
         if (frame.second.has_value()) {
-            auto rects = std::any_cast<RectList>(frame.second);
+            // The frame has dirty rectangles, so selectively copy those portions
+            auto& rects = std::any_cast<std::vector<Rectangle>&>(frame.second);
+
+            if (rects.empty() || (rects.size() == 1 && is_full_frame(rects[0], width, height))) {
+                copy_whole_frame(src, dst, width, height);
+            } else {
+                // int pixel_count = 0 ;
+                // for (const Rectangle& rect :rects) {
+                //     pixel_count += (rect.r_x - rect.l_x) * (rect.r_y - rect.l_y);
+                // }
+
+                int linesize = width * 4;
+                tbb::parallel_for(static_cast<std::size_t>(0), rects.size(), [&](std::size_t index) {
+                    const Rectangle & rect = rects[index];
+                    int rowcount = rect.r_y - rect.l_y;
+                    if (rect.r_x <= rect.l_x || rowcount <= 0) return; // Sanity check
+
+                    int start_offset = rect.l_y * linesize + rect.l_x*4;
+                    int chunksize = (rect.r_x - rect.l_x) * 4;
+
+                    // TODO - parallel?
+                    for (int y = 0; y < rowcount; ++y) {
+                        std::memcpy(dst + start_offset + y * linesize, src + start_offset + y * linesize, chunksize);
+                    }
+                });
+
+                // double percent = ((double)pixel_count) / (width * height) * 100;
+            }
+
             rects.clear();
-
-            // TODO - perform selective copy!
-        }
-
-#ifdef WIN32
-        if (gpu_enabled_) {
-            int chunksize = height * width;
-            tbb::parallel_for(0, 4, [&](int y) { std::memcpy(dst + y * chunksize, src + y * chunksize, chunksize); });
         } else {
-            std::memcpy(dst, src, width * height * 4);
+            // Either a new frame, or dirty rectangles are disabled
+            copy_whole_frame(src, dst, width, height);
         }
-#else
-        // In my linux tests, doing a single memcpy doesn't have the same cost as windows,
-        // making using tbb excessive
-        std::memcpy(dst, src, width * height * 4);
-#endif
 
         graph_->set_value("memcpy", test_timer_.elapsed() * format_desc_.fps * 0.5 * 5);
 

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -278,6 +278,12 @@ class html_client
         rect = CefRect(0, 0, format_desc_.square_width, format_desc_.square_height);
     }
 
+
+    void combine_rectangles(RectList& my_rects, const RectList& new_rects, int width, int height) {
+        // TODO
+    }
+
+
     void OnPaint(CefRefPtr<CefBrowser> browser,
                  PaintElementType      type,
                  const RectList&       dirtyRects,
@@ -295,10 +301,25 @@ class html_client
         if (type != PET_VIEW)
             return;
 
-        core::mutable_frame frame = frame_pool_->create_frame();
+        frame_pool_->for_each([&](std::any& data) {
+            if (!data.has_value()) {
+                data.emplace<RectList>();
+            }
+            auto rects = std::any_cast<RectList>(data);
+            combine_rectangles(rects, dirtyRects, width, height);
+        });
+
+        std::pair<core::mutable_frame, std::any&> frame = frame_pool_->create_frame();
         char*               src   = (char*)buffer;
-        char*               dst   = reinterpret_cast<char*>(frame.image_data(0).begin());
+        char*               dst   = reinterpret_cast<char*>(frame.first.image_data(0).begin());
         test_timer_.restart();
+
+        if (frame.second.has_value()) {
+            auto rects = std::any_cast<RectList>(frame.second);
+            rects.clear();
+
+            // TODO - perform selective copy!
+        }
 
 #ifdef WIN32
         if (gpu_enabled_) {
@@ -319,7 +340,7 @@ class html_client
             std::lock_guard<std::mutex> lock(frames_mutex_);
 
             frames_.push(std::make_pair(now(), core::draw_frame(std::move(frame))));
-            while (frames_.size() > 4) {
+            while (frames_.size() > frames_max_size_) {
                 frames_.pop();
                 graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
             }

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -121,7 +121,6 @@ class html_client
         graph_->set_text(print());
         diagnostics::register_graph(graph_);
 
-        // TODO - is this the correct way to define the format?
         core::pixel_format_desc pixel_desc(core::pixel_format::bgra);
         pixel_desc.planes.emplace_back(format_desc_.square_width, format_desc_.square_height, 4);
         frame_pool_ = frame_factory_->create_frame_pool(this, pixel_desc);
@@ -318,6 +317,15 @@ class html_client
                 merge_rectangles(rects, width, height);
             }
         });
+
+        // Ensure the pool is using the correct format
+        auto pool_pixel_format = frame_pool_->pixel_format();
+        if (pool_pixel_format.planes.empty() || pool_pixel_format.planes[0].height != height ||
+            pool_pixel_format.planes[0].width != width) {
+            core::pixel_format_desc pixel_desc(core::pixel_format::bgra);
+            pixel_desc.planes.emplace_back(width, height, 4);
+            frame_pool_->pixel_format(pixel_desc);
+        }
 
         std::pair<core::mutable_frame, std::any&> frame = frame_pool_->create_frame();
         char*                                     src   = (char*)buffer;

--- a/src/modules/html/producer/rectangles.cpp
+++ b/src/modules/html/producer/rectangles.cpp
@@ -19,6 +19,8 @@
  * Author: Julian Waller, julian@superfly.tv
  */
 
+#define NOMINMAX
+
 #include "rectangles.h"
 
 #include <algorithm>

--- a/src/modules/html/producer/rectangles.cpp
+++ b/src/modules/html/producer/rectangles.cpp
@@ -27,7 +27,14 @@ namespace caspar::html {
 
 bool is_full_frame(const Rectangle& rect, int width, int height)
 {
-    return rect.l_x == 0 && rect.l_y == 0 && rect.r_x == width && rect.r_y == height;
+    // Use some tolerance, so that when we get close to being the full frame, we copy everything
+    int tolerance_n = 9;
+    int tolerance_d = 10;
+
+    int target_pixel_count = (width * height * tolerance_n) / tolerance_d;
+    int rect_pixel_count   = (rect.r_x - rect.l_x) * (rect.r_y - rect.l_y);
+
+    return rect_pixel_count >= target_pixel_count;
 }
 
 bool are_any_full_frame(const std::vector<Rectangle>& rects, int width, int height)

--- a/src/modules/html/producer/rectangles.cpp
+++ b/src/modules/html/producer/rectangles.cpp
@@ -21,6 +21,8 @@
 
 #include "rectangles.h"
 
+#include <algorithm>
+
 namespace caspar::html {
 
 bool is_full_frame(const Rectangle& rect, int width, int height)
@@ -116,32 +118,5 @@ bool merge_rectangles(std::vector<Rectangle>& rects, int width, int height)
     // TODO - recursive?
     return true;
 }
-
-/*
-std::vector<CefRect>
-combine_rectangles(const std::vector<CefRect>& my_rects, const std::vector<CefRect>& new_rects, int width, int height)
-{
-    if (new_rects.empty())
-        return my_rects;
-
-    // Nothing to compare to
-    if (my_rects.empty()) {
-        // TODO: This assumes CEF provides isolated non-overlapping rectangles
-        return new_rects;
-    }
-
-    // If any are full-frame, then that is the only rectangle of interest
-    bool full_frame = are_any_full_frame(my_rects, width, height) || are_any_full_frame(new_rects, width, height);
-    if (full_frame) {
-        return {CefRect(0, 0, width, height)};
-    }
-
-    std::vector<CefRect> updated_rects = my_rects;
-
-    // TODO
-
-    return updated_rects;
-}
- */
 
 } // namespace caspar::html

--- a/src/modules/html/producer/rectangles.cpp
+++ b/src/modules/html/producer/rectangles.cpp
@@ -115,7 +115,6 @@ bool merge_rectangles(std::vector<Rectangle>& rects, int width, int height)
     // Snip out any rectangles that are invalid
     rects.erase(remove_if(rects.begin(), rects.end(), is_invalid), rects.end());
 
-    // TODO - recursive?
     return true;
 }
 

--- a/src/modules/html/producer/rectangles.cpp
+++ b/src/modules/html/producer/rectangles.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#include "rectangles.h"
+
+namespace caspar::html {
+
+bool is_full_frame(const Rectangle& rect, int width, int height)
+{
+    return rect.l_x == 0 && rect.l_y == 0 && rect.r_x == width && rect.r_y == height;
+}
+
+bool are_any_full_frame(const std::vector<Rectangle>& rects, int width, int height)
+{
+    return std::any_of(
+        rects.begin(), rects.end(), [&](const Rectangle& rect) { return is_full_frame(rect, width, height); });
+}
+
+bool should_merge_rectanges(const Rectangle& a, const Rectangle& b)
+{
+    int x_tolerance = 100; // Use some collision tolerance, so that we don't do too many memcpy per line
+
+    // If one rectangle is on left side of other
+    if (a.l_x > b.r_x + x_tolerance || b.l_x > a.r_x + x_tolerance)
+        return false;
+
+    // If one rectangle is above other
+    if (a.r_y < b.l_y || b.r_y < a.l_y)
+        return false;
+
+    return true;
+}
+
+bool is_invalid(const Rectangle& rect) { return rect.invalid; }
+
+struct
+{
+    bool operator()(const Rectangle& a, const Rectangle& b) const
+    {
+        if (a.l_y == b.l_y) {
+            // Secondary sort by x
+            return a.l_x < b.l_x;
+        } else {
+            return a.l_y < b.l_y;
+        }
+    }
+} compare_slices;
+
+bool merge_rectangles(std::vector<Rectangle>& rects, int width, int height)
+{
+    // If there is 0 or 1 rectangles, there is nothing to merge
+    if (rects.size() <= 1)
+        return false;
+
+    // If any are full-frame, then that is the only rectangle of interest
+    bool full_frame = are_any_full_frame(rects, width, height);
+    if (full_frame) {
+        rects.clear();
+        rects.emplace_back(0, 0, width, height);
+        return true;
+    }
+
+    std::sort(rects.begin(), rects.end(), compare_slices);
+
+    bool has_changes = false;
+
+    // Iterate through rectangles, merging any that overlap.
+    for (auto first = rects.begin(); first != rects.end(); ++first) {
+        // Skip over any slices that have been merged.
+        if (first->invalid)
+            continue;
+
+        // Iterate through all following slices
+        for (auto second = first + 1; second != rects.end(); ++second) {
+            // Skip over any slices that have been merged.
+            if (second->invalid)
+                continue;
+
+            if (should_merge_rectanges(*first, *second)) {
+                first->l_x = std::min(first->l_x, second->l_x);
+                first->l_y = std::min(first->l_y, second->l_y);
+                first->r_x = std::max(first->r_x, second->r_x);
+                first->r_y = std::max(first->r_y, second->r_y);
+
+                // Mark the second slice as having been merged.
+                second->invalid = true;
+                has_changes     = true;
+            }
+        }
+    }
+
+    if (!has_changes)
+        return false;
+
+    // Snip out any rectangles that are invalid
+    rects.erase(remove_if(rects.begin(), rects.end(), is_invalid), rects.end());
+
+    // TODO - recursive?
+    return true;
+}
+
+/*
+std::vector<CefRect>
+combine_rectangles(const std::vector<CefRect>& my_rects, const std::vector<CefRect>& new_rects, int width, int height)
+{
+    if (new_rects.empty())
+        return my_rects;
+
+    // Nothing to compare to
+    if (my_rects.empty()) {
+        // TODO: This assumes CEF provides isolated non-overlapping rectangles
+        return new_rects;
+    }
+
+    // If any are full-frame, then that is the only rectangle of interest
+    bool full_frame = are_any_full_frame(my_rects, width, height) || are_any_full_frame(new_rects, width, height);
+    if (full_frame) {
+        return {CefRect(0, 0, width, height)};
+    }
+
+    std::vector<CefRect> updated_rects = my_rects;
+
+    // TODO
+
+    return updated_rects;
+}
+ */
+
+} // namespace caspar::html

--- a/src/modules/html/producer/rectangles.h
+++ b/src/modules/html/producer/rectangles.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <vector>
+
+#pragma warning(push)
+#pragma warning(disable : 4458)
+#include <algorithm>
+#include <include/cef_render_handler.h>
+#pragma warning(pop)
+
+namespace caspar::html {
+
+struct Rectangle
+{
+    Rectangle(int l_x, int l_y, int r_x, int r_y)
+        : l_x(l_x)
+        , l_y(l_y)
+        , r_x(r_x)
+        , r_y(r_y)
+    {
+    }
+
+    Rectangle(const CefRect& rect)
+        : l_x(rect.x)
+        , l_y(rect.y)
+        , r_x(rect.x + rect.width)
+        , r_y(rect.y + rect.height)
+    {
+    }
+
+    int l_x;
+    int l_y;
+    int r_x;
+    int r_y;
+
+    bool invalid = false;
+};
+
+bool is_full_frame(const Rectangle& rect, int width, int height);
+
+bool merge_rectangles(std::vector<Rectangle>& rects, int width, int height);
+
+} // namespace caspar::html

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -2,7 +2,7 @@
 
 <configuration>
     <paths>
-        <media-path>media/</media-path>
+        <media-path>/home/julus/Projects/caspar_media/</media-path>
         <log-path disable="false">log/</log-path>
         <data-path>data/</data-path>
         <template-path>template/</template-path>
@@ -10,11 +10,15 @@
     <lock-clear-phrase>secret</lock-clear-phrase>
     <channels>
         <channel>
-            <video-mode>720p5000</video-mode>
+            <video-mode>1080p5000</video-mode>
             <consumers>
-                <screen />
-                <system-audio />
+                <decklink>
+                    <device>1</device>
+                </decklink>
             </consumers>
+            <producers>
+                <producer id="10">[html] https://www.testufo.com/</producer>
+            </producers>
         </channel>
     </channels>
     <controllers>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -2,7 +2,7 @@
 
 <configuration>
     <paths>
-        <media-path>/home/julus/Projects/caspar_media/</media-path>
+        <media-path>media/</media-path>
         <log-path disable="false">log/</log-path>
         <data-path>data/</data-path>
         <template-path>template/</template-path>
@@ -10,15 +10,11 @@
     <lock-clear-phrase>secret</lock-clear-phrase>
     <channels>
         <channel>
-            <video-mode>1080p5000</video-mode>
+            <video-mode>720p5000</video-mode>
             <consumers>
-                <decklink>
-                    <device>1</device>
-                </decklink>
+                <screen />
+                <system-audio />
             </consumers>
-            <producers>
-                <producer id="10">[html] https://www.testufo.com/</producer>
-            </producers>
         </channel>
     </channels>
     <controllers>
@@ -60,6 +56,7 @@
     <remote-debugging-port>0 [0|1024-65535]</remote-debugging-port>
     <enable-gpu>false [true|false]</enable-gpu>
 	<angle-backend>gl [|gl|d3d11|d3d9]</angle-backend>
+    <use-dirty-regions>false [true|false]</use-dirty-regions>
 </html>
 <system-audio>
     <producer>


### PR DESCRIPTION
Reopen accidentally closed #1510 

This is a prototype which makes use of the dirty rectangles as reported by CEF to minimise the pixel copying from CEF to OpenGL pixel buffers. This copying was found to be rather slow on windows with gpu-enabled.

Performance of this has not been investigated yet