### PR TITLE
Move cache-path under html in config example.

### DIFF
--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -45,7 +45,6 @@
 <flash>
     <enabled>false [true|false]</enabled>
     <buffer-depth>auto [auto|1..]</buffer-depth>
-    <cache-path>(CEF writes some caches next to the executable, which can fail depending on permissions. This changes it to use another path)</cache-path>
 </flash>
 <ffmpeg>
     <producer>
@@ -57,6 +56,7 @@
     <remote-debugging-port>0 [0|1024-65535]</remote-debugging-port>
     <enable-gpu>false [true|false]</enable-gpu>
 	<angle-backend>gl [|gl|d3d11|d3d9]</angle-backend>
+    <cache-path>(CEF writes some caches next to the executable, which can fail depending on permissions. This changes it to use another path)</cache-path>
 </html>
 <system-audio>
     <producer>


### PR DESCRIPTION
New config option appears to be in the wrong place in the sample config file.