### PR TITLE
Add support for edgeblending

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -265,6 +265,20 @@ struct image_kernel::impl
             shader_->set("chroma", false);
         }
 
+        if (params.transform.edgeblend.left > epsilon || params.transform.edgeblend.right > epsilon ||
+            params.transform.edgeblend.top > epsilon || params.transform.edgeblend.bottom > epsilon) {
+            shader_->set("edgeblend", true);
+            shader_->set("edgeblend_left", params.transform.edgeblend.left);
+            shader_->set("edgeblend_right", params.transform.edgeblend.right);
+            shader_->set("edgeblend_top", params.transform.edgeblend.top);
+            shader_->set("edgeblend_bottom", params.transform.edgeblend.bottom);
+            shader_->set("edgeblend_g", params.transform.edgeblend.g);
+            shader_->set("edgeblend_p", params.transform.edgeblend.p);
+            shader_->set("edgeblend_a", params.transform.edgeblend.a);
+        } else {
+            shader_->set("edgeblend", false);
+        }
+
         // Setup blend_func
 
         if (params.transform.is_key) {

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -99,6 +99,13 @@ image_transform& image_transform::operator*=(const image_transform& other)
     chroma.spill_suppress = std::max(other.chroma.spill_suppress, chroma.spill_suppress);
     chroma.spill_suppress_saturation =
         std::min(other.chroma.spill_suppress_saturation, chroma.spill_suppress_saturation);
+    edgeblend.left = std::max(edgeblend.left, other.edgeblend.left);
+    edgeblend.right = std::max(edgeblend.right, other.edgeblend.right);
+    edgeblend.top = std::max(edgeblend.top, other.edgeblend.top);
+    edgeblend.bottom = std::max(edgeblend.bottom, other.edgeblend.bottom);
+    edgeblend.g = std::max(edgeblend.g, other.edgeblend.g);
+    edgeblend.p = std::max(edgeblend.p, other.edgeblend.p);
+    edgeblend.a = std::max(edgeblend.a, other.edgeblend.a);
     is_key |= other.is_key;
     invert |= other.invert;
     is_mix |= other.is_mix;
@@ -175,6 +182,10 @@ image_transform image_transform::tween(double                 time,
     result.levels.max_output   = do_tween(time, source.levels.max_output, dest.levels.max_output, duration, tween);
     result.levels.min_output   = do_tween(time, source.levels.min_output, dest.levels.min_output, duration, tween);
     result.levels.gamma        = do_tween(time, source.levels.gamma, dest.levels.gamma, duration, tween);
+    result.edgeblend.bottom        = do_tween(time, source.edgeblend.bottom, dest.edgeblend.bottom, duration, tween);
+    result.edgeblend.top        = do_tween(time, source.edgeblend.top, dest.edgeblend.top, duration, tween);
+    result.edgeblend.right        = do_tween(time, source.edgeblend.right, dest.edgeblend.right, duration, tween);
+    result.edgeblend.left        = do_tween(time, source.edgeblend.left, dest.edgeblend.left, duration, tween);
     result.chroma.target_hue   = do_tween(time, source.chroma.target_hue, dest.chroma.target_hue, duration, tween);
     result.chroma.hue_width    = do_tween(time, source.chroma.hue_width, dest.chroma.hue_width, duration, tween);
     result.chroma.min_saturation =
@@ -228,7 +239,12 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
            eq(lhs.chroma.min_saturation, rhs.chroma.min_saturation) &&
            eq(lhs.chroma.min_brightness, rhs.chroma.min_brightness) && eq(lhs.chroma.softness, rhs.chroma.softness) &&
            eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
-           eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
+           eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) &&
+           eq(lhs.edgeblend.bottom, rhs.edgeblend.bottom) &&
+           eq(lhs.edgeblend.right, rhs.edgeblend.right) &&
+           eq(lhs.edgeblend.left, rhs.edgeblend.left) &&
+           eq(lhs.edgeblend.top, rhs.edgeblend.top) &&
+           lhs.crop == rhs.crop &&
            lhs.perspective == rhs.perspective;
 }
 

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -50,6 +50,17 @@ struct chroma
     double spill_suppress_saturation = 1.0;
 };
 
+struct edgeblend {
+    double left   = 0.0;
+    double right  = 0.0;
+    double top    = 0.0;
+    double bottom = 0.0;
+
+    double g      = 1.8;
+    double p      = 3.0;
+    double a      = 0.5;
+};
+
 struct levels final
 {
     double min_input  = 0.0;
@@ -90,6 +101,7 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    core::edgeblend       edgeblend;
 
     bool             is_key      = false;
     bool             invert      = false;


### PR DESCRIPTION
This PR adds a new mixer command for adding edgeblending used for overlaying projector feeds. The math is based on this article https://paulbourke.net/miscellaneous/edgeblend/. This feature could be improved so any feedback is much appreciated. The feature stems from that this is essential to our team using caspar as we need the functionality. I've only minimally tested the feature, and I have not had access to test it on real projectors yet, so any help in testing it would be much appreciated as well.