### PR TITLE
feat: add frame_converter and move consumers across

### DIFF
--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
 	ogl/image/image_kernel.cpp
 	ogl/image/image_mixer.cpp
 	ogl/image/image_shader.cpp
+	ogl/image/frame_converter.cpp
 
 	ogl/util/buffer.cpp
 	ogl/util/device.cpp
@@ -17,6 +18,7 @@ set(HEADERS
 	ogl/image/image_kernel.h
 	ogl/image/image_mixer.h
 	ogl/image/image_shader.h
+	ogl/image/frame_converter.h
 
 	ogl/util/buffer.h
 	ogl/util/device.h

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES
 	ogl/image/frame_converter.cpp
 
 	ogl/util/buffer.cpp
+	ogl/util/compute_shader.cpp
 	ogl/util/device.cpp
 	ogl/util/shader.cpp
 	ogl/util/texture.cpp
@@ -21,12 +22,15 @@ set(HEADERS
 	ogl/image/frame_converter.h
 
 	ogl/util/buffer.h
+	ogl/util/compute_shader.h
 	ogl/util/device.h
 	ogl/util/shader.h
 	ogl/util/texture.h
 
 	ogl_image_vertex.h
 	ogl_image_fragment.h
+	ogl_image_compute_to_rgba.h
+	ogl_image_compute_from_rgba.h
 
 	accelerator.h
 	StdAfx.h
@@ -34,6 +38,8 @@ set(HEADERS
 
 bin2c("ogl/image/shader.vert" "ogl_image_vertex.h" "caspar::accelerator::ogl" "vertex_shader")
 bin2c("ogl/image/shader.frag" "ogl_image_fragment.h" "caspar::accelerator::ogl" "fragment_shader")
+bin2c("ogl/image/shader_compute_to_rgba.comp" "ogl_image_compute_to_rgba.h" "caspar::accelerator::ogl" "compute_to_rgba_shader")
+bin2c("ogl/image/shader_compute_from_rgba.comp" "ogl_image_compute_from_rgba.h" "caspar::accelerator::ogl" "compute_from_rgba_shader")
 
 casparcg_add_library(accelerator SOURCES ${SOURCES} ${HEADERS})
 target_include_directories(accelerator PRIVATE

--- a/src/accelerator/ogl/image/frame_converter.cpp
+++ b/src/accelerator/ogl/image/frame_converter.cpp
@@ -34,8 +34,7 @@ ogl_frame_converter::ogl_frame_converter(const spl::shared_ptr<device>& ogl)
 }
 
 std::shared_future<array<const std::uint8_t>>
-ogl_frame_converter::convert_to_buffer(const core::const_frame&         frame,
-                                       const core::frame_conversion_format& format)
+ogl_frame_converter::convert_to_buffer(const core::const_frame& frame, const core::frame_conversion_format& format)
 {
     if (format.format != core::frame_conversion_format::pixel_format::rgba8)
         CASPAR_THROW_EXCEPTION(not_supported() << msg_info("format not implemented"));
@@ -58,7 +57,7 @@ ogl_frame_converter::convert_to_buffer(const core::const_frame&         frame,
     }
 
     // Download unmodified for now
-    auto new_download = ogl_->copy_async(tex_ptr->gl_texture).share();
+    auto new_download = ogl_->copy_async(tex_ptr->gl_texture, true).share();
     tex_ptr->buffer_cache.emplace(cache_key, new_download);
 
     return new_download;

--- a/src/accelerator/ogl/image/frame_converter.cpp
+++ b/src/accelerator/ogl/image/frame_converter.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+#include "frame_converter.h"
+#include "../util/convert_description.h"
+#include "../util/texture.h"
+
+#include <core/frame/pixel_format.h>
+
+#include <common/except.h>
+
+namespace caspar::accelerator::ogl {
+
+ogl_frame_converter::ogl_frame_converter(const spl::shared_ptr<device>& ogl)
+    : ogl_(ogl)
+{
+}
+
+std::shared_future<array<const std::uint8_t>>
+ogl_frame_converter::convert_to_buffer(const core::const_frame&         frame,
+                                       const core::frame_conversion_format& format)
+{
+    if (format.format != core::frame_conversion_format::pixel_format::rgba8)
+        CASPAR_THROW_EXCEPTION(not_supported() << msg_info("format not implemented"));
+    if (format.key_only)
+        CASPAR_THROW_EXCEPTION(not_supported() << msg_info("key_only not implemented"));
+    if (format.straight_alpha)
+        CASPAR_THROW_EXCEPTION(not_supported() << msg_info("straight_alpha not implemented"));
+
+    auto tex_ptr = std::any_cast<std::shared_ptr<ogl_texture_and_buffer_cache>>(frame.image_ptr());
+    if (!tex_ptr)
+        CASPAR_THROW_EXCEPTION(not_supported() << msg_info("No texture inside frame"));
+
+    uint8_t cache_key = 0; // Future: this should be a unique key derived from `frame_conversion_format`
+
+    // Note: This cache is a bit race prone, but is memory safe. At worst we will schedule the download of the same
+    // buffer multiple times rather than reusing the one. But it will do so safely.
+    auto cached_download = tex_ptr->buffer_cache.find(cache_key);
+    if (cached_download != tex_ptr->buffer_cache.end()) {
+        return cached_download->second;
+    }
+
+    // Download unmodified for now
+    auto new_download = ogl_->copy_async(tex_ptr->gl_texture).share();
+    tex_ptr->buffer_cache.emplace(cache_key, new_download);
+
+    return new_download;
+}
+
+common::bit_depth ogl_frame_converter::get_frame_bitdepth(const core::const_frame& frame)
+{
+    auto texture_ptr = std::any_cast<std::shared_ptr<ogl_texture_and_buffer_cache>>(frame.image_ptr());
+    if (!texture_ptr) {
+        CASPAR_THROW_EXCEPTION(not_supported() << msg_info("No texture inside frame"));
+    }
+
+    return texture_ptr->gl_texture->depth();
+}
+
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/frame_converter.h
+++ b/src/accelerator/ogl/image/frame_converter.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <core/frame/draw_frame.h>
+#include <core/frame/frame.h>
+#include <core/frame/frame_factory.h>
+
+#include "../util/device.h"
+
+namespace caspar::accelerator::ogl {
+
+struct ogl_texture_and_buffer_cache
+{
+    const std::shared_ptr<texture> gl_texture;
+
+    tbb::concurrent_unordered_map<uint8_t, std::shared_future<array<const uint8_t>>> buffer_cache;
+
+    ogl_texture_and_buffer_cache(std::shared_ptr<texture> gl_texture) : gl_texture(std::move(gl_texture)) {}
+};
+
+class ogl_frame_converter
+    : public core::frame_converter
+    , public std::enable_shared_from_this<ogl_frame_converter>
+{
+  public:
+    ogl_frame_converter(const spl::shared_ptr<device>& ogl);
+    ogl_frame_converter(const ogl_frame_converter&) = delete;
+
+    ~ogl_frame_converter() override = default;
+
+    ogl_frame_converter& operator=(const ogl_frame_converter&) = delete;
+
+    std::shared_future<array<const std::uint8_t>> convert_to_buffer(const core::const_frame&   frame,
+                                                                    const core::frame_conversion_format& format) override;
+
+    common::bit_depth get_frame_bitdepth(const core::const_frame& frame) override;
+
+  private:
+    const spl::shared_ptr<device> ogl_;
+};
+
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/image_mixer.cpp
+++ b/src/accelerator/ogl/image/image_mixer.cpp
@@ -333,8 +333,7 @@ struct image_mixer::impl
     {
         std::vector<array<std::uint8_t>> image_data;
         for (auto& plane : desc.planes) {
-            auto bytes_per_pixel = depth == common::bit_depth::bit8 ? 1 : 2;
-            image_data.push_back(ogl_->create_array(plane.size * bytes_per_pixel));
+            image_data.push_back(ogl_->create_array(plane.size * bytes_per_pixel(depth)));
         }
 
         std::weak_ptr<image_mixer::impl> weak_self = shared_from_this();

--- a/src/accelerator/ogl/image/image_mixer.cpp
+++ b/src/accelerator/ogl/image/image_mixer.cpp
@@ -20,6 +20,7 @@
  */
 #include "image_mixer.h"
 
+#include "frame_converter.h"
 #include "image_kernel.h"
 
 #include "../util/buffer.h"
@@ -87,22 +88,26 @@ class image_renderer
     {
     }
 
-    std::future<array<const std::uint8_t>> operator()(std::vector<layer>             layers,
-                                                      const core::video_format_desc& format_desc)
+    std::future<std::shared_ptr<ogl_texture_and_buffer_cache>> render(std::vector<layer>             layers,
+                                                                      const core::video_format_desc& format_desc)
     {
-        if (layers.empty()) { // Bypass GPU with empty frame.
-            static const std::vector<uint8_t> buffer(max_frame_size_, 0);
-            return make_ready_future(array<const std::uint8_t>(buffer.data(), format_desc.size, true));
-        }
+        // TODO - reenable
+        // Create and cache a texture that will be purged every time the format_desc changes.
+        // While not strictly necessary, this will minimise the risk of memory 'leaks' when consumers keep changing the
+        // required local buffer size And by caching, we will avoid the overhead of creating and downloading a new
+        // texture each tick if (layers.empty()) { // Bypass GPU with empty frame.
+        //     static const std::vector<uint8_t> buffer(max_frame_size_, 0);
+        //     return make_ready_future(array<const std::uint8_t>(buffer.data(), format_desc.size, true));
+        // }
 
-        return flatten(ogl_->dispatch_async(
-            [=, layers = std::move(layers)]() mutable -> std::shared_future<array<const std::uint8_t>> {
+        return ogl_->dispatch_async(
+            [=, layers = std::move(layers)]() mutable -> std::shared_ptr<ogl_texture_and_buffer_cache> {
                 auto target_texture = ogl_->create_texture(format_desc.width, format_desc.height, 4, depth_);
 
                 draw(target_texture, std::move(layers), format_desc);
 
-                return ogl_->copy_async(target_texture);
-            }));
+                return std::make_shared<ogl_texture_and_buffer_cache>(std::move(target_texture));
+            });
     }
 
     common::bit_depth depth() const { return depth_; }
@@ -296,18 +301,12 @@ struct image_mixer::impl
         item.transform = transform_stack_.back();
         item.geometry  = frame.geometry();
 
-        auto textures_ptr = std::any_cast<std::shared_ptr<std::vector<future_texture>>>(frame.opaque());
+        auto textures_ptr = std::any_cast<std::shared_ptr<std::vector<future_texture>>>(frame.image_ptr());
 
         if (textures_ptr) {
             item.textures = *textures_ptr;
         } else {
-            for (int n = 0; n < static_cast<int>(item.pix_desc.planes.size()); ++n) {
-                item.textures.emplace_back(ogl_->copy_async(frame.image_data(n),
-                                                            item.pix_desc.planes[n].width,
-                                                            item.pix_desc.planes[n].height,
-                                                            item.pix_desc.planes[n].stride,
-                                                            item.pix_desc.planes[n].depth));
-            }
+            CASPAR_LOG(debug) << "Skipping drawing frame which has no textures";
         }
 
         layer_stack_.back()->items.push_back(item);
@@ -319,9 +318,9 @@ struct image_mixer::impl
         layer_stack_.resize(transform_stack_.back().layer_depth);
     }
 
-    std::future<array<const std::uint8_t>> render(const core::video_format_desc& format_desc)
+    std::shared_future<std::shared_ptr<ogl_texture_and_buffer_cache>> render(const core::video_format_desc& format_desc)
     {
-        return renderer_(std::move(layers_), format_desc);
+        return renderer_.render(std::move(layers_), format_desc);
     }
 
     core::mutable_frame create_frame(const void* tag, const core::pixel_format_desc& desc) override
@@ -360,6 +359,11 @@ struct image_mixer::impl
                                    });
     }
 
+    spl::shared_ptr<core::frame_converter> create_frame_converter() override
+    {
+        return spl::make_shared<ogl_frame_converter>(ogl_);
+    }
+
     common::bit_depth depth() const { return renderer_.depth(); }
     core::color_space color_space() const { return renderer_.color_space(); }
 };
@@ -373,12 +377,13 @@ image_mixer::image_mixer(const spl::shared_ptr<device>& ogl,
 {
 }
 image_mixer::~image_mixer() {}
-void image_mixer::push(const core::frame_transform& transform) { impl_->push(transform); }
-void image_mixer::visit(const core::const_frame& frame) { impl_->visit(frame); }
-void image_mixer::pop() { impl_->pop(); }
-std::future<array<const std::uint8_t>> image_mixer::render(const core::video_format_desc& format_desc)
+void                  image_mixer::push(const core::frame_transform& transform) { impl_->push(transform); }
+void                  image_mixer::visit(const core::const_frame& frame) { impl_->visit(frame); }
+void                  image_mixer::pop() { impl_->pop(); }
+std::future<std::any> image_mixer::render(const core::video_format_desc& format_desc)
 {
-    return impl_->render(format_desc);
+    auto texture = impl_->render(format_desc);
+    return std::async([texture = std::move(texture)]() -> std::any { return std::any(texture.get()); });
 }
 core::mutable_frame image_mixer::create_frame(const void* tag, const core::pixel_format_desc& desc)
 {
@@ -389,6 +394,7 @@ image_mixer::create_frame(const void* tag, const core::pixel_format_desc& desc, 
 {
     return impl_->create_frame(tag, desc, depth);
 }
+spl::shared_ptr<core::frame_converter> image_mixer::create_frame_converter() { return impl_->create_frame_converter(); }
 
 common::bit_depth image_mixer::depth() const { return impl_->depth(); }
 core::color_space image_mixer::color_space() const { return impl_->color_space(); }

--- a/src/accelerator/ogl/image/image_mixer.h
+++ b/src/accelerator/ogl/image/image_mixer.h
@@ -48,10 +48,12 @@ class image_mixer final : public core::image_mixer
 
     image_mixer& operator=(const image_mixer&) = delete;
 
-    std::future<array<const std::uint8_t>> render(const core::video_format_desc& format_desc) override;
-    core::mutable_frame                    create_frame(const void* tag, const core::pixel_format_desc& desc) override;
+    std::future<std::any> render(const core::video_format_desc& format_desc) override;
+    core::mutable_frame   create_frame(const void* tag, const core::pixel_format_desc& desc) override;
     core::mutable_frame
     create_frame(const void* video_stream_tag, const core::pixel_format_desc& desc, common::bit_depth depth) override;
+
+    spl::shared_ptr<core::frame_converter> create_frame_converter() override;
 
     // core::image_mixer
 

--- a/src/accelerator/ogl/image/shader_compute_from_rgba.comp
+++ b/src/accelerator/ogl/image/shader_compute_from_rgba.comp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+#version 430
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(rgba16, binding = 0) uniform image2D imgInput16bit; // Note: this needs to match what it is writing to
+layout(rgba8, binding = 1) uniform image2D imgInput8bit; // Note: this needs to match what it is writing to
+
+layout(std430, binding = 2) buffer buffer_layout
+{
+    uint bufferOutput[];
+};
+
+layout(std430, binding = 3) buffer description_layout
+{
+    // This must match convert_from_texture_description in device.h
+    uint target_format;
+    uint is_16_bit;
+    uint frame_width;
+    uint frame_height;
+    uint words_per_line;
+    uint key_only;
+    uint straigthen;
+};
+
+vec4 straighten_pixel(vec4 pixel) {
+    return vec4(
+        pixel.r / pixel.a,
+        pixel.g / pixel.a,
+        pixel.b / pixel.a,
+        pixel.a
+    );
+}
+
+vec4 read_pixel(ivec2 coord) {
+    vec4 pixel = is_16_bit > 0 ? imageLoad(imgInput16bit, coord) : imageLoad(imgInput8bit, coord);
+    if (key_only > 0) return pixel.aaaa;
+    if (straigthen > 0) return straighten_pixel(pixel);
+    return pixel;
+}
+
+vec3 rgba_to_bt709(vec4 pixel) {
+    if (key_only > 0) {
+        // TODO - verify everything about this
+        return vec3(pixel.a, 0.5, 0.5);
+    }
+
+    float KR = 0.2126;
+    float KB = 0.0722;
+    float KG = 1.0 - KR - KB;
+
+    float KRi = 1.0 - KR;
+    float KBi = 1.0 - KB;
+
+    float YRange = 219.0 / 256.0;
+    float CbCrRange = 224.0 / 256.0;
+    float HalfCbCrRange = CbCrRange / 2.0;
+
+    float YOffset = 16.0 / 256.0;
+    float CbCrOffset = 0.5;
+
+    float KRoKBi = KR / KBi;
+    float KGoKBi = KG / KBi;
+    float KBoKRi = KB / KRi;
+    float KGoKRi = KG / KRi;
+
+//    vec3 y_range = vec3(KR * YRange, KG * YRange, KB * YRange);
+//    vec3 y_offset = vec3(YOffset, YOffset, YOffset);
+
+    float y16 = KR * pixel.r + KG * pixel.g + KB * pixel.b;
+    float y = (YOffset + y16 * YRange);
+
+    float cb16 = -KRoKBi * pixel.r - KGoKBi * pixel.g + pixel.b;
+    float cb = (CbCrOffset + cb16 * HalfCbCrRange);
+
+    float cr16 = pixel.r - KGoKRi * pixel.g - KBoKRi * pixel.b;
+    float cr = (CbCrOffset + cr16 * HalfCbCrRange);
+
+    return vec3(y, cb, cr);
+}
+
+uint to_10bit(float val) {
+    return uint(round(val * 1023));
+}
+
+void decklink_v210() {
+    // basic coordinates
+    uint y_offset = gl_GlobalInvocationID.y * words_per_line;
+    uint x_offset = gl_GlobalInvocationID.x * 4; // 4 words per op
+    uint offset = y_offset + x_offset;
+    uint image_x = gl_GlobalInvocationID.x * 6;
+
+    // sample image and compute words
+    vec3 ycbcr0 = rgba_to_bt709(read_pixel(ivec2(image_x + 0, gl_GlobalInvocationID.y)));
+    bufferOutput[offset + 0] = to_10bit(ycbcr0.t) + (to_10bit(ycbcr0.s) << 10) + (to_10bit(ycbcr0.p) << 20);
+
+    vec3 ycbcr1 = rgba_to_bt709(read_pixel(ivec2(image_x + 1, gl_GlobalInvocationID.y)));
+    vec3 ycbcr2 = rgba_to_bt709(read_pixel(ivec2(image_x + 2, gl_GlobalInvocationID.y)));
+    bufferOutput[offset + 1] = to_10bit(ycbcr1.s) + (to_10bit(ycbcr2.t) << 10) + (to_10bit(ycbcr2.s) << 20);
+
+    vec3 ycbcr3 = rgba_to_bt709(read_pixel(ivec2(image_x + 3, gl_GlobalInvocationID.y)));
+    vec3 ycbcr4 = rgba_to_bt709(read_pixel(ivec2(image_x + 4, gl_GlobalInvocationID.y)));
+    bufferOutput[offset + 2] = to_10bit(ycbcr2.p) + (to_10bit(ycbcr3.s) << 10) + (to_10bit(ycbcr4.t) << 20);
+
+    vec3 ycbcr5 = rgba_to_bt709(read_pixel(ivec2(image_x + 5, gl_GlobalInvocationID.y)));
+    bufferOutput[offset + 3] = to_10bit(ycbcr4.s) + (to_10bit(ycbcr4.p) << 10) + (to_10bit(ycbcr5.s) << 20);
+}
+
+
+void rgba16() {
+    // TODO: is this excessive to do in a shader?
+    // basic coordinates
+    uint y_offset = gl_GlobalInvocationID.y * words_per_line;
+    uint x_offset = gl_GlobalInvocationID.x * 2; // 4 words per op
+    uint offset = y_offset + x_offset;
+
+    // TODO - can this be done solely as integer?
+    vec4 pixel = read_pixel(ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y));
+
+    bufferOutput[offset + 0] = uint(pixel.r * 65535) + (uint(pixel.g * 65535) << 16);
+    bufferOutput[offset + 1] = uint(pixel.b * 65535) + (uint(pixel.a * 65535) << 16);
+}
+
+void bgra16() {
+    // TODO: is this excessive to do in a shader?
+    // basic coordinates
+    uint y_offset = gl_GlobalInvocationID.y * words_per_line;
+    uint x_offset = gl_GlobalInvocationID.x * 2; // 4 words per op
+    uint offset = y_offset + x_offset;
+
+    // TODO - can this be done solely as integer?
+    vec4 pixel = read_pixel(ivec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y));
+
+    bufferOutput[offset + 0] = uint(pixel.b * 65535) + (uint(pixel.g * 65535) << 16);
+    bufferOutput[offset + 1] = uint(pixel.r * 65535) + (uint(pixel.a * 65535) << 16);
+}
+
+void main() {
+    ivec2 texelCoord = ivec2(gl_GlobalInvocationID.xy);
+
+    switch(target_format){
+        case 0: // rgba16
+            rgba16();
+            break;
+        case 1: // bgra16
+            bgra16();
+            break;
+
+        case 2:
+            decklink_v210();
+            break;
+    }
+}

--- a/src/accelerator/ogl/image/shader_compute_to_rgba.comp
+++ b/src/accelerator/ogl/image/shader_compute_to_rgba.comp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+#version 430
+
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(rgba16f, binding = 0) uniform image2D imgOutput; // Note: this needs to match what it is writing to
+
+void main() {
+    vec4 value = vec4(0.0, 0.0, 0.0, 1.0);
+    ivec2 texelCoord = ivec2(gl_GlobalInvocationID.xy);
+
+    value.r = float(texelCoord.x)/(gl_NumWorkGroups.x);
+    value.g = float(texelCoord.y)/(gl_NumWorkGroups.y);
+
+    imageStore(imgOutput, texelCoord, value);
+}

--- a/src/accelerator/ogl/util/compute_shader.cpp
+++ b/src/accelerator/ogl/util/compute_shader.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+#include "compute_shader.h"
+
+#include <common/gl/gl_check.h>
+
+#include <GL/glew.h>
+
+namespace caspar { namespace accelerator { namespace ogl {
+
+struct compute_shader::impl
+{
+    GLuint program_;
+
+    impl(const impl&)            = delete;
+    impl& operator=(const impl&) = delete;
+
+  public:
+    impl(const std::string& compute_source_str)
+        : program_(0)
+    {
+        int work_grp_cnt[3];
+
+        glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT, 0, &work_grp_cnt[0]);
+        glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT, 1, &work_grp_cnt[1]);
+        glGetIntegeri_v(GL_MAX_COMPUTE_WORK_GROUP_COUNT, 2, &work_grp_cnt[2]);
+
+        GLint success;
+
+        const char* compute_source = compute_source_str.c_str();
+
+        auto compute_shader = glCreateShader(GL_COMPUTE_SHADER);
+
+        GL(glShaderSource(compute_shader, 1, &compute_source, NULL));
+        GL(glCompileShader(compute_shader));
+
+        GL(glGetObjectParameterivARB(compute_shader, GL_OBJECT_COMPILE_STATUS_ARB, &success));
+        if (success == GL_FALSE) {
+            char info[2048];
+            GL(glGetInfoLogARB(compute_shader, sizeof(info), 0, info));
+            GL(glDeleteObjectARB(compute_shader));
+            std::stringstream str;
+            str << "Failed to compile compute shader:" << std::endl << info << std::endl;
+            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(str.str()));
+        }
+
+        program_ = glCreateProgram();
+
+        GL(glAttachShader(program_, compute_shader));
+        GL(glLinkProgram(program_));
+
+        GL(glDeleteShader(compute_shader));
+
+        GL(glGetObjectParameterivARB(program_, GL_OBJECT_LINK_STATUS_ARB, &success));
+        if (success == GL_FALSE) {
+            char info[2048];
+            GL(glGetInfoLogARB(program_, sizeof(info), 0, info));
+            GL(glDeleteObjectARB(program_));
+            std::stringstream str;
+            str << "Failed to link shader program:" << std::endl << info << std::endl;
+            CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(str.str()));
+        }
+        GL(glUseProgram(program_));
+    }
+
+    ~impl() { glDeleteProgram(program_); }
+
+    void use() { GL(glUseProgram(program_)); }
+};
+
+compute_shader::compute_shader(const std::string& compute_source_str)
+    : impl_(new impl(compute_source_str))
+{
+}
+compute_shader::~compute_shader() {}
+GLuint compute_shader::id() const { return impl_->program_; }
+void   compute_shader::use() const { impl_->use(); }
+
+}}} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/compute_shader.h
+++ b/src/accelerator/ogl/util/compute_shader.h
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include <GL/glew.h>
+#include <memory>
+#include <string>
+
+namespace caspar { namespace accelerator { namespace ogl {
+
+class compute_shader final
+{
+    compute_shader(const compute_shader&);
+    compute_shader& operator=(const compute_shader&);
+
+public:
+    explicit compute_shader(const std::string& compute_source_str);
+    ~compute_shader();
+
+    void use() const;
+
+    [[nodiscard]] GLuint id() const;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> impl_;
+};
+
+}}} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/convert_description.h
+++ b/src/accelerator/ogl/util/convert_description.h
@@ -16,31 +16,26 @@
  * You should have received a copy of the GNU General Public License
  * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
  *
- * Author: Robert Nagy, ronag89@gmail.com
+ * Author: Julian Waller, julian@superfly.tv
  */
 
 #pragma once
 
-#include <common/bit_depth.h>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <memory>
 
-#include "frame_converter.h"
+namespace caspar::accelerator::ogl {
 
-namespace caspar { namespace core {
-
-class frame_factory
+// This must match description_layout in shader_from_rgba.comp
+struct convert_from_texture_description
 {
-  public:
-    frame_factory()                                = default;
-    frame_factory& operator=(const frame_factory&) = delete;
-    virtual ~frame_factory()                       = default;
-
-    frame_factory(const frame_factory&) = delete;
-
-    virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
-    virtual class mutable_frame
-    create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc, common::bit_depth depth) = 0;
-
-    virtual spl::shared_ptr<frame_converter> create_frame_converter() = 0;
+    uint32_t target_format;
+    uint32_t is_16_bit;
+    uint32_t width;
+    uint32_t height;
+    uint32_t words_per_line;
+    uint32_t key_only;
+    uint32_t straighten;
 };
 
-}} // namespace caspar::core
+} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/util/device.cpp
+++ b/src/accelerator/ogl/util/device.cpp
@@ -21,6 +21,7 @@
 #include "device.h"
 
 #include "buffer.h"
+#include "compute_shader.h"
 #include "shader.h"
 #include "texture.h"
 
@@ -51,6 +52,9 @@
 #include <future>
 #include <thread>
 
+#include "ogl_image_from_rgba.h"
+#include "ogl_image_to_rgba.h"
+
 namespace caspar { namespace accelerator { namespace ogl {
 
 using namespace boost::asio;
@@ -64,6 +68,9 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
     std::array<std::array<tbb::concurrent_unordered_map<size_t, texture_queue_t>, 4>, 2> device_pools_;
     std::array<tbb::concurrent_unordered_map<size_t, buffer_queue_t>, 2>                 host_pools_;
+
+    std::unique_ptr<compute_shader> compute_to_rgba_;
+    std::unique_ptr<compute_shader> compute_from_rgba_;
 
     GLuint fbo_;
 
@@ -182,7 +189,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         CASPAR_VERIFY(stride > 0 && stride < 5);
         CASPAR_VERIFY(width > 0 && height > 0);
 
-        auto depth_pool_index = depth == common::bit_depth::bit8 ? 0 : 1;
+        auto depth_pool_index = common::bytes_per_pixel(depth) - 1;
 
         // TODO (perf) Shared pool.
         auto pool = &device_pools_[depth_pool_index][stride - 1][(width << 16 & 0xFFFF0000) | (height & 0x0000FFFF)];
@@ -250,11 +257,13 @@ struct device::impl : public std::enable_shared_from_this<impl>
         });
     }
 
-    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source)
+    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source, bool as_rgba8)
     {
         return spawn_async([=](yield_context yield) {
-            auto buf = create_buffer(source->size(), false);
-            source->copy_to(*buf);
+            auto bit_depth = as_rgba8 ? common::bit_depth::bit8 : source->depth();
+            auto buf       = create_buffer(
+                source->width() * source->height() * source->stride() * common::bytes_per_pixel(bit_depth), false);
+            source->copy_to(*buf, bit_depth);
 
             auto fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
 
@@ -277,6 +286,88 @@ struct device::impl : public std::enable_shared_from_this<impl>
             auto ptr  = reinterpret_cast<uint8_t*>(buf->data());
             auto size = buf->size();
             return array<const uint8_t>(ptr, size, std::move(buf));
+        });
+    }
+
+    /*
+    * In its current form, this is not useful/complete. But it will be needed in some form for a producer 'soon'
+   std::future<std::shared_ptr<texture>>
+   std::future<std::shared_ptr<texture>>
+   copy_async(GLuint source, int width, int height, int stride, common::bit_depth depth)
+   convert_frame(const std::vector<array<const uint8_t>>& sources, int width, int height, int width_samples)
+    {
+        return dispatch_async([=] {
+            if (!compute_to_rgba_)
+                compute_to_rgba_ = std::make_unique<compute_shader>(std::string(compute_to_rgba_shader));
+            auto tex = create_texture(width, height, 4, common::bit_depth::bit16, false);
+            glBindImageTexture(0, tex->id(), 0, GL_FALSE, 0, GL_READ_WRITE, GL_RGBA16F);
+            compute_to_rgba_->use();
+            glDispatchCompute((unsigned int)width_samples, (unsigned int)height, 1);
+            // make sure writing to image has finished before read
+            glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+            return tex;
+        });
+    }
+    */
+
+    std::future<array<const uint8_t>> convert_from_texture(const std::shared_ptr<texture>&         texture,
+                                                           int                                     buffer_size,
+                                                           const convert_from_texture_description& description,
+                                                           unsigned int                            x_count,
+                                                           unsigned int                            y_count)
+    {
+        return spawn_async([=](yield_context yield) {
+            if (!compute_from_rgba_)
+                compute_from_rgba_ = std::make_unique<compute_shader>(std::string(compute_from_rgba_shader));
+
+            // single input texture
+            GLuint texid_8bit  = 0;
+            GLuint texid_16bit = 0;
+
+            switch (texture->depth()) {
+                case common::bit_depth::bit8:
+                    texid_8bit = texture->id();
+                    break;
+                case common::bit_depth::bit16:
+                    texid_16bit = texture->id();
+                    break;
+            }
+
+            GL(glBindImageTexture(0, texid_16bit, 0, GL_FALSE, 0, GL_READ_ONLY, GL_RGBA16));
+            GL(glBindImageTexture(1, texid_8bit, 0, GL_FALSE, 0, GL_READ_ONLY, GL_RGBA8));
+
+            array<const uint8_t> output_buffer = create_array(buffer_size); // TODO - tidy this?
+            auto                 buffer_ptr    = output_buffer.storage<std::shared_ptr<buffer>>();
+            if (!buffer_ptr) {
+                CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Buffer is not gpu backed"));
+            }
+            GL(glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, buffer_ptr->get()->id()));
+
+            auto description_buffer = create_buffer(sizeof(convert_from_texture_description), false);
+            std::memcpy(description_buffer->data(), &description, sizeof(convert_from_texture_description));
+            GL(glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, description_buffer->id()));
+
+            compute_from_rgba_->use();
+
+            GL(glDispatchCompute(x_count, y_count, 1));
+
+            auto fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+            GL(glFlush());
+            deadline_timer timer(service_);
+            for (auto n = 0; true; ++n) {
+                // TODO (perf) Smarter non-polling solution?
+                timer.expires_from_now(boost::posix_time::milliseconds(2));
+                timer.async_wait(yield);
+                auto wait = glClientWaitSync(fence, 0, 1);
+                if (wait == GL_ALREADY_SIGNALED || wait == GL_CONDITION_SATISFIED) {
+                    break;
+                }
+            }
+
+            glDeleteSync(fence);
+
+            return output_buffer;
         });
     }
 
@@ -404,9 +495,17 @@ device::copy_async(const array<const uint8_t>& source, int width, int height, in
 {
     return impl_->copy_async(source, width, height, stride, depth);
 }
-std::future<array<const uint8_t>> device::copy_async(const std::shared_ptr<texture>& source)
+std::future<array<const uint8_t>> device::copy_async(const std::shared_ptr<texture>& source, bool as_rgba8)
 {
-    return impl_->copy_async(source);
+    return impl_->copy_async(source, as_rgba8);
+}
+std::future<array<const uint8_t>> device::convert_from_texture(const std::shared_ptr<texture>&         texture,
+                                                               int                                     buffer_size,
+                                                               const convert_from_texture_description& description,
+                                                               unsigned int                            x_count,
+                                                               unsigned int                            y_count)
+{
+    return impl_->convert_from_texture(texture, buffer_size, description, x_count, y_count);
 }
 void         device::dispatch(std::function<void()> func) { boost::asio::dispatch(impl_->service_, std::move(func)); }
 std::wstring device::version() const { return impl_->version(); }

--- a/src/accelerator/ogl/util/device.h
+++ b/src/accelerator/ogl/util/device.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "convert_description.h"
+
 #include <accelerator/accelerator.h>
 #include <common/array.h>
 #include <common/bit_depth.h>
@@ -51,7 +53,14 @@ class device final
 
     std::future<std::shared_ptr<class texture>>
     copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth);
-    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<class texture>& source);
+    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<class texture>& source, bool as_rgba8);
+
+    std::future<array<const uint8_t>> convert_from_texture(const std::shared_ptr<texture>&         texture,
+                                                           int                                     buffer_size,
+                                                           const convert_from_texture_description& description,
+                                                           unsigned int                            x_count,
+                                                           unsigned int                            y_count);
+
     template <typename Func>
     auto dispatch_async(Func&& func)
     {

--- a/src/accelerator/ogl/util/texture.cpp
+++ b/src/accelerator/ogl/util/texture.cpp
@@ -52,7 +52,7 @@ struct texture::impl
         , height_(height)
         , stride_(stride)
         , depth_(depth)
-        , size_(width * height * stride * (depth == common::bit_depth::bit8 ? 1 : 2))
+        , size_(width * height * stride * common::bytes_per_pixel(depth))
     {
         GL(glCreateTextures(GL_TEXTURE_2D, 1, &id_));
         GL(glTextureParameteri(id_, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
@@ -60,7 +60,7 @@ struct texture::impl
         GL(glTextureParameteri(id_, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
         GL(glTextureParameteri(id_, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
         GL(glTextureStorage2D(
-            id_, 1, INTERNAL_FORMAT[depth_ == common::bit_depth::bit8 ? 0 : 1][stride_], width_, height_));
+            id_, 1, INTERNAL_FORMAT[common::bytes_per_pixel(depth_) - 1][stride_], width_, height_));
     }
 
     ~impl() { glDeleteTextures(1, &id_); }
@@ -79,7 +79,7 @@ struct texture::impl
 
     void clear()
     {
-        GL(glClearTexImage(id_, 0, FORMAT[stride_], TYPE[depth_ == common::bit_depth::bit8 ? 0 : 1][stride_], nullptr));
+        GL(glClearTexImage(id_, 0, FORMAT[stride_], TYPE[common::bytes_per_pixel(depth_) - 1][stride_], nullptr));
     }
 
 #ifdef WIN32
@@ -107,17 +107,17 @@ struct texture::impl
                                width_,
                                height_,
                                FORMAT[stride_],
-                               TYPE[depth_ == common::bit_depth::bit8 ? 0 : 1][stride_],
+                               TYPE[common::bytes_per_pixel(depth_) - 1][stride_],
                                nullptr));
 
         src.unbind();
     }
 
-    void copy_to(buffer& dst)
+    void copy_to(buffer& dst, common::bit_depth depth)
     {
         dst.bind();
         GL(glGetTextureImage(
-            id_, 0, FORMAT[stride_], TYPE[depth_ == common::bit_depth::bit8 ? 0 : 1][stride_], size_, nullptr));
+            id_, 0, FORMAT[stride_], TYPE[common::bytes_per_pixel(depth) - 1][stride_], size_, nullptr));
         dst.unbind();
     }
 };
@@ -144,7 +144,8 @@ void texture::clear() { impl_->clear(); }
 void texture::copy_from(int source) { impl_->copy_from(source); }
 #endif
 void              texture::copy_from(buffer& source) { impl_->copy_from(source); }
-void              texture::copy_to(buffer& dest) { impl_->copy_to(dest); }
+void              texture::copy_to(class buffer& dest, common::bit_depth depth) { impl_->copy_to(dest, depth); }
+void              texture::copy_to(buffer& dest) { impl_->copy_to(dest, impl_->depth_); }
 int               texture::width() const { return impl_->width_; }
 int               texture::height() const { return impl_->height_; }
 int               texture::stride() const { return impl_->stride_; }

--- a/src/accelerator/ogl/util/texture.h
+++ b/src/accelerator/ogl/util/texture.h
@@ -41,6 +41,7 @@ class texture final
     void copy_from(int source);
 #endif
     void copy_from(class buffer& source);
+    void copy_to(class buffer& dest, common::bit_depth depth);
     void copy_to(class buffer& dest);
 
     void attach();

--- a/src/common/bit_depth.h
+++ b/src/common/bit_depth.h
@@ -13,4 +13,11 @@ enum class bit_depth : uint8_t
     bit16,
 };
 
+inline int bytes_per_pixel(bit_depth depth)
+{
+    if (depth == bit_depth::bit8)
+        return 1;
+    return 2;
+}
+
 }} // namespace caspar::common

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -43,6 +43,7 @@ set(HEADERS
 
 		frame/draw_frame.h
 		frame/frame.h
+		frame/frame_converter.h
 		frame/frame_factory.h
 		frame/frame_transform.h
 		frame/frame_visitor.h

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -149,11 +149,10 @@ void frame_consumer_registry::register_preconfigured_consumer_factory(const std:
 }
 
 spl::shared_ptr<core::frame_consumer>
-frame_consumer_registry::create_consumer(const std::vector<std::wstring>&                         params,
-                                         const core::video_format_repository&                     format_repository,
-                                         const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                                         const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                         common::bit_depth                                        depth) const
+frame_consumer_registry::create_consumer(const std::vector<std::wstring>&              params,
+                                         const core::video_format_repository&          format_repository,
+                                         const spl::shared_ptr<core::frame_converter>& frame_converter,
+                                         common::bit_depth                             depth) const
 {
     if (params.empty())
         CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("params cannot be empty"));
@@ -163,7 +162,7 @@ frame_consumer_registry::create_consumer(const std::vector<std::wstring>&       
     if (!std::any_of(
             consumer_factories.begin(), consumer_factories.end(), [&](const consumer_factory_t& factory) -> bool {
                 try {
-                    consumer = factory(params, format_repository, frame_converter, channels, depth);
+                    consumer = factory(params, format_repository, frame_converter, depth);
                 } catch (...) {
                     CASPAR_LOG_CURRENT_EXCEPTION();
                 }
@@ -176,12 +175,11 @@ frame_consumer_registry::create_consumer(const std::vector<std::wstring>&       
 }
 
 spl::shared_ptr<frame_consumer>
-frame_consumer_registry::create_consumer(const std::wstring&                                      element_name,
-                                         const boost::property_tree::wptree&                      element,
-                                         const core::video_format_repository&                     format_repository,
-                                         const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                                         const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                         common::bit_depth                                        depth) const
+frame_consumer_registry::create_consumer(const std::wstring&                           element_name,
+                                         const boost::property_tree::wptree&           element,
+                                         const core::video_format_repository&          format_repository,
+                                         const spl::shared_ptr<core::frame_converter>& frame_converter,
+                                         common::bit_depth                             depth) const
 {
     auto& preconfigured_consumer_factories = preconfigured_consumer_factories_;
     auto  found                            = preconfigured_consumer_factories.find(element_name);
@@ -190,8 +188,8 @@ frame_consumer_registry::create_consumer(const std::wstring&                    
         CASPAR_THROW_EXCEPTION(user_error()
                                << msg_info(L"No consumer factory registered for element name " + element_name));
 
-    return spl::make_shared<destroy_consumer_proxy>(spl::make_shared<print_consumer_proxy>(
-        found->second(element, format_repository, frame_converter, channels, depth)));
+    return spl::make_shared<destroy_consumer_proxy>(
+        spl::make_shared<print_consumer_proxy>(found->second(element, format_repository, frame_converter, depth)));
 }
 
 const spl::shared_ptr<frame_consumer>& frame_consumer::empty()

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -48,9 +48,9 @@ class destroy_consumer_proxy : public frame_consumer
 {
     std::shared_ptr<frame_consumer> consumer_;
 
-public:
+  public:
     destroy_consumer_proxy(spl::shared_ptr<frame_consumer>&& consumer)
-            : consumer_(std::move(consumer))
+        : consumer_(std::move(consumer))
     {
         destroy_consumers_in_separate_thread() = true;
     }
@@ -105,9 +105,9 @@ class print_consumer_proxy : public frame_consumer
 {
     std::shared_ptr<frame_consumer> consumer_;
 
-public:
+  public:
     print_consumer_proxy(spl::shared_ptr<frame_consumer>&& consumer)
-            : consumer_(std::move(consumer))
+        : consumer_(std::move(consumer))
     {
     }
 
@@ -135,10 +135,7 @@ public:
     core::monitor::state state() const override { return consumer_->state(); }
 };
 
-
-frame_consumer_registry::frame_consumer_registry()
-{
-}
+frame_consumer_registry::frame_consumer_registry() {}
 
 void frame_consumer_registry::register_consumer_factory(const std::wstring& name, const consumer_factory_t& factory)
 {
@@ -154,6 +151,7 @@ void frame_consumer_registry::register_preconfigured_consumer_factory(const std:
 spl::shared_ptr<core::frame_consumer>
 frame_consumer_registry::create_consumer(const std::vector<std::wstring>&                         params,
                                          const core::video_format_repository&                     format_repository,
+                                         const spl::shared_ptr<core::frame_converter>&            frame_converter,
                                          const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                          common::bit_depth                                        depth) const
 {
@@ -165,7 +163,7 @@ frame_consumer_registry::create_consumer(const std::vector<std::wstring>&       
     if (!std::any_of(
             consumer_factories.begin(), consumer_factories.end(), [&](const consumer_factory_t& factory) -> bool {
                 try {
-                    consumer = factory(params, format_repository, channels, depth);
+                    consumer = factory(params, format_repository, frame_converter, channels, depth);
                 } catch (...) {
                     CASPAR_LOG_CURRENT_EXCEPTION();
                 }
@@ -181,6 +179,7 @@ spl::shared_ptr<frame_consumer>
 frame_consumer_registry::create_consumer(const std::wstring&                                      element_name,
                                          const boost::property_tree::wptree&                      element,
                                          const core::video_format_repository&                     format_repository,
+                                         const spl::shared_ptr<core::frame_converter>&            frame_converter,
                                          const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                          common::bit_depth                                        depth) const
 {
@@ -191,8 +190,8 @@ frame_consumer_registry::create_consumer(const std::wstring&                    
         CASPAR_THROW_EXCEPTION(user_error()
                                << msg_info(L"No consumer factory registered for element name " + element_name));
 
-    return spl::make_shared<destroy_consumer_proxy>(
-        spl::make_shared<print_consumer_proxy>(found->second(element, format_repository, channels, depth)));
+    return spl::make_shared<destroy_consumer_proxy>(spl::make_shared<print_consumer_proxy>(
+        found->second(element, format_repository, frame_converter, channels, depth)));
 }
 
 const spl::shared_ptr<frame_consumer>& frame_consumer::empty()
@@ -215,7 +214,5 @@ const spl::shared_ptr<frame_consumer>& frame_consumer::empty()
     static spl::shared_ptr<frame_consumer> consumer = spl::make_shared<empty_frame_consumer>();
     return consumer;
 }
-
-
 
 }} // namespace caspar::core

--- a/src/core/consumer/frame_consumer_registry.h
+++ b/src/core/consumer/frame_consumer_registry.h
@@ -45,14 +45,12 @@ using consumer_factory_t =
     std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&              params,
                                                   const core::video_format_repository&          format_repository,
                                                   const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                  common::bit_depth                                        depth)>;
+                                                  common::bit_depth                             depth)>;
 using preconfigured_consumer_factory_t =
     std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&           element,
                                                   const core::video_format_repository&          format_repository,
                                                   const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                  common::bit_depth                                        depth)>;
+                                                  common::bit_depth                             depth)>;
 
 class frame_consumer_registry
 {
@@ -64,14 +62,12 @@ class frame_consumer_registry
     spl::shared_ptr<frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                     const core::video_format_repository&          format_repository,
                                                     const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                    const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                    common::bit_depth depth) const;
+                                                    common::bit_depth                             depth) const;
     spl::shared_ptr<frame_consumer> create_consumer(const std::wstring&                           element_name,
                                                     const boost::property_tree::wptree&           element,
                                                     const core::video_format_repository&          format_repository,
                                                     const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                    const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                    common::bit_depth depth) const;
+                                                    common::bit_depth                             depth) const;
 
   private:
     std::vector<consumer_factory_t>                          consumer_factories_;

--- a/src/core/consumer/frame_consumer_registry.h
+++ b/src/core/consumer/frame_consumer_registry.h
@@ -33,22 +33,24 @@
 
 #include <functional>
 #include <future>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 namespace caspar { namespace core {
 
 void destroy_consumers_synchronously();
 
 using consumer_factory_t =
-    std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&     params,
-                                                  const core::video_format_repository& format_repository,
+    std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&              params,
+                                                  const core::video_format_repository&          format_repository,
+                                                  const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                   common::bit_depth                                        depth)>;
 using preconfigured_consumer_factory_t =
-    std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&  element,
-                                                  const core::video_format_repository& format_repository,
+    std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&           element,
+                                                  const core::video_format_repository&          format_repository,
+                                                  const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                   common::bit_depth                                        depth)>;
 
@@ -59,13 +61,15 @@ class frame_consumer_registry
     void register_consumer_factory(const std::wstring& name, const consumer_factory_t& factory);
     void register_preconfigured_consumer_factory(const std::wstring&                     element_name,
                                                  const preconfigured_consumer_factory_t& factory);
-    spl::shared_ptr<frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                    const core::video_format_repository& format_repository,
+    spl::shared_ptr<frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                    const core::video_format_repository&          format_repository,
+                                                    const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                     common::bit_depth depth) const;
-    spl::shared_ptr<frame_consumer> create_consumer(const std::wstring&                  element_name,
-                                                    const boost::property_tree::wptree&  element,
-                                                    const core::video_format_repository& format_repository,
+    spl::shared_ptr<frame_consumer> create_consumer(const std::wstring&                           element_name,
+                                                    const boost::property_tree::wptree&           element,
+                                                    const core::video_format_repository&          format_repository,
+                                                    const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                     common::bit_depth depth) const;
 

--- a/src/core/consumer/output.cpp
+++ b/src/core/consumer/output.cpp
@@ -122,7 +122,7 @@ struct output::impl
         }
 
         const auto bytesPerComponent1 =
-            input_frame1.pixel_format_desc().planes.at(0).depth == common::bit_depth::bit8 ? 1 : 2;
+            common::bytes_per_pixel(input_frame1.pixel_format_desc().planes.at(0).depth);
         if (input_frame1.size() != format_desc_.size * bytesPerComponent1) {
             CASPAR_LOG(warning) << print() << L" Invalid input frame size.";
             return;
@@ -130,7 +130,7 @@ struct output::impl
 
         if (input_frame2) {
             const auto bytesPerComponent2 =
-                input_frame2.pixel_format_desc().planes.at(0).depth == common::bit_depth::bit8 ? 1 : 2;
+                common::bytes_per_pixel(input_frame2.pixel_format_desc().planes.at(0).depth);
 
             if (input_frame2.size() != format_desc_.size * bytesPerComponent2) {
                 CASPAR_LOG(warning) << print() << L" Invalid input frame size.";

--- a/src/core/frame/frame.cpp
+++ b/src/core/frame/frame.cpp
@@ -76,7 +76,6 @@ mutable_frame& mutable_frame::operator=(mutable_frame&& other)
     impl_ = std::move(other.impl_);
     return *this;
 }
-void                           mutable_frame::swap(mutable_frame& other) { impl_.swap(other.impl_); }
 const core::pixel_format_desc& mutable_frame::pixel_format_desc() const { return impl_->desc_; }
 const array<std::uint8_t>& mutable_frame::image_data(std::size_t index) const { return impl_->image_data_.at(index); }
 const array<std::int32_t>& mutable_frame::audio_data() const { return impl_->audio_data_; }
@@ -89,54 +88,49 @@ frame_geometry&            mutable_frame::geometry() { return impl_->geometry_; 
 
 struct const_frame::impl
 {
-    std::vector<array<const std::uint8_t>> image_data_;
+    std::any image_ptr_;
     array<const std::int32_t>              audio_data_;
     core::pixel_format_desc                desc_     = core::pixel_format_desc(pixel_format::invalid);
     frame_geometry                         geometry_ = frame_geometry::get_default();
-    std::any                               opaque_;
 
-    impl(std::vector<array<const std::uint8_t>> image_data,
+    impl(std::any image_ptr,
          array<const std::int32_t>              audio_data,
          const core::pixel_format_desc&         desc)
-        : image_data_(std::move(image_data))
+        : image_ptr_(std::move(image_ptr))
         , audio_data_(std::move(audio_data))
         , desc_(desc)
     {
-        if (desc_.planes.size() != image_data_.size()) {
+        if (desc_.planes.size() != 1) {
             CASPAR_THROW_EXCEPTION(invalid_argument());
         }
     }
 
-    impl(std::vector<array<std::uint8_t>>&& image_data,
-         array<const std::int32_t>          audio_data,
-         const core::pixel_format_desc&     desc)
-        : image_data_(std::make_move_iterator(image_data.begin()), std::make_move_iterator(image_data.end()))
-        , audio_data_(std::move(audio_data))
-        , desc_(desc)
-    {
-        if (desc_.planes.size() != image_data_.size()) {
-            CASPAR_THROW_EXCEPTION(invalid_argument());
-        }
-    }
+    // impl(std::vector<array<std::uint8_t>>&& image_data,
+    //      array<const std::int32_t>          audio_data,
+    //      const core::pixel_format_desc&     desc)
+    //     : image_data_(std::make_move_iterator(image_data.begin()), std::make_move_iterator(image_data.end()))
+    //     , audio_data_(std::move(audio_data))
+    //     , desc_(desc)
+    // {
+    //     if (desc_.planes.size() != image_data_.size()) {
+    //         CASPAR_THROW_EXCEPTION(invalid_argument());
+    //     }
+    // }
 
     impl(mutable_frame&& other)
-        : image_data_(std::make_move_iterator(other.impl_->image_data_.begin()),
-                      std::make_move_iterator(other.impl_->image_data_.end()))
-        , audio_data_(std::move(other.impl_->audio_data_))
+        : audio_data_(std::move(other.impl_->audio_data_))
         , desc_(std::move(other.impl_->desc_))
         , geometry_(std::move(other.impl_->geometry_))
     {
-        if (desc_.planes.size() != image_data_.size() && !other.impl_->commit_) {
+        if (desc_.planes.size() != other.impl_->image_data_.size() && !other.impl_->commit_) {
             CASPAR_THROW_EXCEPTION(invalid_argument());
         }
-        if (other.impl_->commit_) {
-            opaque_ = other.impl_->commit_(image_data_);
-        }
+
+        image_ptr_ = other.impl_->commit_({std::make_move_iterator(other.impl_->image_data_.begin()),
+                      std::make_move_iterator(other.impl_->image_data_.end())});
     }
 
-    const array<const std::uint8_t>& image_data(std::size_t index) const { return image_data_.at(index); }
-
-    std::size_t width() const { return desc_.planes.at(0).width; }
+    std::size_t     width() const { return desc_.planes.at(0).width; }
 
     std::size_t height() const { return desc_.planes.at(0).height; }
 
@@ -144,10 +138,10 @@ struct const_frame::impl
 };
 
 const_frame::const_frame() {}
-const_frame::const_frame(std::vector<array<const std::uint8_t>> image_data,
+const_frame::const_frame(std::any image_ptr,
                          array<const std::int32_t>              audio_data,
                          const core::pixel_format_desc&         desc)
-    : impl_(new impl(std::move(image_data), std::move(audio_data), desc))
+    : impl_(new impl(std::move(image_ptr), std::move(audio_data), desc))
 {
 }
 const_frame::const_frame(mutable_frame&& other)
@@ -169,12 +163,11 @@ bool                     const_frame::operator!=(const const_frame& other) const
 bool                     const_frame::operator<(const const_frame& other) const { return impl_ < other.impl_; }
 bool                     const_frame::operator>(const const_frame& other) const { return impl_ > other.impl_; }
 const pixel_format_desc& const_frame::pixel_format_desc() const { return impl_->desc_; }
-const array<const std::uint8_t>& const_frame::image_data(std::size_t index) const { return impl_->image_data(index); }
+const std::any& const_frame::image_ptr() const { return impl_->image_ptr_; }
 const array<const std::int32_t>& const_frame::audio_data() const { return impl_->audio_data_; }
 std::size_t                      const_frame::width() const { return impl_->width(); }
 std::size_t                      const_frame::height() const { return impl_->height(); }
 std::size_t                      const_frame::size() const { return impl_->size(); }
 const frame_geometry&            const_frame::geometry() const { return impl_->geometry_; }
-const std::any&                  const_frame::opaque() const { return impl_->opaque_; }
 const_frame::operator bool() const { return impl_ != nullptr && impl_->desc_.format != core::pixel_format::invalid; }
 }} // namespace caspar::core

--- a/src/core/frame/frame.h
+++ b/src/core/frame/frame.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <future>
 #include <memory>
 #include <vector>
 
@@ -31,8 +32,6 @@ class mutable_frame final
     mutable_frame& operator=(const mutable_frame&) = delete;
     mutable_frame& operator=(mutable_frame&& other);
 
-    void swap(mutable_frame& other);
-
     const struct pixel_format_desc& pixel_format_desc() const;
 
     array<std::uint8_t>&       image_data(std::size_t index);
@@ -57,7 +56,7 @@ class const_frame final
 {
   public:
     const_frame();
-    explicit const_frame(std::vector<array<const std::uint8_t>> image_data,
+    explicit const_frame(std::any image_ptr,
                          array<const std::int32_t>              audio_data,
                          const struct pixel_format_desc&        desc);
     const_frame(const const_frame& other);
@@ -69,7 +68,7 @@ class const_frame final
 
     const struct pixel_format_desc& pixel_format_desc() const;
 
-    const array<const std::uint8_t>& image_data(std::size_t index) const;
+    const std::any& image_ptr() const;
 
     const array<const std::int32_t>& audio_data() const;
 
@@ -78,8 +77,6 @@ class const_frame final
     std::size_t height() const;
 
     std::size_t size() const;
-
-    const std::any& opaque() const;
 
     const class frame_geometry& geometry() const;
 
@@ -93,6 +90,26 @@ class const_frame final
   private:
     struct impl;
     std::shared_ptr<impl> impl_;
+};
+
+struct converted_frame
+{
+    const_frame                                   frame;
+    std::shared_future<array<const std::uint8_t>> pixels;
+
+    static converted_frame empty() {
+        return converted_frame({}, {});
+    }
+
+    converted_frame(const core::const_frame& frame, std::shared_future<array<const std::uint8_t>> pixels)
+        : frame(frame)
+        , pixels(std::move(pixels))
+    {
+    }
+
+    bool is_empty() {
+        return frame == core::const_frame{} || !pixels.valid();
+    }
 };
 
 }} // namespace caspar::core

--- a/src/core/frame/frame_converter.h
+++ b/src/core/frame/frame_converter.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Julian Waller, julian@superfly.tv
+ */
+
+#pragma once
+
+#include "core/video_format.h"
+
+#include <common/bit_depth.h>
+
+#include <core/frame/frame.h>
+
+#include <future>
+
+namespace caspar::core {
+
+struct frame_conversion_format
+{
+    enum pixel_format
+    {
+        rgba8 = 0,
+        // rgba16        = 0,
+        // bgra16        = 1,
+        // decklink_v210 = 2,
+    };
+
+    struct subregion_geometry
+    {
+        int src_x  = 0;
+        int src_y  = 0;
+        int dest_x = 0;
+        int dest_y = 0;
+        int w      = 0;
+        int h      = 0;
+    };
+
+    explicit frame_conversion_format(pixel_format format, int width, int height)
+    : format(format)
+    , width(width)
+    , height(height)
+    {
+    }
+
+    explicit frame_conversion_format(pixel_format format)
+   : frame_conversion_format(format, 0, 0)
+    {
+    }
+
+    pixel_format format;
+    int width;
+    int height;
+
+    bool key_only = false;
+    bool straight_alpha = false;
+
+    subregion_geometry region;
+};
+
+
+class frame_converter
+{
+  public:
+    frame_converter()                                  = default;
+    frame_converter& operator=(const frame_converter&) = delete;
+    virtual ~frame_converter()                         = default;
+
+    frame_converter(const frame_converter&) = delete;
+
+    // virtual class mutable_frame create_frame(const void* video_stream_tag, const struct pixel_format_desc& desc) = 0;
+
+    // virtual class draw_frame convert_to_rgba(const class mutable_frame& frame) = 0;
+
+    virtual std::shared_future<array<const std::uint8_t>>
+    convert_to_buffer(const core::const_frame& frame, const frame_conversion_format& format) = 0;
+
+    converted_frame
+    convert_to_buffer_and_frame(const core::const_frame& frame, const frame_conversion_format& format)
+    {
+        auto pixels = this->convert_to_buffer(frame, format);
+        return converted_frame(frame, pixels);
+    }
+
+    virtual common::bit_depth get_frame_bitdepth(const core::const_frame& frame) = 0;
+};
+
+} // namespace caspar::core

--- a/src/core/frame/pixel_format.h
+++ b/src/core/frame/pixel_format.h
@@ -65,10 +65,10 @@ struct pixel_format_desc final
         plane() = default;
 
         plane(int width, int height, int stride, common::bit_depth depth = common::bit_depth::bit8)
-            : linesize(width * stride * (depth == common::bit_depth::bit8 ? 1 : 2))
+            : linesize(width * stride * common::bytes_per_pixel(depth))
             , width(width)
             , height(height)
-            , size(width * height * stride * (depth == common::bit_depth::bit8 ? 1 : 2))
+            , size(width * height * stride * common::bytes_per_pixel(depth))
             , stride(stride)
             , depth(depth)
         {

--- a/src/core/fwd.h
+++ b/src/core/fwd.h
@@ -34,11 +34,13 @@ class output;
 class image_mixer;
 struct video_format_desc;
 class frame_factory;
+class frame_converter;
 class frame_producer;
 class frame_consumer;
 class draw_frame;
 class mutable_frame;
 class const_frame;
+struct converted_frame;
 class video_channel;
 struct pixel_format_desc;
 struct frame_transform;
@@ -48,4 +50,4 @@ class cg_producer_registry;
 class frame_producer_registry;
 class frame_consumer_registry;
 class video_format_repository;
-}
+} // namespace caspar::core

--- a/src/core/mixer/image/image_mixer.h
+++ b/src/core/mixer/image/image_mixer.h
@@ -46,12 +46,14 @@ class image_mixer
     void visit(const class const_frame& frame) override     = 0;
     void pop() override                                     = 0;
 
-    virtual std::future<array<const uint8_t>> render(const struct video_format_desc& format_desc) = 0;
+    virtual std::future<std::any> render(const struct video_format_desc& format_desc) = 0;
 
     class mutable_frame create_frame(const void* tag, const struct pixel_format_desc& desc) override = 0;
     class mutable_frame create_frame(const void*                     video_stream_tag,
                                      const struct pixel_format_desc& desc,
                                      common::bit_depth               depth) override                               = 0;
+
+    spl::shared_ptr<frame_converter> create_frame_converter() override = 0;
 
     virtual common::bit_depth depth() const       = 0;
     virtual core::color_space color_space() const = 0;

--- a/src/core/mixer/mixer.cpp
+++ b/src/core/mixer/mixer.cpp
@@ -87,9 +87,10 @@ struct mixer::impl
                                     auto desc = pixel_format_desc(pixel_format::bgra, color_space);
                                     desc.planes.push_back(
                                         pixel_format_desc::plane(format_desc.width, format_desc.height, 4, depth));
-                                    std::vector<array<const uint8_t>> image_data;
-                                    image_data.emplace_back(std::move(image.get()));
-                                    return const_frame(std::move(image_data), std::move(audio), desc);
+
+                                    auto image_ptr = image.get();
+
+                                    return const_frame(std::move(image_ptr), std::move(audio), desc);
                                 }));
 
         if (buffer_.size() <= format_desc.field_count) {

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -29,6 +29,7 @@
 #include "consumer/output.h"
 #include "frame/draw_frame.h"
 #include "frame/frame.h"
+#include "frame/frame_converter.h"
 #include "frame/frame_factory.h"
 #include "mixer/mixer.h"
 #include "producer/stage.h"
@@ -61,10 +62,11 @@ struct video_channel::impl final
         return spl::make_shared<caspar::diagnostics::graph>();
     }(index_);
 
-    caspar::core::output         output_;
-    spl::shared_ptr<image_mixer> image_mixer_;
-    caspar::core::mixer          mixer_;
-    std::shared_ptr<core::stage> stage_;
+    caspar::core::output                   output_;
+    spl::shared_ptr<image_mixer>           image_mixer_;
+    spl::shared_ptr<core::frame_converter> frame_converter_;
+    caspar::core::mixer                    mixer_;
+    std::shared_ptr<core::stage>           stage_;
 
     uint64_t frame_counter_ = 0;
 
@@ -105,6 +107,7 @@ struct video_channel::impl final
         : index_(index)
         , output_(graph_, format_desc, index)
         , image_mixer_(std::move(image_mixer))
+        , frame_converter_(image_mixer_->create_frame_converter())
         , mixer_(index, graph_, image_mixer_)
         , stage_(std::make_shared<core::stage>(index, graph_, format_desc))
         , tick_(std::move(tick))
@@ -250,6 +253,7 @@ mixer&                              video_channel::mixer() { return impl_->mixer
 const output&                       video_channel::output() const { return impl_->output_; }
 output&                             video_channel::output() { return impl_->output_; }
 spl::shared_ptr<frame_factory>      video_channel::frame_factory() { return impl_->image_mixer_; }
+spl::shared_ptr<frame_converter>    video_channel::frame_converter() { return impl_->frame_converter_; }
 int                                 video_channel::index() const { return impl_->index(); }
 core::monitor::state                video_channel::state() const { return impl_->state_; }
 

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -84,7 +84,8 @@ class video_channel final
     const core::output&                 output() const;
     core::output&                       output();
 
-    spl::shared_ptr<core::frame_factory> frame_factory();
+    spl::shared_ptr<core::frame_factory>   frame_factory();
+    spl::shared_ptr<core::frame_converter> frame_converter();
 
     int index() const;
 

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -319,7 +319,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     configuration config;

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -24,6 +24,8 @@
 #undef NOMINMAX
 // ^^ This is needed to avoid a conflict between boost asio and other header files defining NOMINMAX
 
+#include "core/frame/frame_converter.h"
+
 #include <common/future.h>
 #include <common/log.h>
 #include <common/ptree.h>
@@ -54,14 +56,17 @@ struct configuration
 
 struct artnet_consumer : public core::frame_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     const configuration           config;
     std::vector<computed_fixture> computed_fixtures;
 
   public:
     // frame_consumer
 
-    explicit artnet_consumer(configuration config)
-        : config(std::move(config))
+    explicit artnet_consumer(const spl::shared_ptr<core::frame_converter>& frame_converter, configuration config)
+        : frame_converter_(frame_converter)
+        , config(std::move(config))
         , io_service_()
         , socket(io_service_)
     {
@@ -76,9 +81,12 @@ struct artnet_consumer : public core::frame_consumer
 
     void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override
     {
-        thread_ = std::thread([this] {
+        thread_ = std::thread([this]() {
             long long time      = 1000 / config.refreshRate;
             auto      last_send = std::chrono::system_clock::now();
+
+            array<const uint8_t> last_fetched_pixels;
+            core::const_frame last_fetched_frame;
 
             while (!abort_request_) {
                 try {
@@ -100,11 +108,18 @@ struct artnet_consumer : public core::frame_consumer
                     if (!frame)
                         continue; // No frame available
 
+                    if (last_fetched_frame != frame) {
+                        last_fetched_frame = frame;
+                        // Future: this is not the most performant, but is simple to immediately wait
+                        last_fetched_pixels = frame_converter_->convert_to_buffer(frame, core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8)).get();
+                    }
+
+
                     uint8_t dmx_data[512];
                     memset(dmx_data, 0, 512);
 
                     for (auto computed_fixture : computed_fixtures) {
-                        auto     color = average_color(frame, computed_fixture.rectangle);
+                        auto     color = average_color(frame.pixel_format_desc().planes[0], last_fetched_pixels, computed_fixture.rectangle);
                         uint8_t* ptr   = dmx_data + computed_fixture.address;
 
                         switch (computed_fixture.type) {
@@ -303,6 +318,7 @@ std::vector<fixture> get_fixtures_ptree(const boost::property_tree::wptree& ptre
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
@@ -321,6 +337,6 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
 
     config.fixtures = get_fixtures_ptree(ptree);
 
-    return spl::make_shared<artnet_consumer>(config);
+    return spl::make_shared<artnet_consumer>(frame_converter, config);
 }
 }} // namespace caspar::artnet

--- a/src/modules/artnet/consumer/artnet_consumer.h
+++ b/src/modules/artnet/consumer/artnet_consumer.h
@@ -36,6 +36,7 @@ namespace caspar { namespace artnet {
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 }} // namespace caspar::artnet

--- a/src/modules/artnet/consumer/artnet_consumer.h
+++ b/src/modules/artnet/consumer/artnet_consumer.h
@@ -37,6 +37,5 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 }} // namespace caspar::artnet

--- a/src/modules/artnet/util/fixture_calculation.cpp
+++ b/src/modules/artnet/util/fixture_calculation.cpp
@@ -21,6 +21,8 @@
 
 #include "fixture_calculation.h"
 
+#include "core/frame/pixel_format.h"
+
 #define M_PI 3.14159265358979323846 /* pi */
 
 namespace caspar { namespace artnet {
@@ -84,10 +86,10 @@ rect compute_rect(box fixtureBox, int index, int count)
     return rectangle;
 }
 
-color average_color(const core::const_frame& frame, rect& rectangle)
+color average_color(const core::pixel_format_desc::plane& pix_desc, const array<const uint8_t>& pixels, rect& rectangle)
 {
-    int width  = (int)frame.width();
-    int height = (int)frame.height();
+    int width  = pix_desc.width;
+    int height = pix_desc.height;
 
     float x_values[] = {rectangle.p1.x, rectangle.p2.x, rectangle.p3.x, rectangle.p4.x};
     float y_values[] = {rectangle.p1.y, rectangle.p2.y, rectangle.p3.y, rectangle.p4.y};
@@ -135,8 +137,7 @@ color average_color(const core::const_frame& frame, rect& rectangle)
     int y_min = std::max(0, std::min(height - 1, (int)y_values[0]));
     int y_max = std::max(0, std::min(height - 1, (int)y_values[3]));
 
-    const array<const std::uint8_t>& values    = frame.image_data(0);
-    const std::uint8_t*              value_ptr = values.data();
+    const std::uint8_t*              value_ptr = pixels.data();
 
     // Total color values, as well as the number of pixels in the rectangle
     // used to calculate the average without loss of precision

--- a/src/modules/artnet/util/fixture_calculation.h
+++ b/src/modules/artnet/util/fixture_calculation.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "core/frame/pixel_format.h"
+
 #include <core/frame/frame.h>
 
 #include <cmath>
@@ -86,6 +88,6 @@ struct fixture
 };
 
 rect  compute_rect(box fixtureBox, int index, int count);
-color average_color(const core::const_frame& frame, rect& rectangle);
+color average_color(const core::pixel_format_desc::plane& pix_desc, const array<const uint8_t>& pixels, rect& rectangle);
 
 }} // namespace caspar::artnet

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -881,8 +881,9 @@ struct bluefish_consumer_proxy : public core::frame_consumer
     }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -942,6 +943,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -884,7 +884,6 @@ struct bluefish_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"BLUEFISH")) {
@@ -944,7 +943,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     configuration config;

--- a/src/modules/bluefish/consumer/bluefish_consumer.h
+++ b/src/modules/bluefish/consumer/bluefish_consumer.h
@@ -32,14 +32,16 @@
 
 namespace caspar { namespace bluefish {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 

--- a/src/modules/bluefish/consumer/bluefish_consumer.h
+++ b/src/modules/bluefish/consumer/bluefish_consumer.h
@@ -35,14 +35,12 @@ namespace caspar { namespace bluefish {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 
 }} // namespace caspar::bluefish

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -1127,7 +1127,6 @@ struct decklink_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"DECKLINK")) {
@@ -1150,7 +1149,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     configuration config = parse_xml_config(ptree, format_repository);

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -32,6 +32,7 @@
 
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
+#include <core/frame/frame_converter.h>
 #include <core/frame/pixel_format.h>
 #include <core/video_format.h>
 
@@ -45,7 +46,6 @@
 #include <boost/circular_buffer.hpp>
 
 #include <atomic>
-#include <common/prec_timer.h>
 #include <condition_variable>
 #include <future>
 #include <memory>
@@ -424,7 +424,7 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
     com_iface_ptr<IDeckLinkProfileAttributes> attributes_    = iface_cast<IDeckLinkProfileAttributes>(decklink_);
     com_iface_ptr<IDeckLinkConfiguration>     configuration_ = iface_cast<IDeckLinkConfiguration>(decklink_);
     int                                       device_sync_group_;
-    std::optional<core::const_frame>          first_field_;
+    std::optional<array<const std::uint8_t>>  first_field_;
 
     const std::wstring model_name_ = get_model_name(decklink_);
 
@@ -517,7 +517,7 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
         }
     }
 
-    void schedule_frame(core::const_frame frame, BMDTimeValue display_time)
+    void schedule_frame(const array<const std::uint8_t>& frame, BMDTimeValue display_time)
     {
         bool isInterlaced = decklink_format_desc_.field_count != 1;
         if (isInterlaced && !first_field_.has_value()) {
@@ -527,8 +527,8 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
         }
 
         // Figure out which frame is which
-        core::const_frame frame1;
-        core::const_frame frame2;
+        array<const std::uint8_t> frame1 = frame;
+        array<const std::uint8_t> frame2 = frame;
         if (isInterlaced) {
             frame1       = *first_field_;
             first_field_ = {};
@@ -583,6 +583,8 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
 
 struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     const int           channel_index_;
     const configuration config_;
 
@@ -599,10 +601,10 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
     const core::video_format_desc channel_format_desc_;
     const core::video_format_desc decklink_format_desc_;
 
-    std::mutex                    buffer_mutex_;
-    std::condition_variable       buffer_cond_;
-    std::queue<core::const_frame> buffer_;
-    int                           buffer_capacity_ = channel_format_desc_.field_count;
+    std::mutex                        buffer_mutex_;
+    std::condition_variable           buffer_cond_;
+    std::queue<core::converted_frame> buffer_;
+    int                               buffer_capacity_ = channel_format_desc_.field_count;
 
     const int buffer_size_ = config_.buffer_depth(); // Minimum buffer-size 3.
 
@@ -627,8 +629,12 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
     std::atomic<bool> abort_request_{false};
 
   public:
-    decklink_consumer(const configuration& config, core::video_format_desc channel_format_desc, int channel_index)
-        : channel_index_(channel_index)
+    decklink_consumer(const spl::shared_ptr<core::frame_converter>& frame_converter,
+                      const configuration&                          config,
+                      core::video_format_desc                       channel_format_desc,
+                      int                                           channel_index)
+        : frame_converter_(frame_converter)
+        , channel_index_(channel_index)
         , config_(config)
         , channel_format_desc_(std::move(channel_format_desc))
         , decklink_format_desc_(get_decklink_format(config.primary, channel_format_desc_))
@@ -895,8 +901,8 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                 }
             }
 
-            core::const_frame frame1 = pop();
-            core::const_frame frame2;
+            std::optional<core::converted_frame> frame1 = pop();
+            std::optional<core::converted_frame> frame2;
 
             bool isInterlaced = mode_->GetFieldDominance() != bmdProgressiveFrame;
             if (mode_->GetFieldDominance() != bmdProgressiveFrame) {
@@ -907,14 +913,22 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
             if (abort_request_)
                 return E_FAIL;
 
+            // Skip if frames are missing
+            if (!frame1.has_value() || (isInterlaced && !frame2.has_value()))
+                return S_OK;
+
             BMDTimeValue video_display_time = video_scheduled_;
             video_scheduled_ += decklink_format_desc_.duration;
 
             std::vector<std::int32_t> audio_data;
             if (config_.embedded_audio) {
-                audio_data.insert(audio_data.end(), frame1.audio_data().begin(), frame1.audio_data().end());
+                audio_data.insert(audio_data.end(),
+                                  frame1.value().frame.audio_data().begin(),
+                                  frame1.value().frame.audio_data().end());
                 if (isInterlaced) {
-                    audio_data.insert(audio_data.end(), frame2.audio_data().begin(), frame2.audio_data().end());
+                    audio_data.insert(audio_data.end(),
+                                      frame2.value().frame.audio_data().begin(),
+                                      frame2.value().frame.audio_data().end());
                 }
             }
             // TODO: is this reliable?
@@ -922,18 +936,23 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
             // Schedule video
             tbb::parallel_for(-1, static_cast<int>(secondary_port_contexts_.size()), [&](int i) {
+                auto buffer1 = frame1.value().pixels.get();
+                auto buffer2 = frame2.has_value() ? frame2.value().pixels.get() : buffer1;
+
                 if (i == -1) {
                     // Primary port
                     std::shared_ptr<void> image_data = convert_frame_for_port(channel_format_desc_,
                                                                               decklink_format_desc_,
                                                                               config_.primary,
-                                                                              frame1,
-                                                                              frame2,
+                                                                              buffer1,
+                                                                              buffer2,
                                                                               mode_->GetFieldDominance(),
                                                                               config_.hdr);
 
-                    schedule_next_video(
-                        image_data, nb_samples, video_display_time, frame1.pixel_format_desc().color_space);
+                    schedule_next_video(image_data,
+                                        nb_samples,
+                                        video_display_time,
+                                        frame1.value().frame.pixel_format_desc().color_space);
 
                     if (config_.embedded_audio) {
                         schedule_next_audio(std::move(audio_data), nb_samples);
@@ -941,9 +960,9 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                 } else {
                     // Send frame to secondary ports
                     auto& context = secondary_port_contexts_[i];
-                    context->schedule_frame(frame1, video_display_time);
+                    context->schedule_frame(buffer1, video_display_time);
                     if (isInterlaced) {
-                        context->schedule_frame(frame2, video_display_time);
+                        context->schedule_frame(buffer2, video_display_time);
                     }
 
                     if (config_.embedded_audio) {
@@ -961,9 +980,9 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         return S_OK;
     }
 
-    core::const_frame pop()
+    std::optional<core::converted_frame> pop()
     {
-        core::const_frame frame;
+        std::optional<core::converted_frame> frame;
         {
             std::unique_lock<std::mutex> lock(buffer_mutex_);
             buffer_cond_.wait(lock, [&] { return !buffer_.empty() || abort_request_; });
@@ -1016,12 +1035,18 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         }
 
         if (frame) {
+            auto wrapped_frame = frame_converter_->convert_to_buffer_and_frame(
+                frame,
+                core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8,
+                                              decklink_format_desc_.width,
+                                              decklink_format_desc_.height));
+
             std::unique_lock<std::mutex> lock(buffer_mutex_);
             if (field != core::video_field::b) {
                 // Always push a field2, as we have supplied field1
                 buffer_cond_.wait(lock, [&] { return buffer_.size() < buffer_capacity_ || abort_request_; });
             }
-            buffer_.push(std::move(frame));
+            buffer_.push(std::move(wrapped_frame));
         }
         buffer_cond_.notify_all();
 
@@ -1045,14 +1070,18 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
 struct decklink_consumer_proxy : public core::frame_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     const configuration                config_;
     std::unique_ptr<decklink_consumer> consumer_;
     core::video_format_desc            format_desc_;
     executor                           executor_;
 
   public:
-    explicit decklink_consumer_proxy(const configuration& config)
-        : config_(config)
+    explicit decklink_consumer_proxy(const spl::shared_ptr<core::frame_converter>& frame_converter,
+                                     const configuration&                          config)
+        : frame_converter_(frame_converter)
+        , config_(config)
         , executor_(L"decklink_consumer[" + std::to_wstring(config.primary.device_index) + L"]")
     {
         executor_.begin_invoke([=] { com_initialize(); });
@@ -1072,7 +1101,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
         format_desc_ = format_desc;
         executor_.invoke([=] {
             consumer_.reset();
-            consumer_ = std::make_unique<decklink_consumer>(config_, format_desc, channel_index);
+            consumer_ = std::make_unique<decklink_consumer>(frame_converter_, config_, format_desc, channel_index);
         });
     }
 
@@ -1095,8 +1124,9 @@ struct decklink_consumer_proxy : public core::frame_consumer
     [[nodiscard]] core::monitor::state state() const override { return get_state_for_config(config_, format_desc_); }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -1113,12 +1143,13 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
                                << msg_info("Decklink consumer does not support hdr in combination with key only"));
     }
 
-    return spl::make_shared<decklink_consumer_proxy>(config);
+    return spl::make_shared<decklink_consumer_proxy>(frame_converter, config);
 }
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
@@ -1139,7 +1170,7 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
                                << msg_info("Decklink consumer does not support hdr in combination with key only"));
     }
 
-    return spl::make_shared<decklink_consumer_proxy>(config);
+    return spl::make_shared<decklink_consumer_proxy>(frame_converter, config);
 }
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/decklink_consumer.h
+++ b/src/modules/decklink/consumer/decklink_consumer.h
@@ -33,13 +33,15 @@
 
 namespace caspar { namespace decklink {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 

--- a/src/modules/decklink/consumer/decklink_consumer.h
+++ b/src/modules/decklink/consumer/decklink_consumer.h
@@ -36,13 +36,11 @@ namespace caspar { namespace decklink {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/frame.h
+++ b/src/modules/decklink/consumer/frame.h
@@ -39,12 +39,12 @@ int            get_row_bytes(const core::video_format_desc& format_desc, bool hd
 
 std::shared_ptr<void> allocate_frame_data(const core::video_format_desc& format_desc, bool hdr);
 
-std::shared_ptr<void> convert_frame_for_port(const core::video_format_desc& channel_format_desc,
-                                             const core::video_format_desc& decklink_format_desc,
-                                             const port_configuration&      config,
-                                             const core::const_frame&       frame1,
-                                             const core::const_frame&       frame2,
-                                             BMDFieldDominance              field_dominance,
-                                             bool                           hdr);
+std::shared_ptr<void> convert_frame_for_port(const core::video_format_desc&   channel_format_desc,
+                                             const core::video_format_desc&   decklink_format_desc,
+                                             const port_configuration&        config,
+                                             const array<const std::uint8_t>& frame1,
+                                             const array<const std::uint8_t>& frame2,
+                                             BMDFieldDominance                field_dominance,
+                                             bool                             hdr);
 
 }} // namespace caspar::decklink

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -754,7 +754,6 @@ struct ffmpeg_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.size() < 2 || (!boost::iequals(params.at(0), L"STREAM") && !boost::iequals(params.at(0), L"FILE")))
@@ -773,7 +772,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     return spl::make_shared<ffmpeg_consumer>(frame_converter, u8(ptree.get<std::wstring>(L"path", L"")),

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -85,6 +85,8 @@ namespace caspar { namespace ffmpeg {
 
 struct Stream
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     std::shared_ptr<AVFilterGraph> graph  = nullptr;
     AVFilterContext*               sink   = nullptr;
     AVFilterContext*               source = nullptr;
@@ -96,13 +98,15 @@ struct Stream
 
     int64_t pts = 0;
 
-    Stream(AVFormatContext*                    oc,
+    Stream(const spl::shared_ptr<core::frame_converter>& frame_converter,
+           AVFormatContext*                    oc,
            std::string                         suffix,
            AVCodecID                           codec_id,
            const core::video_format_desc&      format_desc,
            bool                                realtime,
            common::bit_depth                   depth,
            std::map<std::string, std::string>& options)
+    : frame_converter_(frame_converter)
     {
         std::map<std::string, std::string> stream_options;
 
@@ -376,16 +380,17 @@ struct Stream
         return std::shared_ptr<SwsContext>(sws.get(), [this, sws](SwsContext*) { sws_.push(sws); });
     }
 
-    void send(core::const_frame&                             in_frame,
+    void send(std::optional<core::converted_frame>&          in_frame,
               const core::video_format_desc&                 format_desc,
               std::function<void(std::shared_ptr<AVPacket>)> cb)
     {
         std::shared_ptr<AVFrame>  frame;
         std::shared_ptr<AVPacket> pkt;
 
-        if (in_frame) {
+        if (in_frame.has_value()) {
             if (enc->codec_type == AVMEDIA_TYPE_VIDEO) {
-                frame = make_av_video_frame(in_frame, format_desc);
+                frame = make_av_video_frame(in_frame.value(), format_desc);
+                if (!frame) FF_RET(AVERROR(EFAULT), "make_av_video_frame");
 
                 {
                     auto frame2                 = alloc_frame();
@@ -426,7 +431,7 @@ struct Stream
                 frame->pts = pts;
                 pts += 1;
             } else if (enc->codec_type == AVMEDIA_TYPE_AUDIO) {
-                frame      = make_av_audio_frame(in_frame, format_desc);
+                frame      = make_av_audio_frame(in_frame.value().frame, format_desc);
                 frame->pts = pts;
                 pts += frame->nb_samples;
             } else {
@@ -467,6 +472,8 @@ struct Stream
 
 struct ffmpeg_consumer : public core::frame_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     core::monitor::state    state_;
     mutable std::mutex      state_mutex_;
     int                     channel_index_ = -1;
@@ -487,8 +494,10 @@ struct ffmpeg_consumer : public core::frame_consumer
     common::bit_depth depth_;
 
   public:
-    ffmpeg_consumer(std::string path, std::string args, bool realtime, common::bit_depth depth)
-        : channel_index_([&] {
+    ffmpeg_consumer(
+    const spl::shared_ptr<core::frame_converter> frame_converter, std::string path, std::string args, bool realtime, common::bit_depth depth)
+        : frame_converter_(frame_converter)
+        , channel_index_([&] {
             boost::crc_16_type result;
             result.process_bytes(path.data(), path.length());
             return result.checksum();
@@ -581,7 +590,7 @@ struct ffmpeg_consumer : public core::frame_consumer
                     if (oc->oformat->video_codec == AV_CODEC_ID_H264 && options.find("preset:v") == options.end()) {
                         options["preset:v"] = "veryfast";
                     }
-                    video_stream.emplace(oc, ":v", oc->oformat->video_codec, format_desc, realtime_, depth_, options);
+                    video_stream.emplace(frame_converter_, oc, ":v", oc->oformat->video_codec, format_desc, realtime_, depth_, options);
 
                     {
                         std::lock_guard<std::mutex> lock(state_mutex_);
@@ -591,7 +600,7 @@ struct ffmpeg_consumer : public core::frame_consumer
 
                 std::optional<Stream> audio_stream;
                 if (oc->oformat->audio_codec != AV_CODEC_ID_NONE) {
-                    audio_stream.emplace(oc, ":a", oc->oformat->audio_codec, format_desc, realtime_, depth_, options);
+                    audio_stream.emplace(frame_converter_,oc, ":a", oc->oformat->audio_codec, format_desc, realtime_, depth_, options);
                 }
 
                 if (!(oc->oformat->flags & AVFMT_NOFILE)) {
@@ -675,16 +684,21 @@ struct ffmpeg_consumer : public core::frame_consumer
                     graph_->set_value("input",
                                       static_cast<double>(frame_buffer_.size() + 0.001) / frame_buffer_.capacity());
 
+                    std::optional<core::converted_frame> wrapped_frame;
+                    if (frame)
+                        // TODO - better pixel format
+                        wrapped_frame = frame_converter_->convert_to_buffer_and_frame(frame, core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8));
+
                     caspar::timer frame_timer;
                     tbb::parallel_invoke(
                         [&] {
                             if (video_stream) {
-                                video_stream->send(frame, format_desc, packet_cb);
+                                video_stream->send(wrapped_frame, format_desc, packet_cb);
                             }
                         },
                         [&] {
                             if (audio_stream) {
-                                audio_stream->send(frame, format_desc, packet_cb);
+                                audio_stream->send(wrapped_frame, format_desc, packet_cb);
                             }
                         });
                     graph_->set_value("frame-time", frame_timer.elapsed() * format_desc.fps * 0.5);
@@ -737,8 +751,9 @@ struct ffmpeg_consumer : public core::frame_consumer
     }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -750,17 +765,18 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     for (auto n = 2; n < params.size(); ++n) {
         args.emplace_back(u8(params[n]));
     }
-    return spl::make_shared<ffmpeg_consumer>(
+    return spl::make_shared<ffmpeg_consumer>(frame_converter,
         path, boost::join(args, " "), boost::iequals(params.at(0), L"STREAM"), depth);
 }
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
-    return spl::make_shared<ffmpeg_consumer>(u8(ptree.get<std::wstring>(L"path", L"")),
+    return spl::make_shared<ffmpeg_consumer>(frame_converter, u8(ptree.get<std::wstring>(L"path", L"")),
                                              u8(ptree.get<std::wstring>(L"args", L"")),
                                              ptree.get(L"realtime", false),
                                              depth);

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
@@ -33,13 +33,15 @@
 
 namespace caspar { namespace ffmpeg {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
@@ -36,13 +36,11 @@ namespace caspar { namespace ffmpeg {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 
 }} // namespace caspar::ffmpeg

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -237,11 +237,12 @@ core::pixel_format_desc pixel_format_desc(AVPixelFormat     pix_fmt,
     }
 }
 
-std::shared_ptr<AVFrame> make_av_video_frame(const core::const_frame& frame, const core::video_format_desc& format_desc)
+std::shared_ptr<AVFrame> make_av_video_frame(const core::converted_frame& frame, const core::video_format_desc& format_desc)
 {
     auto av_frame = alloc_frame();
 
-    auto pix_desc = frame.pixel_format_desc();
+    auto pix_desc = frame.frame.pixel_format_desc();
+    auto pixels = frame.pixels.get();
 
     auto planes = pix_desc.planes;
     auto format = pix_desc.format;
@@ -254,69 +255,78 @@ std::shared_ptr<AVFrame> make_av_video_frame(const core::const_frame& frame, con
     av_frame->height              = format_desc.height;
 
     const auto is_16bit = planes[0].depth != common::bit_depth::bit8;
-    switch (format) {
-        case core::pixel_format::rgb:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_RGB48 : AVPixelFormat::AV_PIX_FMT_RGB24;
-            break;
-        case core::pixel_format::bgr:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGR48 : AVPixelFormat::AV_PIX_FMT_BGR24;
-            break;
-        case core::pixel_format::rgba:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_RGBA64 : AVPixelFormat::AV_PIX_FMT_RGBA;
-            break;
-        case core::pixel_format::argb:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_ARGB;
-            break;
-        case core::pixel_format::bgra:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_BGRA;
-            break;
-        case core::pixel_format::abgr:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_ABGR;
-            break;
-        case core::pixel_format::gray:
-        case core::pixel_format::luma:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_GRAY16 : AVPixelFormat::AV_PIX_FMT_GRAY8;
-            break;
-        case core::pixel_format::ycbcr: {
-            int y_w = planes[0].width;
-            int y_h = planes[0].height;
-            int c_w = planes[1].width;
-            int c_h = planes[1].height;
-
-            if (c_h == y_h && c_w == y_w)
-                av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV444P10 : AVPixelFormat::AV_PIX_FMT_YUV444P;
-            else if (c_h == y_h && c_w * 2 == y_w)
-                av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV422P10 : AVPixelFormat::AV_PIX_FMT_YUV422P;
-            else if (c_h == y_h && c_w * 4 == y_w)
-                av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV422P10 : AVPixelFormat::AV_PIX_FMT_YUV411P;
-            else if (c_h * 2 == y_h && c_w * 2 == y_w)
-                av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV420P10 : AVPixelFormat::AV_PIX_FMT_YUV420P;
-            else if (c_h * 2 == y_h && c_w * 4 == y_w)
-                av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV420P10 : AVPixelFormat::AV_PIX_FMT_YUV410P;
-
-            break;
-        }
-        case core::pixel_format::ycbcra:
-            av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUVA420P10 : AVPixelFormat::AV_PIX_FMT_YUVA420P;
-            break;
-        case core::pixel_format::uyvy:
-            // TODO
-            break;
-        case core::pixel_format::count:
-        case core::pixel_format::invalid:
-            break;
+    // We only need to support the formats that the mixer can produce
+    if (format == core::pixel_format::rgba) {
+        av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_RGBA64 : AVPixelFormat::AV_PIX_FMT_RGBA;
+    } else if (format == core::pixel_format::bgra) {
+        av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_BGRA;
+    } else{
+        // TODO - is this safe?
+        return nullptr;
     }
+
+    // switch (format) {
+    //     case core::pixel_format::rgb:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_RGB48 : AVPixelFormat::AV_PIX_FMT_RGB24;
+    //         break;
+    //     case core::pixel_format::bgr:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGR48 : AVPixelFormat::AV_PIX_FMT_BGR24;
+    //         break;
+    //     case core::pixel_format::rgba:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_RGBA64 : AVPixelFormat::AV_PIX_FMT_RGBA;
+    //         break;
+    //     case core::pixel_format::argb:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_ARGB;
+    //         break;
+    //     case core::pixel_format::bgra:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_BGRA;
+    //         break;
+    //     case core::pixel_format::abgr:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_BGRA64 : AVPixelFormat::AV_PIX_FMT_ABGR;
+    //         break;
+    //     case core::pixel_format::gray:
+    //     case core::pixel_format::luma:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_GRAY16 : AVPixelFormat::AV_PIX_FMT_GRAY8;
+    //         break;
+    //     case core::pixel_format::ycbcr: {
+    //         int y_w = planes[0].width;
+    //         int y_h = planes[0].height;
+    //         int c_w = planes[1].width;
+    //         int c_h = planes[1].height;
+    //
+    //         if (c_h == y_h && c_w == y_w)
+    //             av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV444P10 : AVPixelFormat::AV_PIX_FMT_YUV444P;
+    //         else if (c_h == y_h && c_w * 2 == y_w)
+    //             av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV422P10 : AVPixelFormat::AV_PIX_FMT_YUV422P;
+    //         else if (c_h == y_h && c_w * 4 == y_w)
+    //             av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV422P10 : AVPixelFormat::AV_PIX_FMT_YUV411P;
+    //         else if (c_h * 2 == y_h && c_w * 2 == y_w)
+    //             av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV420P10 : AVPixelFormat::AV_PIX_FMT_YUV420P;
+    //         else if (c_h * 2 == y_h && c_w * 4 == y_w)
+    //             av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUV420P10 : AVPixelFormat::AV_PIX_FMT_YUV410P;
+    //
+    //         break;
+    //     }
+    //     case core::pixel_format::ycbcra:
+    //         av_frame->format = is_16bit ? AVPixelFormat::AV_PIX_FMT_YUVA420P10 : AVPixelFormat::AV_PIX_FMT_YUVA420P;
+    //         break;
+    //     case core::pixel_format::uyvy:
+    //         // TODO
+    //         break;
+    //     case core::pixel_format::count:
+    //     case core::pixel_format::invalid:
+    //         break;
+    // }
 
     FF(av_frame_get_buffer(av_frame.get(), is_16bit ? 64 : 32));
 
     // TODO (perf) Avoid extra memcpy.
-    for (int n = 0; n < planes.size(); ++n) {
-        for (int y = 0; y < av_frame->height; ++y) {
-            std::memcpy(av_frame->data[n] + y * av_frame->linesize[n],
-                        frame.image_data(n).data() + y * planes[n].linesize,
-                        planes[n].linesize);
-        }
+    for (int y = 0; y < av_frame->height; ++y) {
+        std::memcpy(av_frame->data[0] + y * av_frame->linesize[0],
+                    pixels.data() + y * planes[0].linesize,
+                    planes[0].linesize);
     }
+
 
     return av_frame;
 }

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -169,7 +169,7 @@ core::pixel_format_desc pixel_format_desc(AVPixelFormat     pix_fmt,
     const auto fmt   = get_pixel_format(pix_fmt);
     auto       desc  = core::pixel_format_desc(std::get<0>(fmt), color_space);
     auto       depth = std::get<1>(fmt);
-    auto       bpc   = depth == common::bit_depth::bit8 ? 1 : 2;
+    auto       bpc   = common::bytes_per_pixel(depth);
 
     for (int i = 0; i < 4; i++)
         linesizes[i] /= bpc;

--- a/src/modules/ffmpeg/util/av_util.h
+++ b/src/modules/ffmpeg/util/av_util.h
@@ -35,7 +35,7 @@ core::mutable_frame     make_frame(void*                    tag,
                                    core::color_space        color_space = core::color_space::bt709,
                                    core::frame_geometry::scale_mode     = core::frame_geometry::scale_mode::stretch);
 
-std::shared_ptr<AVFrame> make_av_video_frame(const core::const_frame& frame, const core::video_format_desc& format_des);
+std::shared_ptr<AVFrame> make_av_video_frame(const core::converted_frame& frame, const core::video_format_desc& format_des);
 std::shared_ptr<AVFrame> make_av_audio_frame(const core::const_frame& frame, const core::video_format_desc& format_des);
 
 AVDictionary*                      to_dict(std::map<std::string, std::string>&& map);

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -36,6 +36,7 @@
 #include <common/utf.h>
 
 #include <core/consumer/frame_consumer.h>
+#include <core/frame/frame_converter.h>
 #include <core/frame/frame.h>
 #include <core/video_format.h>
 
@@ -52,13 +53,15 @@ namespace caspar { namespace image {
 
 struct image_consumer : public core::frame_consumer
 {
-    const std::wstring filename_;
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+    const std::wstring                           filename_;
 
   public:
     // frame_consumer
 
-    explicit image_consumer(std::wstring filename)
-        : filename_(std::move(filename))
+    explicit image_consumer(const spl::shared_ptr<core::frame_converter>& frame_converter, std::wstring filename)
+        : frame_converter_(frame_converter)
+        , filename_(std::move(filename))
     {
     }
 
@@ -68,7 +71,10 @@ struct image_consumer : public core::frame_consumer
     {
         auto filename = filename_;
 
-        std::thread async([frame, filename] {
+        auto encode_format = core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8);
+        // encode_format.straight_alpha = true; // Future
+
+        std::thread async([frame_converter = frame_converter_, frame, filename, encode_format] {
             try {
                 auto filename2 = filename;
 
@@ -79,10 +85,13 @@ struct image_consumer : public core::frame_consumer
                 else
                     filename2 = env::media_folder() + filename2 + L".png";
 
+                auto rgba_bytes =
+                    frame_converter->convert_to_buffer(frame, encode_format).get();
+
                 auto bitmap = std::shared_ptr<FIBITMAP>(
                     FreeImage_Allocate(static_cast<int>(frame.width()), static_cast<int>(frame.height()), 32),
                     FreeImage_Unload);
-                std::memcpy(FreeImage_GetBits(bitmap.get()), frame.image_data(0).begin(), frame.image_data(0).size());
+                std::memcpy(FreeImage_GetBits(bitmap.get()), rgba_bytes.begin(), rgba_bytes.size());
 
                 image_view<bgra_pixel> original_view(
                     FreeImage_GetBits(bitmap.get()), static_cast<int>(frame.width()), static_cast<int>(frame.height()));
@@ -117,8 +126,9 @@ struct image_consumer : public core::frame_consumer
     }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -133,7 +143,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     if (params.size() > 1)
         filename = params.at(1);
 
-    return spl::make_shared<image_consumer>(filename);
+    return spl::make_shared<image_consumer>(frame_converter, filename);
 }
 
 }} // namespace caspar::image

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -129,7 +129,6 @@ struct image_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"IMAGE"))

--- a/src/modules/image/consumer/image_consumer.h
+++ b/src/modules/image/consumer/image_consumer.h
@@ -35,7 +35,6 @@ namespace caspar { namespace image {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 
 }} // namespace caspar::image

--- a/src/modules/image/consumer/image_consumer.h
+++ b/src/modules/image/consumer/image_consumer.h
@@ -32,8 +32,9 @@
 
 namespace caspar { namespace image {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -275,7 +275,6 @@ spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
                     const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                    const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                     common::bit_depth                                        depth)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"NDI"))
@@ -293,7 +292,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
                                   const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                   common::bit_depth                                        depth)
 {
     auto name         = ptree.get(L"name", L"");

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -47,11 +47,14 @@
 #include <thread>
 
 #include "../util/ndi.h"
+#include "core/frame/frame_converter.h"
 
 namespace caspar { namespace newtek {
 
 struct newtek_ndi_consumer : public core::frame_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     static std::atomic<int> instances_;
     const int               instance_no_;
     const std::wstring      name_;
@@ -72,15 +75,17 @@ struct newtek_ndi_consumer : public core::frame_consumer
     std::condition_variable              buffer_cond_;
     std::condition_variable              worker_cond_;
     bool                                 ready_for_frame_;
-    std::queue<core::const_frame>        buffer_;
+    std::queue<core::converted_frame>    buffer_;
     boost::thread                        send_thread;
     executor                             executor_;
 
     std::unique_ptr<NDIlib_send_instance_t, std::function<void(NDIlib_send_instance_t*)>> ndi_send_instance_;
 
   public:
-    newtek_ndi_consumer(std::wstring name, bool allow_fields)
-        : name_(!name.empty() ? name : default_ndi_name())
+    newtek_ndi_consumer(
+    const spl::shared_ptr<core::frame_converter>& frame_converter, std::wstring name, bool allow_fields)
+        : frame_converter_(frame_converter)
+        , name_(!name.empty() ? name : default_ndi_name())
         , instance_no_(instances_++)
         , frame_no_(0)
         , allow_fields_(allow_fields)
@@ -171,14 +176,22 @@ struct newtek_ndi_consumer : public core::frame_consumer
                 auto time_point  = std::chrono::steady_clock::now();
                 time_point += std::chrono::microseconds(frametimeUs);
                 while (!send_thread.interruption_requested()) {
-                    core::const_frame frame;
+                    std::optional<core::converted_frame> wrapped_frame;
                     {
                         std::unique_lock<std::mutex> lock(buffer_mutex_);
                         worker_cond_.wait(lock, [&] { return !buffer_.empty(); });
                         graph_->set_value("buffered-frames", static_cast<double>(buffer_.size() + 0.001) / 8);
-                        frame = std::move(buffer_.front());
+                        wrapped_frame = std::move(buffer_.front());
                         buffer_.pop();
+
+                        if (!wrapped_frame.has_value()) {
+                            // Didn't get a frame for some reason, try again
+                            continue;
+                        }
                     }
+                    auto frame = wrapped_frame.value().frame;
+                    auto pixels = wrapped_frame.value().pixels.get();
+
                     graph_->set_value("ndi-tick", ndi_timer_.elapsed() * format_desc_.fps * 0.5);
                     ndi_timer_.restart();
                     frame_timer_.restart();
@@ -192,11 +205,11 @@ struct newtek_ndi_consumer : public core::frame_consumer
                             (frame_no_ % 2 ? NDIlib_frame_format_type_field_1 : NDIlib_frame_format_type_field_0);
                         for (auto y = 0; y < ndi_video_frame_.yres; ++y) {
                             std::memcpy(reinterpret_cast<char*>(ndi_video_frame_.p_data) + y * format_desc_.width * 4,
-                                        frame.image_data(0).data() + (y * 2 + frame_no_ % 2) * format_desc_.width * 4,
+                                        pixels.data() + (y * 2 + frame_no_ % 2) * format_desc_.width * 4,
                                         format_desc_.width * 4);
                         }
                     } else {
-                        ndi_video_frame_.p_data = const_cast<uint8_t*>(frame.image_data(0).begin());
+                        ndi_video_frame_.p_data = const_cast<uint8_t*>(pixels.begin());
                     }
                     ndi_lib_->send_send_video_v2(*ndi_send_instance_, &ndi_video_frame_);
                     frame_no_++;
@@ -212,12 +225,15 @@ struct newtek_ndi_consumer : public core::frame_consumer
 
     std::future<bool> send(core::video_field field, core::const_frame frame) override
     {
+        auto wrapped_frame =
+               frame_converter_->convert_to_buffer_and_frame(frame, core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8));
+
         return executor_.begin_invoke([=] {
             graph_->set_value("tick-time", tick_timer_.elapsed() * format_desc_.fps * 0.5);
             tick_timer_.restart();
             {
                 std::unique_lock<std::mutex> lock(buffer_mutex_);
-                buffer_.push(std::move(frame));
+                buffer_.push(std::move(wrapped_frame));
             }
             worker_cond_.notify_all();
             return true;
@@ -258,6 +274,7 @@ std::atomic<int> newtek_ndi_consumer::instances_(0);
 spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
+                    const spl::shared_ptr<core::frame_converter>&            frame_converter,
                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                     common::bit_depth                                        depth)
 {
@@ -269,12 +286,13 @@ create_ndi_consumer(const std::vector<std::wstring>&                         par
 
     std::wstring name         = get_param(L"NAME", params, L"");
     bool         allow_fields = contains_param(L"ALLOW_FIELDS", params);
-    return spl::make_shared<newtek_ndi_consumer>(name, allow_fields);
+    return spl::make_shared<newtek_ndi_consumer>(frame_converter, name, allow_fields);
 }
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
+                                  const spl::shared_ptr<core::frame_converter>&            frame_converter,
                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                   common::bit_depth                                        depth)
 {
@@ -284,7 +302,7 @@ create_preconfigured_ndi_consumer(const boost::property_tree::wptree&           
     if (depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Newtek NDI consumer only supports 8-bit color depth."));
 
-    return spl::make_shared<newtek_ndi_consumer>(name, allow_fields);
+    return spl::make_shared<newtek_ndi_consumer>(frame_converter, name, allow_fields);
 }
 
 }} // namespace caspar::newtek

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.h
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.h
@@ -37,13 +37,11 @@ spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
                     const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                    const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                     common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
                                   const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                                  const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                   common::bit_depth                                        depth);
 
 }} // namespace caspar::newtek

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.h
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.h
@@ -36,11 +36,13 @@ namespace caspar { namespace newtek {
 spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
+                    const spl::shared_ptr<core::frame_converter>&            frame_converter,
                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                     common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
+                                  const spl::shared_ptr<core::frame_converter>&            frame_converter,
                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                   common::bit_depth                                        depth);
 

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -397,8 +397,9 @@ struct oal_consumer : public core::frame_consumer
     }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -411,6 +412,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -400,7 +400,6 @@ struct oal_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"AUDIO"))
@@ -413,7 +412,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     return spl::make_shared<oal_consumer>();

--- a/src/modules/oal/consumer/oal_consumer.h
+++ b/src/modules/oal/consumer/oal_consumer.h
@@ -35,13 +35,11 @@ namespace caspar { namespace oal {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 
 }} // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.h
+++ b/src/modules/oal/consumer/oal_consumer.h
@@ -32,13 +32,15 @@
 
 namespace caspar { namespace oal {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -618,7 +618,6 @@ struct screen_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"SCREEN")) {
@@ -672,7 +671,6 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
     configuration config;

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -60,6 +60,8 @@
 
 #include "consumer_screen_fragment.h"
 #include "consumer_screen_vertex.h"
+#include "core/frame/frame_converter.h"
+
 #include <accelerator/ogl/util/shader.h>
 
 namespace caspar { namespace screen {
@@ -121,6 +123,8 @@ struct frame
 
 struct screen_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
+
     const configuration     config_;
     core::video_format_desc format_desc_;
     int                     channel_index_;
@@ -141,7 +145,7 @@ struct screen_consumer
     spl::shared_ptr<diagnostics::graph> graph_;
     caspar::timer                       tick_timer_;
 
-    tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_;
+    tbb::concurrent_bounded_queue<core::converted_frame> frame_buffer_;
 
     std::unique_ptr<accelerator::ogl::shader> shader_;
     GLuint                                    vao_;
@@ -154,8 +158,9 @@ struct screen_consumer
     screen_consumer& operator=(const screen_consumer&) = delete;
 
   public:
-    screen_consumer(const configuration& config, const core::video_format_desc& format_desc, int channel_index)
-        : config_(config)
+    screen_consumer(const spl::shared_ptr<core::frame_converter>& frame_converter, const configuration& config, const core::video_format_desc& format_desc, int channel_index)
+        : frame_converter_(frame_converter)
+        , config_(config)
         , format_desc_(format_desc)
         , channel_index_(channel_index)
     {
@@ -366,7 +371,7 @@ struct screen_consumer
 
     void tick()
     {
-        core::const_frame in_frame;
+        auto in_frame = core::converted_frame::empty();
 
         while (!frame_buffer_.try_pop(in_frame) && is_running_) {
             // TODO (fix)
@@ -375,7 +380,7 @@ struct screen_consumer
             }
         }
 
-        if (!in_frame) {
+        if (in_frame.is_empty()) {
             return;
         }
 
@@ -395,7 +400,8 @@ struct screen_consumer
                 }
             }
 
-            std::memcpy(frame.ptr, in_frame.image_data(0).begin(), format_desc_.size);
+            auto pixels = in_frame.pixels.get();
+            std::memcpy(frame.ptr, pixels.begin(), format_desc_.size);
 
             GL(glBindBuffer(GL_PIXEL_UNPACK_BUFFER, frame.pbo));
             GL(glTextureSubImage2D(
@@ -463,7 +469,8 @@ struct screen_consumer
 
     std::future<bool> send(core::video_field field, const core::const_frame& frame)
     {
-        if (!frame_buffer_.try_push(frame)) {
+        auto frame2 = frame_converter_->convert_to_buffer_and_frame(frame, core::frame_conversion_format(core::frame_conversion_format::pixel_format::rgba8));
+        if (!frame_buffer_.try_push(frame2)) {
             graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
         }
         return make_ready_future(is_running_.load());
@@ -565,12 +572,14 @@ struct screen_consumer
 
 struct screen_consumer_proxy : public core::frame_consumer
 {
+    const spl::shared_ptr<core::frame_converter> frame_converter_;
     const configuration              config_;
     std::unique_ptr<screen_consumer> consumer_;
 
   public:
-    explicit screen_consumer_proxy(configuration config)
-        : config_(std::move(config))
+    explicit screen_consumer_proxy(const spl::shared_ptr<core::frame_converter> &frame_converter, configuration config)
+        : frame_converter_(frame_converter)
+        , config_(std::move(config))
     {
     }
 
@@ -579,7 +588,7 @@ struct screen_consumer_proxy : public core::frame_consumer
     void initialize(const core::video_format_desc& format_desc, int channel_index) override
     {
         consumer_.reset();
-        consumer_ = std::make_unique<screen_consumer>(config_, format_desc, channel_index);
+        consumer_ = std::make_unique<screen_consumer>(frame_converter_, config_, format_desc, channel_index);
     }
 
     std::future<bool> send(core::video_field field, core::const_frame frame) override
@@ -606,8 +615,9 @@ struct screen_consumer_proxy : public core::frame_consumer
     }
 };
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth)
 {
@@ -655,12 +665,13 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
         config.key_only = false;
     }
 
-    return spl::make_shared<screen_consumer_proxy>(config);
+    return spl::make_shared<screen_consumer_proxy>(frame_converter, config);
 }
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth)
 {
@@ -725,7 +736,7 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
         config.aspect = configuration::aspect_ratio::aspect_4_3;
     }
 
-    return spl::make_shared<screen_consumer_proxy>(config);
+    return spl::make_shared<screen_consumer_proxy>(frame_converter, config);
 }
 
 }} // namespace caspar::screen

--- a/src/modules/screen/consumer/screen_consumer.h
+++ b/src/modules/screen/consumer/screen_consumer.h
@@ -31,13 +31,15 @@
 
 namespace caspar { namespace screen {
 
-spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
-                                                      const core::video_format_repository& format_repository,
+spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
+                                                      const core::video_format_repository&          format_repository,
+                                                      const spl::shared_ptr<core::frame_converter>& frame_converter,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
+                              const spl::shared_ptr<core::frame_converter>&            frame_converter,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 

--- a/src/modules/screen/consumer/screen_consumer.h
+++ b/src/modules/screen/consumer/screen_consumer.h
@@ -34,13 +34,11 @@ namespace caspar { namespace screen {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&              params,
                                                       const core::video_format_repository&          format_repository,
                                                       const spl::shared_ptr<core::frame_converter>& frame_converter,
-                                                      const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       common::bit_depth                                        depth);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const spl::shared_ptr<core::frame_converter>&            frame_converter,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               common::bit_depth                                        depth);
 
 }} // namespace caspar::screen

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -483,7 +483,6 @@ std::wstring add_command(command_context& ctx)
     auto consumer = ctx.static_context->consumer_registry->create_consumer(ctx.parameters,
                                                                            ctx.static_context->format_repository,
                                                                            ctx.channel.raw_channel->frame_converter(),
-                                                                           get_channels(ctx),
                                                                            ctx.channel.raw_channel->mixer().depth());
     ctx.channel.raw_channel->output().add(ctx.layer_index(consumer->index()), consumer);
 
@@ -505,7 +504,6 @@ std::wstring remove_command(command_context& ctx)
                     ->create_consumer(ctx.parameters,
                                       ctx.static_context->format_repository,
                                       ctx.channel.raw_channel->frame_converter(),
-                                      get_channels(ctx),
                                       ctx.channel.raw_channel->mixer().depth())
                     ->index();
     }
@@ -529,7 +527,6 @@ std::wstring print_command(command_context& ctx)
         ctx.static_context->consumer_registry->create_consumer(params,
                                                                ctx.static_context->format_repository,
                                                                ctx.channel.raw_channel->frame_converter(),
-                                                               get_channels(ctx),
                                                                ctx.channel.raw_channel->mixer().depth()));
 
     return L"202 PRINT OK\r\n";
@@ -1398,7 +1395,6 @@ std::wstring channel_grid_command(command_context& ctx)
     auto screen = ctx.static_context->consumer_registry->create_consumer(params,
                                                                          ctx.static_context->format_repository,
                                                                          ctx.channel.raw_channel->frame_converter(),
-                                                                         get_channels(ctx),
                                                                          ctx.channel.raw_channel->mixer().depth());
 
     self.raw_channel->output().add(screen);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -482,6 +482,7 @@ std::wstring add_command(command_context& ctx)
 
     auto consumer = ctx.static_context->consumer_registry->create_consumer(ctx.parameters,
                                                                            ctx.static_context->format_repository,
+                                                                           ctx.channel.raw_channel->frame_converter(),
                                                                            get_channels(ctx),
                                                                            ctx.channel.raw_channel->mixer().depth());
     ctx.channel.raw_channel->output().add(ctx.layer_index(consumer->index()), consumer);
@@ -503,6 +504,7 @@ std::wstring remove_command(command_context& ctx)
         index = ctx.static_context->consumer_registry
                     ->create_consumer(ctx.parameters,
                                       ctx.static_context->format_repository,
+                                      ctx.channel.raw_channel->frame_converter(),
                                       get_channels(ctx),
                                       ctx.channel.raw_channel->mixer().depth())
                     ->index();
@@ -523,8 +525,12 @@ std::wstring print_command(command_context& ctx)
         std::copy(std::cbegin(ctx.parameters), std::cend(ctx.parameters), params.begin() + 1);
     }
 
-    ctx.channel.raw_channel->output().add(ctx.static_context->consumer_registry->create_consumer(
-        params, ctx.static_context->format_repository, get_channels(ctx), ctx.channel.raw_channel->mixer().depth()));
+    ctx.channel.raw_channel->output().add(
+        ctx.static_context->consumer_registry->create_consumer(params,
+                                                               ctx.static_context->format_repository,
+                                                               ctx.channel.raw_channel->frame_converter(),
+                                                               get_channels(ctx),
+                                                               ctx.channel.raw_channel->mixer().depth()));
 
     return L"202 PRINT OK\r\n";
 }
@@ -1389,8 +1395,11 @@ std::wstring channel_grid_command(command_context& ctx)
     params.emplace_back(L"0");
     params.emplace_back(L"NAME");
     params.emplace_back(L"Channel Grid Window");
-    auto screen = ctx.static_context->consumer_registry->create_consumer(
-        params, ctx.static_context->format_repository, get_channels(ctx), ctx.channel.raw_channel->mixer().depth());
+    auto screen = ctx.static_context->consumer_registry->create_consumer(params,
+                                                                         ctx.static_context->format_repository,
+                                                                         ctx.channel.raw_channel->frame_converter(),
+                                                                         get_channels(ctx),
+                                                                         ctx.channel.raw_channel->mixer().depth());
 
     self.raw_channel->output().add(screen);
 

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -365,6 +365,7 @@ struct server::impl
                                 consumer_registry_->create_consumer(name,
                                                                     xml_consumer.second,
                                                                     video_format_repository_,
+                                                                    channel.raw_channel->frame_converter(),
                                                                     channels_vec,
                                                                     channel.raw_channel->mixer().depth()));
                     } catch (...) {

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -343,11 +343,6 @@ struct server::impl
     {
         auto console_client = spl::make_shared<IO::ConsoleClientInfo>();
 
-        std::vector<spl::shared_ptr<core::video_channel>> channels_vec;
-        for (auto& cc : *channels_) {
-            channels_vec.emplace_back(cc.raw_channel);
-        }
-
         for (auto& channel : *channels_) {
             core::diagnostics::scoped_call_context save;
             core::diagnostics::call_context::for_thread().video_channel = channel.raw_channel->index();
@@ -366,7 +361,6 @@ struct server::impl
                                                                     xml_consumer.second,
                                                                     video_format_repository_,
                                                                     channel.raw_channel->frame_converter(),
-                                                                    channels_vec,
                                                                     channel.raw_channel->mixer().depth()));
                     } catch (...) {
                         CASPAR_LOG_CURRENT_EXCEPTION();


### PR DESCRIPTION
Continues https://github.com/CasparCG/server/pull/1609 

This starts work on adding the compute shader for consumer frame conversion.
Not tested or complete yet, opening this for visibility