### PR TITLE
chore: Improve Dockerfile for non-docker applications

### DIFF
--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jammy as build-casparcg
+FROM docker.io/buildpack-deps:jammy as build-casparcg
 	ADD tools/linux/install-dependencies /
 
 	RUN apt-get update && /install-dependencies
@@ -24,7 +24,7 @@ FROM buildpack-deps:jammy as build-casparcg
 	RUN ln -s /build/staging /staging && \
 		/source/shell/copy_deps.sh /staging/bin/casparcg /staging/lib
 
-FROM nvidia/opengl:1.2-glvnd-devel-ubuntu22.04
+FROM docker.io/nvidia/opengl:1.2-glvnd-devel-ubuntu22.04
 	COPY --from=build-casparcg /staging /opt/casparcg
 
 	RUN set -ex; \


### PR DESCRIPTION
For applications that are not the official docker, eg podman they do not by default search the dockerhub repository, it is better to explicity place the repository in the image name