### PR TITLE
fix: Remove RPATH linking

### DIFF
--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -92,8 +92,6 @@ else ()
 		z
 		pthread
 	)
-
-    set_target_properties(casparcg PROPERTIES INSTALL_RPATH "$ORIGIN/../lib" BUILD_WITH_INSTALL_RPATH ON)
 endif ()
 
 add_custom_target(casparcg_copy_dependencies ALL)


### PR DESCRIPTION
Commit e0bbb969b171c85332e77ee8b50f29b4634b7ad7 changed how casparcg is linked and launched on Linux, which caused a few problems.

It was partially reverted by ff1c0ba926c014f08e4c62af8e9c86013dd08a56 which restored how casparcg is launched, and this commit reverts the linking part.