### PR TITLE
fix: compilation on 32bit platforms

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -643,8 +643,8 @@ class decklink_producer : public IDeckLinkInputCallback
                 state_["has_signal"]             = has_signal_;
 
                 if (video) {
-                    state_["file/video/width"]  = video->GetWidth();
-                    state_["file/video/height"] = video->GetHeight();
+                    state_["file/video/width"]  = static_cast<int>(video->GetWidth());
+                    state_["file/video/height"] = static_cast<int>(video->GetHeight());
                 }
             }
 


### PR DESCRIPTION
On 32bit platforms passing `long` to `data_t` causes ambiguity, because it doesn't map directly into any of the types held by `data_t`.