### PR TITLE
Fix NDI video stretched

### DIFF
--- a/src/modules/newtek/CMakeLists.txt
+++ b/src/modules/newtek/CMakeLists.txt
@@ -1,51 +1,31 @@
-cmake_minimum_required (VERSION 3.16)
-project (newtek)
+cmake_minimum_required(VERSION 3.16)
+project(newtek)
 
-set(SOURCES
-		consumer/newtek_ndi_consumer.cpp
-
-		producer/newtek_ndi_producer.cpp
-
-		util/ndi.cpp
-
-		newtek.cpp
-
-)
+set(SOURCES consumer/newtek_ndi_consumer.cpp producer/newtek_ndi_producer.cpp
+            util/ndi.cpp newtek.cpp)
 set(HEADERS
-		consumer/newtek_ndi_consumer.h
+    consumer/newtek_ndi_consumer.h
+    producer/newtek_ndi_producer.h
+    util/ndi.h
+    newtek.h
+    interop/Processing.NDI.compat.h
+    interop/Processing.NDI.deprecated.h
+    interop/Processing.NDI.DynamicLoad.h
+    interop/Processing.NDI.Find.h
+    interop/Processing.NDI.FrameSync.h
+    interop/Processing.NDI.Lib.cplusplus.h
+    interop/Processing.NDI.Lib.h
+    interop/Processing.NDI.Recv.ex.h
+    interop/Processing.NDI.Recv.h
+    interop/Processing.NDI.Routing.h
+    interop/Processing.NDI.Send.h
+    interop/Processing.NDI.structs.h
+    interop/Processing.NDI.utilities.h
+    StdAfx.h)
 
-		producer/newtek_ndi_producer.h
-
-		util/ndi.h
-
-		newtek.h
-
-		interop/Processing.NDI.compat.h
-		interop/Processing.NDI.deprecated.h
-		interop/Processing.NDI.DynamicLoad.h
-		interop/Processing.NDI.Find.h
-		interop/Processing.NDI.FrameSync.h
-		interop/Processing.NDI.Lib.cplusplus.h
-		interop/Processing.NDI.Lib.h
-		interop/Processing.NDI.Recv.ex.h
-		interop/Processing.NDI.Recv.h
-		interop/Processing.NDI.Routing.h
-		interop/Processing.NDI.Send.h
-		interop/Processing.NDI.structs.h
-		interop/Processing.NDI.utilities.h
-
-		StdAfx.h
-)
-
-casparcg_add_module_project(newtek
-	SOURCES ${SOURCES} ${HEADERS}
-	INIT_FUNCTION "newtek::init"
-)
-target_include_directories(newtek PRIVATE
-    ..
-    ../..
-    ${FFMPEG_INCLUDE_PATH}
-    )
+casparcg_add_module_project(newtek SOURCES ${SOURCES} ${HEADERS} INIT_FUNCTION
+                            "newtek::init")
+target_include_directories(newtek PRIVATE .. ../.. ${FFMPEG_INCLUDE_PATH})
 target_precompile_headers(newtek PRIVATE "StdAfx.h")
 
 set_target_properties(newtek PROPERTIES FOLDER modules)
@@ -55,6 +35,4 @@ source_group(sources\\interop interop/*)
 source_group(sources\\util util/*)
 source_group(sources ./*)
 
-target_link_libraries(newtek
-    ffmpeg
-)
+target_link_libraries(newtek ${FFMPEG_LIBRARIES})


### PR DESCRIPTION
This is a potential fix for https://github.com/CasparCG/server/issues/1542, unfortunately I cannot test on windows right now but it does work on linux with and without alpha and at multiple resolutions. Since I suspect there were no issues on windows I rather used an ifdef to not touch the code that runs on windows.