### PR TITLE
feat: rework mixer transforms

### DIFF
--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -10,6 +10,8 @@ set(SOURCES
 	ogl/util/device.cpp
 	ogl/util/shader.cpp
 	ogl/util/texture.cpp
+	ogl/util/matrix.cpp
+	ogl/util/transforms.cpp
 
 	accelerator.cpp
 )
@@ -22,6 +24,8 @@ set(HEADERS
 	ogl/util/device.h
 	ogl/util/shader.h
 	ogl/util/texture.h
+	ogl/util/matrix.h
+	ogl/util/transforms.h
 
 	ogl_image_vertex.h
 	ogl_image_fragment.h

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -40,46 +40,7 @@
 #include <array>
 #include <cmath>
 
-namespace caspar { namespace accelerator { namespace ogl {
-
-// http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-bool get_line_intersection(double  p0_x,
-                           double  p0_y,
-                           double  p1_x,
-                           double  p1_y,
-                           double  p2_x,
-                           double  p2_y,
-                           double  p3_x,
-                           double  p3_y,
-                           double& result_x,
-                           double& result_y)
-{
-    double s1_x = p1_x - p0_x;
-    double s1_y = p1_y - p0_y;
-    double s2_x = p3_x - p2_x;
-    double s2_y = p3_y - p2_y;
-
-    double s = (-s1_y * (p0_x - p2_x) + s1_x * (p0_y - p2_y)) / (-s2_x * s1_y + s1_x * s2_y);
-    double t = (s2_x * (p0_y - p2_y) - s2_y * (p0_x - p2_x)) / (-s2_x * s1_y + s1_x * s2_y);
-
-    if (s >= 0 && s <= 1 && t >= 0 && t <= 1) {
-        // Collision detected
-        result_x = p0_x + t * s1_x;
-        result_y = p0_y + t * s1_y;
-
-        return true;
-    }
-
-    return false; // No collision
-}
-
-double hypotenuse(double x1, double y1, double x2, double y2)
-{
-    auto x = x2 - x1;
-    auto y = y2 - y1;
-
-    return std::sqrt(x * x + y * y);
-}
+namespace caspar::accelerator::ogl {
 
 double get_precision_factor(common::bit_depth depth)
 {
@@ -95,11 +56,6 @@ double get_precision_factor(common::bit_depth depth)
         default:
             return 1.0;
     }
-}
-
-double calc_q(double close_diagonal, double distant_diagonal)
-{
-    return (close_diagonal + distant_diagonal) / distant_diagonal;
 }
 
 bool is_above_screen(double y) { return y < 0.0; }
@@ -122,6 +78,8 @@ bool is_outside_screen(const std::vector<core::frame_geometry::coord>& coords)
            boost::algorithm::all_of(y_coords, &is_above_screen) || boost::algorithm::all_of(y_coords, &is_below_screen);
 }
 
+static const double epsilon = 0.001;
+
 struct image_kernel::impl
 {
     spl::shared_ptr<device> ogl_;
@@ -129,9 +87,14 @@ struct image_kernel::impl
     GLuint                  vao_;
     GLuint                  vbo_;
 
+    spl::shared_ptr<texture> white_texture_;
+
     explicit impl(const spl::shared_ptr<device>& ogl)
         : ogl_(ogl)
         , shader_(ogl_->dispatch_sync([&] { return get_image_shader(ogl); }))
+        , white_texture_(
+              ogl_->copy_async(caspar::array<uint8_t>(std::vector<uint8_t>{255}), 1, 1, 1, common::bit_depth::bit8)
+                  .get())
     {
         ogl_->dispatch_sync([&] {
             GL(glGenVertexArrays(1, &vao_));
@@ -149,131 +112,98 @@ struct image_kernel::impl
 
     void draw(draw_params params)
     {
-        static const double epsilon = 0.001;
-
         CASPAR_ASSERT(params.pix_desc.planes.size() == params.textures.size());
 
         if (params.textures.empty() || !params.background) {
             return;
         }
 
-        if (params.transform.opacity < epsilon) {
+        if (params.transforms.image_transform.opacity < epsilon) {
             return;
         }
 
         auto coords = params.geometry.data();
-
         if (coords.empty()) {
             return;
         }
 
-        // Calculate transforms
-        auto f_p = params.transform.fill_translation;
-        auto f_s = params.transform.fill_scale;
-
-        bool is_default_geometry = boost::equal(coords, core::frame_geometry::get_default().data()) ||
-                                   boost::equal(coords, core::frame_geometry::get_default_vflip().data());
-        auto aspect = params.aspect_ratio;
-        auto angle  = params.transform.angle;
-        auto anchor = params.transform.anchor;
-        auto crop   = params.transform.crop;
-        auto pers   = params.transform.perspective;
-        pers.ur[0] -= 1.0;
-        pers.lr[0] -= 1.0;
-        pers.lr[1] -= 1.0;
-        pers.ll[1] -= 1.0;
-        std::vector<std::array<double, 2>> pers_corners = {pers.ul, pers.ur, pers.lr, pers.ll};
-
-        auto do_crop = [&](core::frame_geometry::coord& coord) {
-            if (!is_default_geometry) {
-                // TODO implement support for non-default geometry.
-                return;
-            }
-
-            coord.vertex_x  = std::max(coord.vertex_x, crop.ul[0]);
-            coord.vertex_x  = std::min(coord.vertex_x, crop.lr[0]);
-            coord.vertex_y  = std::max(coord.vertex_y, crop.ul[1]);
-            coord.vertex_y  = std::min(coord.vertex_y, crop.lr[1]);
-            coord.texture_x = std::max(coord.texture_x, crop.ul[0]);
-            coord.texture_x = std::min(coord.texture_x, crop.lr[0]);
-            coord.texture_y = std::max(coord.texture_y, crop.ul[1]);
-            coord.texture_y = std::min(coord.texture_y, crop.lr[1]);
-        };
-        auto do_perspective = [=](core::frame_geometry::coord& coord, const std::array<double, 2>& pers_corner) {
-            if (!is_default_geometry) {
-                // TODO implement support for non-default geometry.
-                return;
-            }
-
-            coord.vertex_x += pers_corner[0];
-            coord.vertex_y += pers_corner[1];
-        };
-        auto rotate = [&](core::frame_geometry::coord& coord) {
-            auto orig_x    = (coord.vertex_x - anchor[0]) * f_s[0];
-            auto orig_y    = (coord.vertex_y - anchor[1]) * f_s[1] / aspect;
-            coord.vertex_x = orig_x * std::cos(angle) - orig_y * std::sin(angle);
-            coord.vertex_y = orig_x * std::sin(angle) + orig_y * std::cos(angle);
-            coord.vertex_y *= aspect;
-        };
-        auto move = [&](core::frame_geometry::coord& coord) {
-            coord.vertex_x += f_p[0];
-            coord.vertex_y += f_p[1];
-        };
-
         auto const first_plane = params.pix_desc.planes.at(0);
         if (params.geometry.mode() != core::frame_geometry::scale_mode::stretch && first_plane.width > 0 &&
             first_plane.height > 0) {
-            auto width_scale  = static_cast<double>(params.target_width) / static_cast<double>(first_plane.width);
-            auto height_scale = static_cast<double>(params.target_height) / static_cast<double>(first_plane.height);
+            /* auto width_scale  = static_cast<double>(params.target_width) / static_cast<double>(first_plane.width);
+             auto height_scale = static_cast<double>(params.target_height) / static_cast<double>(first_plane.height);*/
 
-            double target_scale;
-            switch (params.geometry.mode()) {
-                case core::frame_geometry::scale_mode::fit:
-                    target_scale = std::min(width_scale, height_scale);
-                    f_s[0] *= target_scale / width_scale;
-                    f_s[1] *= target_scale / height_scale;
-                    break;
-
-                case core::frame_geometry::scale_mode::fill:
-                    target_scale = std::max(width_scale, height_scale);
-                    f_s[0] *= target_scale / width_scale;
-                    f_s[1] *= target_scale / height_scale;
-                    break;
-
-                case core::frame_geometry::scale_mode::original:
-                    f_s[0] /= width_scale;
-                    f_s[1] /= height_scale;
-                    break;
-
-                case core::frame_geometry::scale_mode::hfill:
-                    f_s[1] *= width_scale / height_scale;
-                    break;
-
-                case core::frame_geometry::scale_mode::vfill:
-                    f_s[0] *= height_scale / width_scale;
-                    break;
-
-                default:;
-            }
+            // HACK: TODO
+            //            double target_scale;
+            //			switch (params.geometry.mode()) {
+            //                case core::frame_geometry::scale_mode::fit:
+            //                    target_scale = std::min(width_scale, height_scale);
+            //                    f_s[0] *= target_scale / width_scale;
+            //                    f_s[1] *= target_scale / height_scale;
+            //                    break;
+            //
+            //                case core::frame_geometry::scale_mode::fill:
+            //                    target_scale = std::max(width_scale, height_scale);
+            //                    f_s[0] *= target_scale / width_scale;
+            //                    f_s[1] *= target_scale / height_scale;
+            //                    break;
+            //
+            //                case core::frame_geometry::scale_mode::original:
+            //                    f_s[0] /= width_scale;
+            //                    f_s[1] /= height_scale;
+            //                    break;
+            //
+            //                case core::frame_geometry::scale_mode::hfill:
+            //                    f_s[1] *= width_scale / height_scale;
+            //                    break;
+            //
+            //                case core::frame_geometry::scale_mode::vfill:
+            //                    f_s[0] *= height_scale / width_scale;
+            //                    break;
+            //
+            //                default:;
+            //			}
         }
 
-        int corner = 0;
-        for (auto& coord : coords) {
-            do_crop(coord);
-            do_perspective(coord, pers_corners.at(corner));
-            rotate(coord);
-            move(coord);
-
-            if (++corner == 4) {
-                corner = 0;
-            }
-        }
+        auto transformed_coords = params.transforms.transform_coords(coords);
 
         // Skip drawing if all the coordinates will be outside the screen.
-        if (is_outside_screen(coords)) {
+        if (transformed_coords.cropped_coords.size() < 3 || is_outside_screen(transformed_coords.cropped_coords)) {
             return;
         }
 
+        if (!transformed_coords.uncropped_coords.empty()) {
+            // If separate uncropped_coords were provided, then we need to do a first pass to generate a new mask.
+            // This could probably be done mathematically to figure out the correct texture_q values to allow doing this
+            // in one pass, but this is rather edge case logic, only applicable when perspective is used
+
+            auto modified_local_key =
+                ogl_->create_texture(params.target_width, params.target_height, 1, common::bit_depth::bit8);
+
+            draw_params tmp_params;
+            tmp_params.target_width    = params.target_width;
+            tmp_params.target_height   = params.target_height;
+            tmp_params.pix_desc.format = core::pixel_format::gray;
+            tmp_params.pix_desc.planes = {core::pixel_format_desc::plane(1, 1, 1, common::bit_depth::bit8)};
+            tmp_params.textures        = {white_texture_};
+            tmp_params.background      = modified_local_key; // Debug: set to params.background to see the crop region instead
+            tmp_params.local_key       = params.local_key;
+            tmp_params.aspect_ratio    = params.aspect_ratio;
+
+            // Draw the first pass
+            draw_unchecked(tmp_params, transformed_coords.cropped_coords);
+
+            // Do the final pass with the textute coordinates and the modified local_key
+            params.local_key = std::move(modified_local_key);
+            draw_unchecked(params, transformed_coords.uncropped_coords);
+        } else {
+            // Draw with the cropped coordinates
+            draw_unchecked(params, transformed_coords.cropped_coords);
+        }
+    }
+
+    void draw_unchecked(draw_params params, const std::vector<core::frame_geometry::coord>& coords) const
+    {
         double precision_factor[4] = {1, 1, 1, 1};
 
         // Bind textures
@@ -324,25 +254,27 @@ struct image_kernel::impl
         shader_->set("has_local_key", static_cast<bool>(params.local_key));
         shader_->set("has_layer_key", static_cast<bool>(params.layer_key));
         shader_->set("pixel_format", params.pix_desc.format);
-        shader_->set("opacity", params.transform.is_key ? 1.0 : params.transform.opacity);
+        shader_->set("opacity",
+                     params.transforms.image_transform.is_key ? 1.0 : params.transforms.image_transform.opacity);
 
-        if (params.transform.chroma.enable) {
+        if (params.transforms.image_transform.chroma.enable) {
             shader_->set("chroma", true);
-            shader_->set("chroma_show_mask", params.transform.chroma.show_mask);
-            shader_->set("chroma_target_hue", params.transform.chroma.target_hue / 360.0);
-            shader_->set("chroma_hue_width", params.transform.chroma.hue_width);
-            shader_->set("chroma_min_saturation", params.transform.chroma.min_saturation);
-            shader_->set("chroma_min_brightness", params.transform.chroma.min_brightness);
-            shader_->set("chroma_softness", 1.0 + params.transform.chroma.softness);
-            shader_->set("chroma_spill_suppress", params.transform.chroma.spill_suppress / 360.0);
-            shader_->set("chroma_spill_suppress_saturation", params.transform.chroma.spill_suppress_saturation);
+            shader_->set("chroma_show_mask", params.transforms.image_transform.chroma.show_mask);
+            shader_->set("chroma_target_hue", params.transforms.image_transform.chroma.target_hue / 360.0);
+            shader_->set("chroma_hue_width", params.transforms.image_transform.chroma.hue_width);
+            shader_->set("chroma_min_saturation", params.transforms.image_transform.chroma.min_saturation);
+            shader_->set("chroma_min_brightness", params.transforms.image_transform.chroma.min_brightness);
+            shader_->set("chroma_softness", 1.0 + params.transforms.image_transform.chroma.softness);
+            shader_->set("chroma_spill_suppress", params.transforms.image_transform.chroma.spill_suppress / 360.0);
+            shader_->set("chroma_spill_suppress_saturation",
+                         params.transforms.image_transform.chroma.spill_suppress_saturation);
         } else {
             shader_->set("chroma", false);
         }
 
         // Setup blend_func
 
-        if (params.transform.is_key) {
+        if (params.transforms.image_transform.is_key) {
             params.blend_mode = core::blend_mode::normal;
         }
 
@@ -352,29 +284,31 @@ struct image_kernel::impl
         shader_->set("keyer", params.keyer);
 
         // Setup image-adjustements
-        shader_->set("invert", params.transform.invert);
+        shader_->set("invert", params.transforms.image_transform.invert);
 
-        if (params.transform.levels.min_input > epsilon || params.transform.levels.max_input < 1.0 - epsilon ||
-            params.transform.levels.min_output > epsilon || params.transform.levels.max_output < 1.0 - epsilon ||
-            std::abs(params.transform.levels.gamma - 1.0) > epsilon) {
+        if (params.transforms.image_transform.levels.min_input > epsilon ||
+            params.transforms.image_transform.levels.max_input < 1.0 - epsilon ||
+            params.transforms.image_transform.levels.min_output > epsilon ||
+            params.transforms.image_transform.levels.max_output < 1.0 - epsilon ||
+            std::abs(params.transforms.image_transform.levels.gamma - 1.0) > epsilon) {
             shader_->set("levels", true);
-            shader_->set("min_input", params.transform.levels.min_input);
-            shader_->set("max_input", params.transform.levels.max_input);
-            shader_->set("min_output", params.transform.levels.min_output);
-            shader_->set("max_output", params.transform.levels.max_output);
-            shader_->set("gamma", params.transform.levels.gamma);
+            shader_->set("min_input", params.transforms.image_transform.levels.min_input);
+            shader_->set("max_input", params.transforms.image_transform.levels.max_input);
+            shader_->set("min_output", params.transforms.image_transform.levels.min_output);
+            shader_->set("max_output", params.transforms.image_transform.levels.max_output);
+            shader_->set("gamma", params.transforms.image_transform.levels.gamma);
         } else {
             shader_->set("levels", false);
         }
 
-        if (std::abs(params.transform.brightness - 1.0) > epsilon ||
-            std::abs(params.transform.saturation - 1.0) > epsilon ||
-            std::abs(params.transform.contrast - 1.0) > epsilon) {
+        if (std::abs(params.transforms.image_transform.brightness - 1.0) > epsilon ||
+            std::abs(params.transforms.image_transform.saturation - 1.0) > epsilon ||
+            std::abs(params.transforms.image_transform.contrast - 1.0) > epsilon) {
             shader_->set("csb", true);
 
-            shader_->set("brt", params.transform.brightness);
-            shader_->set("sat", params.transform.saturation);
-            shader_->set("con", params.transform.contrast);
+            shader_->set("brt", params.transforms.image_transform.brightness);
+            shader_->set("sat", params.transforms.image_transform.saturation);
+            shader_->set("con", params.transforms.image_transform.contrast);
         } else {
             shader_->set("csb", false);
         }
@@ -384,110 +318,37 @@ struct image_kernel::impl
         GL(glViewport(0, 0, params.background->width(), params.background->height()));
         glDisable(GL_DEPTH_TEST);
 
-        auto m_p = params.transform.clip_translation;
-        auto m_s = params.transform.clip_scale;
-
-        bool scissor = m_p[0] > std::numeric_limits<double>::epsilon() ||
-                       m_p[1] > std::numeric_limits<double>::epsilon() ||
-                       m_s[0] < 1.0 - std::numeric_limits<double>::epsilon() ||
-                       m_s[1] < 1.0 - std::numeric_limits<double>::epsilon();
-
-        if (scissor) {
-            double w = static_cast<double>(params.background->width());
-            double h = static_cast<double>(params.background->height());
-
-            GL(glEnable(GL_SCISSOR_TEST));
-            GL(glScissor(static_cast<int>(m_p[0] * w),
-                         static_cast<int>(m_p[1] * h),
-                         std::max(0, static_cast<int>(m_s[0] * w)),
-                         std::max(0, static_cast<int>(m_s[1] * h))));
-        }
-
         // Set render target
         params.background->attach();
 
-        // Perspective correction
-        double diagonal_intersection_x;
-        double diagonal_intersection_y;
-
-        if (get_line_intersection(pers.ul[0] + crop.ul[0],
-                                  pers.ul[1] + crop.ul[1],
-                                  pers.lr[0] + crop.lr[0],
-                                  pers.lr[1] + crop.lr[1],
-                                  pers.ur[0] + crop.lr[0],
-                                  pers.ur[1] + crop.ul[1],
-                                  pers.ll[0] + crop.ul[0],
-                                  pers.ll[1] + crop.lr[1],
-                                  diagonal_intersection_x,
-                                  diagonal_intersection_y) &&
-            is_default_geometry) {
-            // http://www.reedbeta.com/blog/2012/05/26/quadrilateral-interpolation-part-1/
-            auto d0 = hypotenuse(
-                pers.ll[0] + crop.ul[0], pers.ll[1] + crop.lr[1], diagonal_intersection_x, diagonal_intersection_y);
-            auto d1 = hypotenuse(
-                pers.lr[0] + crop.lr[0], pers.lr[1] + crop.lr[1], diagonal_intersection_x, diagonal_intersection_y);
-            auto d2 = hypotenuse(
-                pers.ur[0] + crop.lr[0], pers.ur[1] + crop.ul[1], diagonal_intersection_x, diagonal_intersection_y);
-            auto d3 = hypotenuse(
-                pers.ul[0] + crop.ul[0], pers.ul[1] + crop.ul[1], diagonal_intersection_x, diagonal_intersection_y);
-
-            auto ulq = calc_q(d3, d1);
-            auto urq = calc_q(d2, d0);
-            auto lrq = calc_q(d1, d3);
-            auto llq = calc_q(d0, d2);
-
-            std::vector<double> q_values = {ulq, urq, lrq, llq};
-
-            corner = 0;
-            for (auto& coord : coords) {
-                coord.texture_q = q_values[corner];
-                coord.texture_x *= q_values[corner];
-                coord.texture_y *= q_values[corner];
-
-                if (++corner == 4)
-                    corner = 0;
-            }
-        }
-
         // Draw
-        switch (params.geometry.type()) {
-            case core::frame_geometry::geometry_type::quad: {
-                GL(glBindVertexArray(vao_));
-                GL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
+        GL(glBindVertexArray(vao_));
+        GL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
 
-                std::vector<core::frame_geometry::coord> coords_triangles{
-                    coords[0], coords[1], coords[2], coords[0], coords[2], coords[3]};
+        GL(glBufferData(GL_ARRAY_BUFFER,
+                        static_cast<GLsizeiptr>(sizeof(core::frame_geometry::coord)) * coords.size(),
+                        coords.data(),
+                        GL_STATIC_DRAW));
 
-                GL(glBufferData(GL_ARRAY_BUFFER,
-                                static_cast<GLsizeiptr>(sizeof(core::frame_geometry::coord)) * coords_triangles.size(),
-                                coords_triangles.data(),
-                                GL_STATIC_DRAW));
+        auto stride = static_cast<GLsizei>(sizeof(core::frame_geometry::coord));
 
-                auto stride = static_cast<GLsizei>(sizeof(core::frame_geometry::coord));
+        auto vtx_loc = shader_->get_attrib_location("Position");
+        auto tex_loc = shader_->get_attrib_location("TexCoordIn");
 
-                auto vtx_loc = shader_->get_attrib_location("Position");
-                auto tex_loc = shader_->get_attrib_location("TexCoordIn");
+        GL(glEnableVertexAttribArray(vtx_loc));
+        GL(glEnableVertexAttribArray(tex_loc));
 
-                GL(glEnableVertexAttribArray(vtx_loc));
-                GL(glEnableVertexAttribArray(tex_loc));
+        GL(glVertexAttribPointer(vtx_loc, 2, GL_DOUBLE, GL_FALSE, stride, nullptr));
+        GL(glVertexAttribPointer(tex_loc, 4, GL_DOUBLE, GL_FALSE, stride, (GLvoid*)(2 * sizeof(GLdouble))));
 
-                GL(glVertexAttribPointer(vtx_loc, 2, GL_DOUBLE, GL_FALSE, stride, nullptr));
-                GL(glVertexAttribPointer(tex_loc, 4, GL_DOUBLE, GL_FALSE, stride, (GLvoid*)(2 * sizeof(GLdouble))));
+        GL(glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(coords.size())));
+        GL(glTextureBarrier());
 
-                GL(glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(coords_triangles.size())));
-                GL(glTextureBarrier());
+        GL(glDisableVertexAttribArray(vtx_loc));
+        GL(glDisableVertexAttribArray(tex_loc));
 
-                GL(glDisableVertexAttribArray(vtx_loc));
-                GL(glDisableVertexAttribArray(tex_loc));
-
-                GL(glBindVertexArray(0));
-                GL(glBindBuffer(GL_ARRAY_BUFFER, 0));
-
-                break;
-            }
-            default:
-                break;
-        }
+        GL(glBindVertexArray(0));
+        GL(glBindBuffer(GL_ARRAY_BUFFER, 0));
 
         // Cleanup
         GL(glDisable(GL_SCISSOR_TEST));
@@ -502,4 +363,4 @@ image_kernel::image_kernel(const spl::shared_ptr<device>& ogl)
 image_kernel::~image_kernel() {}
 void image_kernel::draw(const draw_params& params) { impl_->draw(params); }
 
-}}} // namespace caspar::accelerator::ogl
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/image_kernel.h
+++ b/src/accelerator/ogl/image/image_kernel.h
@@ -29,6 +29,11 @@
 #include <core/frame/geometry.h>
 #include <core/frame/pixel_format.h>
 
+#include <utility>
+
+#include "../util/matrix.h"
+#include "../util/transforms.h"
+
 namespace caspar { namespace accelerator { namespace ogl {
 
 enum class keyer
@@ -41,7 +46,7 @@ struct draw_params final
 {
     core::pixel_format_desc                     pix_desc = core::pixel_format_desc(core::pixel_format::invalid);
     std::vector<spl::shared_ptr<class texture>> textures;
-    core::image_transform                       transform;
+    draw_transforms                             transforms;
     core::frame_geometry                        geometry   = core::frame_geometry::get_default();
     core::blend_mode                            blend_mode = core::blend_mode::normal;
     ogl::keyer                                  keyer      = ogl::keyer::linear;

--- a/src/accelerator/ogl/image/image_mixer.h
+++ b/src/accelerator/ogl/image/image_mixer.h
@@ -53,6 +53,8 @@ class image_mixer final : public core::image_mixer
     core::mutable_frame
     create_frame(const void* video_stream_tag, const core::pixel_format_desc& desc, common::bit_depth depth) override;
 
+    void update_aspect_ratio(double aspect_ratio) override;
+
     // core::image_mixer
 
     void              push(const core::frame_transform& frame) override;

--- a/src/accelerator/ogl/util/matrix.cpp
+++ b/src/accelerator/ogl/util/matrix.cpp
@@ -1,0 +1,55 @@
+
+
+#include <core/frame/frame_transform.h>
+
+#include <common/except.h>
+#include <common/log.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include <boost/numeric/ublas/io.hpp>
+#include <boost/numeric/ublas/matrix.hpp>
+#include <boost/numeric/ublas/matrix_vector.hpp>
+#include <boost/numeric/ublas/vector.hpp>
+
+#include "matrix.h"
+
+namespace caspar::accelerator::ogl {
+
+t_matrix create_matrix(std::vector<std::vector<double>> data)
+{
+    if (data.empty())
+        CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info(L"data cannot be empty"));
+
+    t_matrix matrix(data.size(), data.at(0).size());
+    for (int y = 0; y < matrix.size1(); ++y) {
+        if (data.at(y).size() != matrix.size2())
+            CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info(L"Each row must be of the same length"));
+
+        for (int x = 0; x < matrix.size2(); ++x)
+            matrix(x, y) = data.at(y).at(x);
+    }
+    return matrix;
+}
+
+t_matrix get_vertex_matrix(const core::image_transform& transform, double aspect_ratio)
+{
+    using namespace boost::numeric::ublas;
+    auto anchor_matrix =
+        create_matrix({{1.0, 0.0, -transform.anchor[0]}, {0.0, 1.0, -transform.anchor[1]}, {0.0, 0.0, 1.0}});
+    auto scale_matrix =
+        create_matrix({{transform.fill_scale[0], 0.0, 0.0}, {0.0, transform.fill_scale[1], 0.0}, {0.0, 0.0, 1.0}});
+    auto aspect_matrix      = create_matrix({{1.0, 0.0, 0.0}, {0.0, 1.0 / aspect_ratio, 0.0}, {0.0, 0.0, 1.0}});
+    auto aspect_inv_matrix  = create_matrix({{1.0, 0.0, 0.0}, {0.0, aspect_ratio, 0.0}, {0.0, 0.0, 1.0}});
+    auto rotation_matrix    = create_matrix({{std::cos(transform.angle), -std::sin(transform.angle), 0.0},
+                                             {std::sin(transform.angle), std::cos(transform.angle), 0.0},
+                                             {0.0, 0.0, 1.0}});
+    auto translation_matrix = create_matrix(
+        {{1.0, 0.0, transform.fill_translation[0]}, {0.0, 1.0, transform.fill_translation[1]}, {0.0, 0.0, 1.0}});
+
+    return anchor_matrix * aspect_matrix * scale_matrix * rotation_matrix * aspect_inv_matrix * translation_matrix;
+}
+
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/matrix.h
+++ b/src/accelerator/ogl/util/matrix.h
@@ -1,0 +1,44 @@
+
+
+#pragma once
+
+#include <boost/numeric/ublas/matrix.hpp>
+#include <boost/numeric/ublas/matrix_vector.hpp>
+
+#include <core/frame/geometry.h>
+
+namespace caspar::accelerator::ogl {
+
+typedef boost::numeric::ublas::matrix<double, boost::numeric::ublas::row_major, std::vector<double>> t_matrix;
+
+typedef boost::numeric::ublas::vector<double, std::vector<double>> t_point;
+
+t_matrix get_vertex_matrix(const core::image_transform& transform, double aspect_ratio);
+
+} // namespace caspar::accelerator::ogl
+
+namespace boost::numeric::ublas {
+template <typename T, typename L, typename S>
+boost::numeric::ublas::matrix<T, L, S> operator*(const boost::numeric::ublas::matrix<T, L, S>& lhs,
+                                                 const boost::numeric::ublas::matrix<T, L, S>& rhs)
+{
+    return boost::numeric::ublas::matrix<T>(boost::numeric::ublas::prod(lhs, rhs));
+}
+template <typename T, typename L, typename S1, typename S2>
+boost::numeric::ublas::vector<T, S1> operator*(const boost::numeric::ublas::vector<T, S1>&    lhs,
+                                               const boost::numeric::ublas::matrix<T, L, S2>& rhs)
+{
+    return boost::numeric::ublas::vector<T, S1>(boost::numeric::ublas::prod(lhs, rhs));
+}
+template <typename T, typename L, typename S1, typename S2>
+bool operator==(const boost::numeric::ublas::matrix<T, L, S1>& lhs, const boost::numeric::ublas::matrix<T, L, S2>& rhs)
+{
+    if (lhs.size1() != rhs.size1() || lhs.size2() != rhs.size2())
+        return false;
+    for (int y = 0; y < lhs.size1(); ++y)
+        for (int x = 0; x < lhs.size2(); ++x)
+            if (lhs(y, x) != rhs(y, x))
+                return false;
+    return true;
+}
+} // namespace boost::numeric::ublas

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -1,0 +1,469 @@
+
+#include "transforms.h"
+
+#include <algorithm>
+#include <unordered_set>
+
+namespace caspar::accelerator::ogl {
+
+draw_crop_region::draw_crop_region(double left, double top, double right, double bottom)
+{
+    // upper left
+    coords[0]    = t_point(3);
+    coords[0](0) = left;
+    coords[0](1) = top;
+    coords[0](2) = 1;
+
+    // upper right
+    coords[1]    = t_point(3);
+    coords[1](0) = right;
+    coords[1](1) = top;
+    coords[1](2) = 1;
+
+    // lower right
+    coords[2]    = t_point(3);
+    coords[2](0) = right;
+    coords[2](1) = bottom;
+    coords[2](2) = 1;
+
+    // lower left
+    coords[3]    = t_point(3);
+    coords[3](0) = left;
+    coords[3](1) = bottom;
+    coords[3](2) = 1;
+}
+
+void draw_crop_region::apply_transform(const caspar::accelerator::ogl::t_matrix& matrix)
+{
+    coords[0] = coords[0] * matrix;
+    coords[1] = coords[1] * matrix;
+    coords[2] = coords[2] * matrix;
+    coords[3] = coords[3] * matrix;
+}
+
+void apply_transform_colour_values(core::image_transform& self, const core::image_transform& other)
+{
+    // Note: this intentionally does not affect any geometry-related fields, they follow a separate flow
+
+    self.opacity *= other.opacity;
+    self.brightness *= other.brightness;
+    self.contrast *= other.contrast;
+    self.saturation *= other.saturation;
+
+    self.levels.min_input  = std::max(self.levels.min_input, other.levels.min_input);
+    self.levels.max_input  = std::min(self.levels.max_input, other.levels.max_input);
+    self.levels.min_output = std::max(self.levels.min_output, other.levels.min_output);
+    self.levels.max_output = std::min(self.levels.max_output, other.levels.max_output);
+    self.levels.gamma *= other.levels.gamma;
+    self.chroma.enable |= other.chroma.enable;
+    self.chroma.show_mask |= other.chroma.show_mask;
+    self.chroma.target_hue     = std::max(other.chroma.target_hue, self.chroma.target_hue);
+    self.chroma.min_saturation = std::max(other.chroma.min_saturation, self.chroma.min_saturation);
+    self.chroma.min_brightness = std::max(other.chroma.min_brightness, self.chroma.min_brightness);
+    self.chroma.hue_width      = std::max(other.chroma.hue_width, self.chroma.hue_width);
+    self.chroma.softness       = std::max(other.chroma.softness, self.chroma.softness);
+    self.chroma.spill_suppress = std::max(other.chroma.spill_suppress, self.chroma.spill_suppress);
+    self.chroma.spill_suppress_saturation =
+        std::min(other.chroma.spill_suppress_saturation, self.chroma.spill_suppress_saturation);
+    self.is_key |= other.is_key;
+    self.invert |= other.invert;
+    self.is_mix |= other.is_mix;
+    self.blend_mode = std::max(self.blend_mode, other.blend_mode);
+    self.layer_depth += other.layer_depth;
+}
+
+bool is_default_perspective(const core::corners& perspective)
+{
+    return perspective.ul[0] == 0 && perspective.ul[1] == 0 && perspective.ur[0] == 1 && perspective.ur[1] == 0 &&
+           perspective.ll[0] == 0 && perspective.ll[1] == 1 && perspective.lr[0] == 1 && perspective.lr[1] == 1;
+}
+
+draw_transforms draw_transforms::combine_transform(const core::image_transform& transform, double aspect_ratio) const
+{
+    draw_transforms new_transform(image_transform, steps);
+
+    auto transform_before = new_transform.current().vertex_matrix;
+
+    // Get matrix for turning coords in 'transform' into the parent frame.
+    auto new_matrix = get_vertex_matrix(transform, aspect_ratio);
+
+    apply_transform_colour_values(new_transform.image_transform, transform);
+    new_transform.current().vertex_matrix = new_matrix * new_transform.current().vertex_matrix;
+
+    // Only enable this for some transforms, to avoid applying crops when a draw_frame is just being used to flatten other draw_frames
+    if (transform.enable_geometry_modifiers) {
+        // Push the new clip before the new transform applied
+        draw_crop_region new_clip(transform.clip_translation[0],transform.clip_translation[1], transform.clip_translation[0]+ transform.clip_scale[0],transform.clip_translation[1] + transform.clip_scale[1]);
+        new_clip.apply_transform(transform_before);
+        new_transform.current().crop_regions.push_back(std::move(new_clip));
+
+        if (!is_default_perspective(transform.perspective)) {
+            // Split into a new step
+            new_transform.steps.emplace_back(transform.perspective,
+                                             boost::numeric::ublas::identity_matrix<double>(3, 3));
+        }
+
+        // Push the new crop region with the new transform applied
+        draw_crop_region new_crop(
+            transform.crop.ul[0], transform.crop.ul[1], transform.crop.lr[0], transform.crop.lr[1]);
+        new_crop.apply_transform(new_transform.current().vertex_matrix);
+        new_transform.current().crop_regions.push_back(std::move(new_crop));
+    }
+
+    return std::move(new_transform);
+}
+
+void apply_perspective_to_vertex(t_point& vertex, const core::corners& perspective)
+{
+    const double x = vertex(0);
+    const double y = vertex(1);
+
+    // ul: x' =  (1-y) * a + (1 - a * (1-y)) * x
+    vertex(0) += (1 - y) * perspective.ul[0] + (1 - perspective.ul[0] + perspective.ul[0] * y) * x - x;
+    vertex(1) += (1 - x) * perspective.ul[1] + (1 - perspective.ul[1] + perspective.ul[1] * x) * y - y;
+
+    // ur/ll: x' = x * (a * (1-y) + y)
+    vertex(0) += x * (perspective.ur[0] * (1 - y) + y) - x;
+    vertex(1) += y * (perspective.ll[1] * (1 - x) + x) - y;
+
+    // ur/ll: x' = y * a + x * (1 - a * y)
+    vertex(0) += y * perspective.ll[0] + x * (1 - perspective.ll[0] * y) - x;
+    vertex(1) += x * perspective.ur[1] + y * (1 - perspective.ur[1] * x) - y;
+
+    // lr: x' = x * (y * a + (1-y))
+    vertex(0) += x * (y * perspective.lr[0] + (1 - y)) - x;
+    vertex(1) += y * (x * perspective.lr[1] + (1 - x)) - y;
+}
+
+struct wrapped_vertex
+{
+    explicit wrapped_vertex(const core::frame_geometry::coord& coord)
+    {
+        vertex(0) = coord.vertex_x;
+        vertex(1) = coord.vertex_y;
+        vertex(2) = 1;
+
+        texture_x = coord.texture_x;
+        texture_y = coord.texture_y;
+        texture_r = coord.texture_r;
+        texture_q = coord.texture_q;
+    }
+
+    explicit wrapped_vertex() {
+        vertex(2) = 1;
+    };
+
+    [[nodiscard]] core::frame_geometry::coord as_geometry() const
+    {
+        core::frame_geometry::coord res = {vertex(0), vertex(1), texture_x, texture_y};
+        res.texture_r                   = texture_r;
+        res.texture_q                   = texture_q;
+        return res;
+    }
+
+    t_point vertex = t_point(3);
+
+    double texture_x = 0.0;
+    double texture_y = 0.0;
+    double texture_r = 0.0;
+    double texture_q = 1.0;
+};
+
+static const double epsilon = 0.001;
+
+bool inline point_is_to_left_of_line(const t_point& line_1, const t_point& line_2, const t_point& vertex)
+{
+    // use a cross product to check if the point is on the right side of the line
+    return (line_2(0) - line_1(0)) * (vertex(1) - line_1(1)) - (line_2(1) - line_1(1)) * (vertex(0) - line_1(0)) <
+           -epsilon;
+}
+
+// http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
+bool get_line_intersection(double  p0_x,
+                           double  p0_y,
+                           double  p1_x,
+                           double  p1_y,
+                           double  p2_x,
+                           double  p2_y,
+                           double  p3_x,
+                           double  p3_y,
+                           double& result_x,
+                           double& result_y)
+{
+    double s1_x = p1_x - p0_x;
+    double s1_y = p1_y - p0_y;
+    double s2_x = p3_x - p2_x;
+    double s2_y = p3_y - p2_y;
+
+    double s = (-s1_y * (p0_x - p2_x) + s1_x * (p0_y - p2_y)) / (-s2_x * s1_y + s1_x * s2_y);
+    double t = (s2_x * (p0_y - p2_y) - s2_y * (p0_x - p2_x)) / (-s2_x * s1_y + s1_x * s2_y);
+
+    if (s >= 0 && s <= 1 && t >= 0 && t <= 1) {
+        // Collision detected
+        result_x = p0_x + t * s1_x;
+        result_y = p0_y + t * s1_y;
+
+        return true;
+    }
+
+    return false; // No collision
+}
+
+// http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
+bool get_intersection_with_crop_line(const t_point& crop0, const t_point& crop1, const t_point& p0, const t_point& p1, t_point& result)
+{
+    double s1_x = crop1(0) - crop0(0);
+    double s1_y = crop1(1) - crop0(1);
+    double s2_x = p1(0) - p0(0);
+    double s2_y = p1(1) - p0(1);
+
+    double s = (-s1_y * (crop0(0) - p0(0)) + s1_x * (crop0(1) - p0(1))) / (-s2_x * s1_y + s1_x * s2_y);
+    double t = (s2_x * (crop0(1) - p0(1)) - s2_y * (crop0(0) - p0(0))) / (-s2_x * s1_y + s1_x * s2_y);
+
+    if (s >= 0 && s <= 1) {
+        // Collision detected
+        result(0) = crop0(0) + t * s1_x;
+        result(1) = crop0(1) + t * s1_y;
+
+        return true;
+    }
+
+    return false; // No collision
+}
+
+double hypotenuse(double x1, double y1, double x2, double y2)
+{
+    auto x = x2 - x1;
+    auto y = y2 - y1;
+
+    return std::sqrt(x * x + y * y);
+}
+
+double calc_q(double close_diagonal, double distant_diagonal)
+{
+    return (close_diagonal + distant_diagonal) / distant_diagonal;
+}
+
+void crop_texture_for_vertex(const wrapped_vertex& line_a, const wrapped_vertex& line_b, wrapped_vertex& vertex)
+{
+    auto delta_point = vertex.vertex - line_a.vertex;
+    auto delta_line  = line_b.vertex - line_a.vertex;
+
+    // Calculate the dot product
+    auto dot_product      = delta_point(0) * delta_line(0) + delta_point(1) * delta_line(1);
+    auto line_len_squared = delta_line(0) * delta_line(0) + delta_line(1) * delta_line(1);
+
+    // Skip if line has no length
+    if (line_len_squared == 0) {
+        vertex.texture_x = line_a.texture_x;
+        vertex.texture_y = line_a.texture_y;
+        return;
+    }
+
+    auto dist_delta = dot_product / line_len_squared;
+
+    vertex.texture_x = line_a.texture_x + dist_delta * (line_b.texture_x - line_a.texture_x);
+    vertex.texture_y = line_a.texture_y + dist_delta * (line_b.texture_y - line_a.texture_y);
+}
+
+void fill_texture_q_for_quad(std::vector<core::frame_geometry::coord>& result)
+{
+    double diagonal_intersection_x;
+    double diagonal_intersection_y;
+
+    if (result.size() == 4 && get_line_intersection(result[0].vertex_x,
+                                                    result[0].vertex_y,
+                                                    result[2].vertex_x,
+                                                    result[2].vertex_y,
+                                                    result[1].vertex_x,
+                                                    result[1].vertex_y,
+                                                    result[3].vertex_x,
+                                                    result[3].vertex_y,
+                                                    diagonal_intersection_x,
+                                                    diagonal_intersection_y)) {
+        // http://www.reedbeta.com/blog/2012/05/26/quadrilateral-interpolation-part-1/
+        auto d0 = hypotenuse(result[3].vertex_x, result[3].vertex_y, diagonal_intersection_x, diagonal_intersection_y);
+        auto d1 = hypotenuse(result[2].vertex_x, result[2].vertex_y, diagonal_intersection_x, diagonal_intersection_y);
+        auto d2 = hypotenuse(result[1].vertex_x, result[1].vertex_y, diagonal_intersection_x, diagonal_intersection_y);
+        auto d3 = hypotenuse(result[0].vertex_x, result[0].vertex_y, diagonal_intersection_x, diagonal_intersection_y);
+
+        auto ulq = calc_q(d3, d1);
+        auto urq = calc_q(d2, d0);
+        auto lrq = calc_q(d1, d3);
+        auto llq = calc_q(d0, d2);
+
+        std::vector<double> q_values = {ulq, urq, lrq, llq};
+
+        int corner = 0;
+        for (auto& coord : result) {
+            coord.texture_q = q_values[corner];
+            coord.texture_x *= q_values[corner];
+            coord.texture_y *= q_values[corner];
+
+            if (++corner == 4)
+                corner = 0;
+        }
+    }
+}
+
+draw_transformed_coords
+draw_transforms::transform_coords(const std::vector<core::frame_geometry::coord>& coords) const
+{
+    // Convert to matrix representations
+    std::vector<wrapped_vertex> cropped_coords;
+    std::vector<wrapped_vertex> uncropped_coords;
+    cropped_coords.reserve(coords.size());
+    uncropped_coords.reserve(coords.size());
+
+    for (const auto& coord : coords) {
+        cropped_coords.emplace_back(coord);
+        uncropped_coords.emplace_back(coord);
+    }
+
+    // Apply the transforms
+    for (int i = (int)steps.size() - 1; i >= 0; i--) {
+        for (auto& coord : cropped_coords) {
+            // Apply basic transforms of this step
+            coord.vertex = coord.vertex * steps[i].vertex_matrix;
+
+            // Apply perspective. These rely on x and y of the coord, so can't be done as a shared matrix
+            apply_perspective_to_vertex(coord.vertex, steps[i].perspective);
+        }
+
+        for (auto& coord : uncropped_coords) {
+            // Apply basic transforms of this step
+            coord.vertex = coord.vertex * steps[i].vertex_matrix;
+
+            // Apply perspective. These rely on x and y of the coord, so can't be done as a shared matrix
+            apply_perspective_to_vertex(coord.vertex, steps[i].perspective);
+        }
+
+        for (auto& crop_region : steps[i].crop_regions) {
+            for (int l = 0; l < 4; ++l) {
+                // Apply the crop, one edge at a time
+                auto to_index   = l == 3 ? 0 : l + 1;
+                auto from_point = crop_region.coords[l];
+                auto to_point   = crop_region.coords[to_index];
+
+                // Apply perspective. These rely on x and y of the coord, so can't be done as a shared matrix
+                apply_perspective_to_vertex(from_point, steps[i].perspective);
+                apply_perspective_to_vertex(to_point, steps[i].perspective);
+
+                std::unordered_set<size_t> points_to_left_of_line;
+
+                // Figure out which points are 'left' of the line (outside the crop region)
+                for (size_t j = 0; j < cropped_coords.size(); ++j) {
+                    bool v = point_is_to_left_of_line(from_point, to_point, cropped_coords[j].vertex);
+                    if (v) points_to_left_of_line.insert(j);
+                }
+
+                if (points_to_left_of_line.empty()) {
+                    // Line has no effect, skip
+                    continue;
+                } else if (points_to_left_of_line.size() == cropped_coords.size()) {
+                    // All are to the left, shape has no geometry
+                    return {};
+                }
+
+                std::vector<wrapped_vertex> new_coords;
+                new_coords.reserve(cropped_coords.size() * 2); // Avoid reallocs for complex shapes
+
+                // Iterate through the coords
+                for (size_t j = 0; j < cropped_coords.size(); ++j) {
+                    if (points_to_left_of_line.count(j) == 0) {
+                        new_coords.push_back(cropped_coords[j]);
+                        continue;
+                    }
+
+                    size_t prev_index = j == 0 ? cropped_coords.size() - 1 : j - 1;
+                    size_t next_index = j == cropped_coords.size() - 1 ? 0 : j + 1;
+
+                    bool prev_is_left_of_line = points_to_left_of_line.count(prev_index) == 1;
+                    bool next_is_left_of_line = points_to_left_of_line.count(next_index) == 1;
+
+                    if (prev_is_left_of_line && next_is_left_of_line) {
+                        // Vertex and its edges are completely left of the line, skip
+                        continue;
+                    }
+
+                    if (!prev_is_left_of_line) {
+                        // This edge intersects the crop line, calculate the new coordinates
+                        wrapped_vertex new_coord;
+                        if (get_intersection_with_crop_line(to_point,
+                                                            from_point,
+                                                            cropped_coords[prev_index].vertex,
+                                                            cropped_coords[j].vertex,
+                                                            new_coord.vertex)) {
+                            crop_texture_for_vertex(cropped_coords[prev_index], cropped_coords[j], new_coord);
+                            new_coords.emplace_back(std::move(new_coord));
+                        } else {
+                            // Geometry error! skip coordinate
+                        }
+                    }
+
+                    if (!next_is_left_of_line) {
+                        // This edge intersects the crop line, calculate the new coordinates
+                        wrapped_vertex new_coord;
+                        if (get_intersection_with_crop_line(to_point,
+                                                            from_point,
+                                                            cropped_coords[j].vertex,
+                                                            cropped_coords[next_index].vertex,
+                                                            new_coord.vertex)) {
+                            crop_texture_for_vertex(cropped_coords[j], cropped_coords[next_index], new_coord);
+                            new_coords.emplace_back(std::move(new_coord));
+                        } else {
+                            // Geometry error! skip coordinate
+                        }
+                    }
+                }
+
+                // Polygon is cropped, update state
+                cropped_coords = new_coords;
+            }
+
+            {
+                static const double pixel_epsilon = 0.0001; // less than a pixel at 8k
+
+                // Prune duplicate coords
+                std::vector<wrapped_vertex> new_coords;
+                new_coords.reserve(cropped_coords.size()); // Avoid reallocs
+
+                for (size_t j = 0; j < cropped_coords.size(); ++j) {
+                    size_t prev_index = j == 0 ? cropped_coords.size() - 1 : j - 1;
+
+                    auto delta = cropped_coords[j].vertex - cropped_coords[prev_index].vertex;
+                    if (std::abs(delta(0)) > pixel_epsilon || std::abs(delta(1)) > pixel_epsilon) {
+                        new_coords.emplace_back(cropped_coords[j]);
+                    }
+                }
+
+                if (new_coords.size() < 3) {
+                    // Not enough coords to draw anything
+                    return {};
+                }
+                cropped_coords = new_coords;
+            }
+        }
+    }
+
+    // Convert back to frame_geometry types
+    draw_transformed_coords result = {};
+    result.cropped_coords.reserve(cropped_coords.size());
+    for (auto& coord : cropped_coords) {
+        result.cropped_coords.push_back(coord.as_geometry());
+    }
+
+    // If there is a perspective applied, we need separate coords for drawing the texture, with correct texture_q values
+    if (steps.size() > 1) {
+        result.uncropped_coords.reserve(uncropped_coords.size());
+        for (auto& coord : uncropped_coords) {
+            result.uncropped_coords.push_back(coord.as_geometry());
+        }
+
+        fill_texture_q_for_quad(result.uncropped_coords);
+    }
+
+    return result;
+}
+
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/transforms.h
+++ b/src/accelerator/ogl/util/transforms.h
@@ -43,12 +43,6 @@ struct draw_transform_step
     t_matrix vertex_matrix;
 };
 
-struct draw_transformed_coords
-{
-    std::vector<core::frame_geometry::coord> cropped_coords;
-    std::vector<core::frame_geometry::coord> uncropped_coords;
-};
-
 struct draw_transforms
 {
     std::vector<draw_transform_step> steps;
@@ -71,7 +65,7 @@ struct draw_transforms
 
     [[nodiscard]] draw_transforms combine_transform(const core::image_transform& transform, double aspect_ratio) const;
 
-    [[nodiscard]] draw_transformed_coords transform_coords(const std::vector<core::frame_geometry::coord>& coords) const;
+    [[nodiscard]] std::vector<core::frame_geometry::coord> transform_coords(const std::vector<core::frame_geometry::coord>& coords) const;
 };
 
 } // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/transforms.h
+++ b/src/accelerator/ogl/util/transforms.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <core/mixer/image/blend_modes.h>
+
+#include <common/memory.h>
+
+#include <core/frame/frame_transform.h>
+#include <core/frame/geometry.h>
+#include <core/frame/pixel_format.h>
+
+#include <utility>
+
+#include "matrix.h"
+
+namespace caspar::accelerator::ogl {
+
+struct draw_crop_region
+{
+    explicit draw_crop_region(double left, double top, double right, double bottom);
+
+    void apply_transform(const t_matrix& matrix);
+
+    std::array<t_point, 4> coords;
+};
+
+struct draw_transform_step
+{
+    draw_transform_step()
+        : vertex_matrix(boost::numeric::ublas::identity_matrix<double>(3, 3))
+    {
+    }
+
+    draw_transform_step(const core::corners& perspective, const t_matrix& vertex_matrix)
+        : perspective(perspective)
+        , vertex_matrix(vertex_matrix)
+    {
+    }
+
+    core::corners perspective;
+
+    std::vector<draw_crop_region> crop_regions;
+
+    t_matrix vertex_matrix;
+};
+
+struct draw_transformed_coords
+{
+    std::vector<core::frame_geometry::coord> cropped_coords;
+    std::vector<core::frame_geometry::coord> uncropped_coords;
+};
+
+struct draw_transforms
+{
+    std::vector<draw_transform_step> steps;
+
+    draw_transforms()
+        : image_transform(core::image_transform())
+        , steps({draw_transform_step()})
+    {
+    }
+
+    explicit draw_transforms(core::image_transform transform, std::vector<draw_transform_step> steps)
+        : image_transform(transform)
+        , steps(std::move(steps))
+    {
+    }
+
+    core::image_transform image_transform;
+
+    draw_transform_step& current() { return steps.back(); }
+
+    [[nodiscard]] draw_transforms combine_transform(const core::image_transform& transform, double aspect_ratio) const;
+
+    [[nodiscard]] draw_transformed_coords transform_coords(const std::vector<core::frame_geometry::coord>& coords) const;
+};
+
+} // namespace caspar::accelerator::ogl

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -28,91 +28,6 @@
 
 namespace caspar { namespace core {
 
-// image_transform
-
-template <typename Rect>
-void transform_rect(Rect& self, const Rect& other)
-{
-    self.ul[0] += other.ul[0];
-    self.ul[1] += other.ul[1];
-    self.lr[0] *= other.lr[0];
-    self.lr[1] *= other.lr[1];
-}
-
-void transform_corners(corners& self, const corners& other)
-{
-    transform_rect(self, other);
-
-    self.ur[0] *= other.ur[0];
-    self.ur[1] += other.ur[1];
-    self.ll[0] += other.ll[0];
-    self.ll[1] *= other.ll[1];
-
-    // TODO (fix) figure out the math to compose perspective transforms correctly.
-}
-
-image_transform& image_transform::operator*=(const image_transform& other)
-{
-    opacity *= other.opacity;
-    brightness *= other.brightness;
-    contrast *= other.contrast;
-    saturation *= other.saturation;
-
-    // TODO (fix)
-    auto aspect_ratio = 1.0;
-
-    std::array<double, 2> rotated{};
-
-    auto orig_x = other.fill_translation[0];
-    auto orig_y = other.fill_translation[1] / aspect_ratio;
-    rotated[0]  = orig_x * std::cos(angle) - orig_y * std::sin(angle);
-    rotated[1]  = orig_x * std::sin(angle) + orig_y * std::cos(angle);
-    rotated[1] *= aspect_ratio;
-
-    anchor[0] += other.anchor[0] * fill_scale[0];
-    anchor[1] += other.anchor[1] * fill_scale[1];
-    fill_translation[0] += rotated[0] * fill_scale[0];
-    fill_translation[1] += rotated[1] * fill_scale[1];
-    fill_scale[0] *= other.fill_scale[0];
-    fill_scale[1] *= other.fill_scale[1];
-    clip_translation[0] += other.clip_translation[0] * clip_scale[0];
-    clip_translation[1] += other.clip_translation[1] * clip_scale[1];
-    clip_scale[0] *= other.clip_scale[0];
-    clip_scale[1] *= other.clip_scale[1];
-    angle += other.angle;
-
-    transform_rect(crop, other.crop);
-    transform_corners(perspective, other.perspective);
-
-    levels.min_input  = std::max(levels.min_input, other.levels.min_input);
-    levels.max_input  = std::min(levels.max_input, other.levels.max_input);
-    levels.min_output = std::max(levels.min_output, other.levels.min_output);
-    levels.max_output = std::min(levels.max_output, other.levels.max_output);
-    levels.gamma *= other.levels.gamma;
-    chroma.enable |= other.chroma.enable;
-    chroma.show_mask |= other.chroma.show_mask;
-    chroma.target_hue     = std::max(other.chroma.target_hue, chroma.target_hue);
-    chroma.min_saturation = std::max(other.chroma.min_saturation, chroma.min_saturation);
-    chroma.min_brightness = std::max(other.chroma.min_brightness, chroma.min_brightness);
-    chroma.hue_width      = std::max(other.chroma.hue_width, chroma.hue_width);
-    chroma.softness       = std::max(other.chroma.softness, chroma.softness);
-    chroma.spill_suppress = std::max(other.chroma.spill_suppress, chroma.spill_suppress);
-    chroma.spill_suppress_saturation =
-        std::min(other.chroma.spill_suppress_saturation, chroma.spill_suppress_saturation);
-    is_key |= other.is_key;
-    invert |= other.invert;
-    is_mix |= other.is_mix;
-    blend_mode = std::max(blend_mode, other.blend_mode);
-    layer_depth += other.layer_depth;
-
-    return *this;
-}
-
-image_transform image_transform::operator*(const image_transform& other) const
-{
-    return image_transform(*this) *= other;
-}
-
 double do_tween(double time, double source, double dest, double duration, const tweener& tween)
 {
     return tween(time, source, dest - source, duration);
@@ -229,7 +144,7 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
            eq(lhs.chroma.min_brightness, rhs.chroma.min_brightness) && eq(lhs.chroma.softness, rhs.chroma.softness) &&
            eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
            eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-           lhs.perspective == rhs.perspective;
+           lhs.perspective == rhs.perspective || lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 
 bool operator!=(const image_transform& lhs, const image_transform& rhs) { return !(lhs == rhs); }
@@ -265,18 +180,6 @@ bool operator!=(const audio_transform& lhs, const audio_transform& rhs) { return
 
 // frame_transform
 frame_transform::frame_transform() = default;
-
-frame_transform& frame_transform::operator*=(const frame_transform& other)
-{
-    image_transform *= other.image_transform;
-    audio_transform *= other.audio_transform;
-    return *this;
-}
-
-frame_transform frame_transform::operator*(const frame_transform& other) const
-{
-    return frame_transform(*this) *= other;
-}
 
 frame_transform frame_transform::tween(double                 time,
                                        const frame_transform& source,

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -80,6 +80,12 @@ struct image_transform final
     double brightness = 1.0;
     double saturation = 1.0;
 
+    /**
+     * This enables the clip/crop/perspective fields.
+     * It is often desirable to have this disabled, to avoid cropping/clipping unnecessarily
+     */
+    bool enable_geometry_modifiers = false;
+
     std::array<double, 2> anchor           = {0.0, 0.0};
     std::array<double, 2> fill_translation = {0.0, 0.0};
     std::array<double, 2> fill_scale       = {1.0, 1.0};
@@ -96,9 +102,6 @@ struct image_transform final
     bool             is_mix      = false;
     core::blend_mode blend_mode  = blend_mode::normal;
     int              layer_depth = 0;
-
-    image_transform& operator*=(const image_transform& other);
-    image_transform  operator*(const image_transform& other) const;
 
     static image_transform tween(double                 time,
                                  const image_transform& source,
@@ -134,9 +137,6 @@ struct frame_transform final
 
     core::image_transform image_transform;
     core::audio_transform audio_transform;
-
-    frame_transform& operator*=(const frame_transform& other);
-    frame_transform  operator*(const frame_transform& other) const;
 
     static frame_transform tween(double                 time,
                                  const frame_transform& source,

--- a/src/core/mixer/image/image_mixer.h
+++ b/src/core/mixer/image/image_mixer.h
@@ -46,6 +46,8 @@ class image_mixer
     void visit(const class const_frame& frame) override     = 0;
     void pop() override                                     = 0;
 
+    virtual void update_aspect_ratio(double aspect_ratio) = 0;
+
     virtual std::future<array<const uint8_t>> render(const struct video_format_desc& format_desc) = 0;
 
     class mutable_frame create_frame(const void* tag, const struct pixel_format_desc& desc) override = 0;

--- a/src/core/mixer/mixer.cpp
+++ b/src/core/mixer/mixer.cpp
@@ -62,6 +62,8 @@ struct mixer::impl
 
     const_frame operator()(std::vector<draw_frame> frames, const video_format_desc& format_desc, int nb_samples)
     {
+        image_mixer_->update_aspect_ratio(static_cast<double>(format_desc.square_width) / static_cast<double>(format_desc.square_height));
+
         for (auto& frame : frames) {
             frame.accept(audio_mixer_);
             frame.transform().image_transform.layer_depth = 1;

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -173,8 +173,10 @@ struct stage::impl : public std::enable_shared_from_this<impl>
                         std::find(fetch_background.begin(), fetch_background.end(), p->first) != fetch_background.end();
 
                     layer_frame res = {};
-                    if (l.second)
+                    if (l.second) {
                         res.foreground1 = draw_frame::push(layer.receive(field1, result.nb_samples), tween.fetch());
+                        res.foreground1.transform().image_transform.enable_geometry_modifiers = true;
+                    }
 
                     res.has_background = layer.has_background();
                     if (has_background_route)
@@ -182,9 +184,11 @@ struct stage::impl : public std::enable_shared_from_this<impl>
 
                     if (is_interlaced) {
                         res.is_interlaced = true;
-                        if (l.second)
+                        if (l.second) {
                             res.foreground2 =
-                                draw_frame::push(layer.receive(video_field::b, result.nb_samples), tween.fetch());
+                                    draw_frame::push(layer.receive(video_field::b, result.nb_samples), tween.fetch());
+                            res.foreground2.transform().image_transform.enable_geometry_modifiers = true;
+                        }
                         if (has_background_route)
                             res.background2 = layer.receive_background(video_field::b, result.nb_samples);
                     }


### PR DESCRIPTION
This adds a fair amount of complexity in calculations, but it allows for routes to preserve transforms which got broken when changing the route behaviour in 2.2. closes #1307 #1274
This finishes the work started years ago in 777b7f2

Unless anyone has any objections, I shall aim to merge this to 2.5 soon.
~~I still need to reenable/reimplement the scale_modes~~, but this is otherwise looking functional and pretty complete.

This is a slightly breaking change, as the way that crops compound now is slightly different. This should only affect routing one channel into another, where the crop values to be used on that routed frame are relative to the viewport and not the content. (This does sound wrong, could that change?) And also when routing a channel, the clip values for each layer are now respected correctly and may need to be set over amcp to avoid clipping the routed frame. While annoying, this is how it behaved before 2.2, so is consistent with behaviour when routes preserved transforms.
The other simple 'fix' for avoiding unexpected clips is to not scale beyond the channel bounds of the source channel, likely using a custom resolution channel to do so.

The one bit of this change that I do not like is the `enable_geometry_modifiers` property, but that became necessary to avoid cropping on intermediary frames with no way to control it. The other option I can see is to entirely change how we do cropping, but that is a much larger and more breaking change
