### PR TITLE
fix: pass channel_info object to consumer factory methods

### DIFF
--- a/src/accelerator/accelerator.cpp
+++ b/src/accelerator/accelerator.cpp
@@ -25,14 +25,10 @@ struct accelerator::impl
     {
     }
 
-    std::unique_ptr<core::image_mixer>
-    create_image_mixer(int channel_id, common::bit_depth depth, core::color_space color_space)
+    std::unique_ptr<core::image_mixer> create_image_mixer(int channel_id, common::bit_depth depth)
     {
-        return std::make_unique<ogl::image_mixer>(spl::make_shared_ptr(get_device()),
-                                                  channel_id,
-                                                  format_repository_.get_max_video_format_size(),
-                                                  depth,
-                                                  color_space);
+        return std::make_unique<ogl::image_mixer>(
+            spl::make_shared_ptr(get_device()), channel_id, format_repository_.get_max_video_format_size(), depth);
     }
 
     std::shared_ptr<ogl::device> get_device()
@@ -52,10 +48,9 @@ accelerator::accelerator(const core::video_format_repository format_repository)
 
 accelerator::~accelerator() {}
 
-std::unique_ptr<core::image_mixer>
-accelerator::create_image_mixer(const int channel_id, common::bit_depth depth, core::color_space color_space)
+std::unique_ptr<core::image_mixer> accelerator::create_image_mixer(const int channel_id, common::bit_depth depth)
 {
-    return impl_->create_image_mixer(channel_id, depth, color_space);
+    return impl_->create_image_mixer(channel_id, depth);
 }
 
 std::shared_ptr<accelerator_device> accelerator::get_device() const

--- a/src/accelerator/accelerator.h
+++ b/src/accelerator/accelerator.h
@@ -30,8 +30,7 @@ class accelerator
 
     accelerator& operator=(accelerator&) = delete;
 
-    std::unique_ptr<caspar::core::image_mixer>
-    create_image_mixer(int channel_id, common::bit_depth depth, core::color_space color_space);
+    std::unique_ptr<caspar::core::image_mixer> create_image_mixer(int channel_id, common::bit_depth depth);
 
     std::shared_ptr<accelerator_device> get_device() const;
 

--- a/src/accelerator/ogl/image/image_mixer.cpp
+++ b/src/accelerator/ogl/image/image_mixer.cpp
@@ -72,18 +72,13 @@ class image_renderer
     image_kernel            kernel_;
     const size_t            max_frame_size_;
     common::bit_depth       depth_;
-    core::color_space       color_space_;
 
   public:
-    explicit image_renderer(const spl::shared_ptr<device>& ogl,
-                            const size_t                   max_frame_size,
-                            common::bit_depth              depth,
-                            core::color_space              color_space)
+    explicit image_renderer(const spl::shared_ptr<device>& ogl, const size_t max_frame_size, common::bit_depth depth)
         : ogl_(ogl)
         , kernel_(ogl_)
         , max_frame_size_(max_frame_size)
         , depth_(depth)
-        , color_space_(color_space)
     {
     }
 
@@ -106,7 +101,6 @@ class image_renderer
     }
 
     common::bit_depth depth() const { return depth_; }
-    core::color_space color_space() const { return color_space_; }
 
   private:
     void draw(std::shared_ptr<texture>&      target_texture,
@@ -255,13 +249,9 @@ struct image_mixer::impl
     double aspect_ratio_ = 1.0;
 
   public:
-    impl(const spl::shared_ptr<device>& ogl,
-         const int                      channel_id,
-         const size_t                   max_frame_size,
-         common::bit_depth              depth,
-         core::color_space              color_space)
+    impl(const spl::shared_ptr<device>& ogl, const int channel_id, const size_t max_frame_size, common::bit_depth depth)
         : ogl_(ogl)
-        , renderer_(ogl, max_frame_size, depth, color_space)
+        , renderer_(ogl, max_frame_size, depth)
         , transform_stack_(1)
     {
         CASPAR_LOG(info) << L"Initialized OpenGL Accelerated GPU Image Mixer for channel " << channel_id;
@@ -368,15 +358,13 @@ struct image_mixer::impl
     }
 
     common::bit_depth depth() const { return renderer_.depth(); }
-    core::color_space color_space() const { return renderer_.color_space(); }
 };
 
 image_mixer::image_mixer(const spl::shared_ptr<device>& ogl,
                          const int                      channel_id,
                          const size_t                   max_frame_size,
-                         common::bit_depth              depth,
-                         core::color_space              color_space)
-    : impl_(std::make_unique<impl>(ogl, channel_id, max_frame_size, depth, color_space))
+                         common::bit_depth              depth)
+    : impl_(std::make_unique<impl>(ogl, channel_id, max_frame_size, depth))
 {
 }
 image_mixer::~image_mixer() {}
@@ -399,6 +387,5 @@ image_mixer::create_frame(const void* tag, const core::pixel_format_desc& desc, 
 }
 
 common::bit_depth image_mixer::depth() const { return impl_->depth(); }
-core::color_space image_mixer::color_space() const { return impl_->color_space(); }
 
 }}} // namespace caspar::accelerator::ogl

--- a/src/accelerator/ogl/image/image_mixer.h
+++ b/src/accelerator/ogl/image/image_mixer.h
@@ -40,8 +40,7 @@ class image_mixer final : public core::image_mixer
     image_mixer(const spl::shared_ptr<class device>& ogl,
                 int                                  channel_id,
                 const size_t                         max_frame_size,
-                common::bit_depth                    depth,
-                core::color_space                    color_space);
+                common::bit_depth                    depth);
     image_mixer(const image_mixer&) = delete;
 
     ~image_mixer();
@@ -61,7 +60,6 @@ class image_mixer final : public core::image_mixer
     void              visit(const core::const_frame& frame) override;
     void              pop() override;
     common::bit_depth depth() const override;
-    core::color_space color_space() const override;
 
   private:
     struct impl;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -75,6 +75,7 @@ set(HEADERS
 		StdAfx.h
 		video_channel.h
 		video_format.h
+		consumer/channel_info.h
 )
 
 casparcg_add_library(core SOURCES ${SOURCES} ${HEADERS})

--- a/src/core/consumer/channel_info.h
+++ b/src/core/consumer/channel_info.h
@@ -28,7 +28,13 @@ namespace caspar::core {
 
 struct channel_info
 {
-    int               channel_index;
+    channel_info(int channel_index, common::bit_depth depth, color_space color_space)
+    : index(channel_index)
+    , depth(depth)
+    , default_color_space(color_space)
+    {}
+
+    int               index;
     common::bit_depth depth;
     color_space       default_color_space;
 };

--- a/src/core/consumer/channel_info.h
+++ b/src/core/consumer/channel_info.h
@@ -16,26 +16,21 @@
  * You should have received a copy of the GNU General Public License
  * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
  *
- * Author: Eliyah Sundström eliyah@sundstroem.com
+ * Author: Julian Waller, julian@superfly.tv
  */
 
 #pragma once
 
-#include "../util/fixture_calculation.h"
+#include "common/bit_depth.h"
+#include "core/frame/pixel_format.h"
 
-#include <common/bit_depth.h>
-#include <common/memory.h>
+namespace caspar::core {
 
-#include <core/consumer/frame_consumer.h>
+struct channel_info
+{
+    int               channel_index;
+    common::bit_depth depth;
+    //    color_space default_color_space;
+};
 
-#include <string>
-#include <vector>
-
-namespace caspar { namespace artnet {
-
-spl::shared_ptr<core::frame_consumer>
-create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
-                              const core::video_format_repository&                     format_repository,
-                              const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              const core::channel_info&                                channel_info);
-}} // namespace caspar::artnet
+} // namespace caspar::core

--- a/src/core/consumer/channel_info.h
+++ b/src/core/consumer/channel_info.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include "../frame/pixel_format.h"
 #include "common/bit_depth.h"
-#include "core/frame/pixel_format.h"
 
 namespace caspar::core {
 
@@ -30,7 +30,7 @@ struct channel_info
 {
     int               channel_index;
     common::bit_depth depth;
-    //    color_space default_color_space;
+    color_space       default_color_space;
 };
 
 } // namespace caspar::core

--- a/src/core/consumer/frame_consumer.cpp
+++ b/src/core/consumer/frame_consumer.cpp
@@ -38,7 +38,7 @@ const spl::shared_ptr<frame_consumer>& frame_consumer::empty()
     {
       public:
         std::future<bool> send(const core::video_field field, const_frame) override { return make_ready_future(false); }
-        void              initialize(const video_format_desc&, int) override {}
+        void              initialize(const video_format_desc&, const core::channel_info&, int port_index) override {}
         std::wstring      print() const override { return L"empty"; }
         std::wstring      name() const override { return L"empty"; }
         bool              has_synchronization_clock() const override { return false; }

--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -50,7 +50,7 @@ class frame_consumer
     virtual ~frame_consumer() {}
 
     virtual std::future<bool> send(const core::video_field field, const_frame frame)              = 0;
-    virtual void              initialize(const video_format_desc& format_desc, int channel_index) = 0;
+    virtual void              initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) = 0;
 
     virtual core::monitor::state state() const = 0;
 

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -152,7 +152,7 @@ spl::shared_ptr<core::frame_consumer>
 frame_consumer_registry::create_consumer(const std::vector<std::wstring>&                         params,
                                          const core::video_format_repository&                     format_repository,
                                          const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                         common::bit_depth                                        depth) const
+                                         const core::channel_info&                                channel_info) const
 {
     if (params.empty())
         CASPAR_THROW_EXCEPTION(invalid_argument() << msg_info("params cannot be empty"));
@@ -162,7 +162,7 @@ frame_consumer_registry::create_consumer(const std::vector<std::wstring>&       
     if (!std::any_of(
             consumer_factories.begin(), consumer_factories.end(), [&](const consumer_factory_t& factory) -> bool {
                 try {
-                    consumer = factory(params, format_repository, channels, depth);
+                    consumer = factory(params, format_repository, channels, channel_info);
                 } catch (...) {
                     CASPAR_LOG_CURRENT_EXCEPTION();
                 }
@@ -179,7 +179,7 @@ frame_consumer_registry::create_consumer(const std::wstring&                    
                                          const boost::property_tree::wptree&                      element,
                                          const core::video_format_repository&                     format_repository,
                                          const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                         common::bit_depth                                        depth) const
+                                         const core::channel_info&                                channel_info) const
 {
     auto& preconfigured_consumer_factories = preconfigured_consumer_factories_;
     auto  found                            = preconfigured_consumer_factories.find(element_name);
@@ -189,7 +189,7 @@ frame_consumer_registry::create_consumer(const std::wstring&                    
                                << msg_info(L"No consumer factory registered for element name " + element_name));
 
     return spl::make_shared<destroy_consumer_proxy>(
-        spl::make_shared<print_consumer_proxy>(found->second(element, format_repository, channels, depth)));
+        spl::make_shared<print_consumer_proxy>(found->second(element, format_repository, channels, channel_info)));
 }
 
 }} // namespace caspar::core

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -90,9 +90,9 @@ class destroy_consumer_proxy : public frame_consumer
     {
         return consumer_->send(field, std::move(frame));
     }
-    void initialize(const video_format_desc& format_desc, int channel_index) override
+    void initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
-        return consumer_->initialize(format_desc, channel_index);
+        return consumer_->initialize(format_desc, channel_info, port_index);
     }
     std::wstring         print() const override { return consumer_->print(); }
     std::wstring         name() const override { return consumer_->name(); }
@@ -123,9 +123,9 @@ class print_consumer_proxy : public frame_consumer
     {
         return consumer_->send(field, std::move(frame));
     }
-    void initialize(const video_format_desc& format_desc, int channel_index) override
+    void initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
-        consumer_->initialize(format_desc, channel_index);
+        consumer_->initialize(format_desc, channel_info, port_index);
         CASPAR_LOG(info) << consumer_->print() << L" Initialized.";
     }
     std::wstring         print() const override { return consumer_->print(); }

--- a/src/core/consumer/frame_consumer_registry.h
+++ b/src/core/consumer/frame_consumer_registry.h
@@ -23,6 +23,7 @@
 
 #include "../fwd.h"
 #include "../monitor/monitor.h"
+#include "channel_info.h"
 
 #include <common/bit_depth.h>
 #include <common/memory.h>
@@ -45,12 +46,12 @@ using consumer_factory_t =
     std::function<spl::shared_ptr<frame_consumer>(const std::vector<std::wstring>&     params,
                                                   const core::video_format_repository& format_repository,
                                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                  common::bit_depth                                        depth)>;
+                                                  const core::channel_info& channel_info)>;
 using preconfigured_consumer_factory_t =
     std::function<spl::shared_ptr<frame_consumer>(const boost::property_tree::wptree&  element,
                                                   const core::video_format_repository& format_repository,
                                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                  common::bit_depth                                        depth)>;
+                                                  const core::channel_info& channel_info)>;
 
 class frame_consumer_registry
 {
@@ -62,12 +63,12 @@ class frame_consumer_registry
     spl::shared_ptr<frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                     const core::video_format_repository& format_repository,
                                                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                    common::bit_depth depth) const;
+                                                    const core::channel_info& channel_info) const;
     spl::shared_ptr<frame_consumer> create_consumer(const std::wstring&                  element_name,
                                                     const boost::property_tree::wptree&  element,
                                                     const core::video_format_repository& format_repository,
                                                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                    common::bit_depth depth) const;
+                                                    const core::channel_info& channel_info) const;
 
   private:
     std::vector<consumer_factory_t>                          consumer_factories_;

--- a/src/core/consumer/output.h
+++ b/src/core/consumer/output.h
@@ -40,7 +40,7 @@ class output final
   public:
     explicit output(const spl::shared_ptr<diagnostics::graph>& graph,
                     const video_format_desc&                   format_desc,
-                    int                                        channel_index);
+                    const core::channel_info&                  channel_info);
 
     output(const output&)            = delete;
     output& operator=(const output&) = delete;

--- a/src/core/fwd.h
+++ b/src/core/fwd.h
@@ -48,4 +48,5 @@ class cg_producer_registry;
 class frame_producer_registry;
 class frame_consumer_registry;
 class video_format_repository;
+struct channel_info;
 } // namespace caspar::core

--- a/src/core/mixer/image/image_mixer.h
+++ b/src/core/mixer/image/image_mixer.h
@@ -55,8 +55,7 @@ class image_mixer
                                      const struct pixel_format_desc& desc,
                                      common::bit_depth               depth) override                               = 0;
 
-    virtual common::bit_depth depth() const       = 0;
-    virtual core::color_space color_space() const = 0;
+    virtual common::bit_depth depth() const = 0;
 };
 
 }} // namespace caspar::core

--- a/src/core/mixer/mixer.cpp
+++ b/src/core/mixer/mixer.cpp
@@ -76,18 +76,16 @@ struct mixer::impl
 
         state_["audio"] = audio_mixer_.state();
 
-        auto depth       = image_mixer_->depth();
-        auto color_space = image_mixer_->color_space();
+        auto depth = image_mixer_->depth();
 
         buffer_.push(std::async(std::launch::deferred,
                                 [image = std::move(image),
                                  audio = std::move(audio),
                                  graph = graph_,
                                  depth,
-                                 color_space,
                                  format_desc,
                                  tag = this]() mutable {
-                                    auto desc = pixel_format_desc(pixel_format::bgra, color_space);
+                                    auto desc = pixel_format_desc(pixel_format::bgra);
                                     desc.planes.push_back(
                                         pixel_format_desc::plane(format_desc.width, format_desc.height, 4, depth));
                                     std::vector<array<const uint8_t>> image_data;

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -26,6 +26,7 @@
 
 #include "video_format.h"
 
+#include "consumer/channel_info.h"
 #include "consumer/output.h"
 #include "frame/draw_frame.h"
 #include "frame/frame.h"
@@ -233,6 +234,16 @@ struct video_channel::impl final
     }
 
     int index() const { return index_; }
+
+    channel_info get_consumer_channel_info() const
+    {
+        channel_info info  = {};
+        info.channel_index = index_;
+        info.depth         = mixer_.depth();
+        // TODO - color_space
+        // info.default_color_space = mixer_.
+        return info;
+    }
 };
 
 video_channel::video_channel(int                                       index,
@@ -251,7 +262,8 @@ const output&                       video_channel::output() const { return impl_
 output&                             video_channel::output() { return impl_->output_; }
 spl::shared_ptr<frame_factory>      video_channel::frame_factory() { return impl_->image_mixer_; }
 int                                 video_channel::index() const { return impl_->index(); }
-core::monitor::state                video_channel::state() const { return impl_->state_; }
+channel_info         video_channel::get_consumer_channel_info() const { return impl_->get_consumer_channel_info(); };
+core::monitor::state video_channel::state() const { return impl_->state_; }
 
 std::shared_ptr<route> video_channel::route(int index, route_mode mode) { return impl_->route(index, mode); }
 

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -54,7 +54,8 @@ struct video_channel::impl final
 {
     monitor::state state_;
 
-    const int index_;
+    const int         index_;
+    const color_space default_color_space_;
 
     const spl::shared_ptr<caspar::diagnostics::graph> graph_ = [](int index) {
         core::diagnostics::scoped_call_context save;
@@ -101,9 +102,11 @@ struct video_channel::impl final
   public:
     impl(int                                       index,
          const core::video_format_desc&            format_desc,
+         color_space                               default_color_space,
          std::unique_ptr<image_mixer>              image_mixer,
          std::function<void(core::monitor::state)> tick)
         : index_(index)
+        , default_color_space_(default_color_space)
         , output_(graph_, format_desc, index)
         , image_mixer_(std::move(image_mixer))
         , mixer_(index, graph_, image_mixer_)
@@ -237,20 +240,20 @@ struct video_channel::impl final
 
     channel_info get_consumer_channel_info() const
     {
-        channel_info info  = {};
-        info.channel_index = index_;
-        info.depth         = mixer_.depth();
-        // TODO - color_space
-        // info.default_color_space = mixer_.
+        channel_info info        = {};
+        info.channel_index       = index_;
+        info.depth               = mixer_.depth();
+        info.default_color_space = default_color_space_;
         return info;
     }
 };
 
 video_channel::video_channel(int                                       index,
                              const core::video_format_desc&            format_desc,
+                             color_space                               default_color_space,
                              std::unique_ptr<image_mixer>              image_mixer,
                              std::function<void(core::monitor::state)> tick)
-    : impl_(new impl(index, format_desc, std::move(image_mixer), std::move(tick)))
+    : impl_(new impl(index, format_desc, default_color_space, std::move(image_mixer), std::move(tick)))
 {
 }
 video_channel::~video_channel() {}

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -88,6 +88,8 @@ class video_channel final
 
     int index() const;
 
+    [[nodiscard]] channel_info get_consumer_channel_info() const;
+
     std::shared_ptr<core::route> route(int index = -1, route_mode mode = route_mode::foreground);
 
   private:

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -24,6 +24,8 @@
 #include "fwd.h"
 #include "video_format.h"
 
+#include "frame/pixel_format.h"
+
 #include "monitor/monitor.h"
 
 #include <common/memory.h>
@@ -71,6 +73,7 @@ class video_channel final
   public:
     explicit video_channel(int                                       index,
                            const video_format_desc&                  format_desc,
+                           color_space                               default_color_space,
                            std::unique_ptr<image_mixer>              image_mixer,
                            std::function<void(core::monitor::state)> on_tick);
     ~video_channel();

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -28,6 +28,8 @@
 #include <common/log.h>
 #include <common/ptree.h>
 
+#include <core/consumer/channel_info.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -304,11 +306,11 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     configuration config;
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Artnet consumer only supports 8-bit color depth."));
 
     config.universe    = ptree.get(L"universe", config.universe);

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -76,7 +76,7 @@ struct artnet_consumer : public core::frame_consumer
         compute_fixtures();
     }
 
-    void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override
+    void initialize(const core::video_format_desc& /*format_desc*/, const core::channel_info& channel_info, int port_index) override
     {
         thread_ = std::thread([this] {
             long long time      = 1000 / config.refreshRate;

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -850,12 +850,12 @@ struct bluefish_consumer_proxy : public core::frame_consumer
     }
 
     // frame_consumer
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         format_desc_ = format_desc;
         executor_.invoke([=] {
             consumer_.reset();
-            consumer_.reset(new bluefish_consumer(config_, format_desc, channel_index));
+            consumer_.reset(new bluefish_consumer(config_, format_desc, channel_info.index));
         });
     }
 

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -25,6 +25,7 @@
 #include "../util/blue_velvet.h"
 #include "../util/memory.h"
 
+#include <core/consumer/channel_info.h>
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
 
@@ -884,13 +885,13 @@ struct bluefish_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"BLUEFISH")) {
         return core::frame_consumer::empty();
     }
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Bluefish consumer only supports 8-bit color depth."));
 
     configuration config;
@@ -943,13 +944,13 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     configuration config;
     auto          device_index = ptree.get(L"device", 1);
     config.device_index        = device_index;
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Bluefish consumer only supports 8-bit color depth."));
 
     auto device_stream = ptree.get(L"sdi-stream", L"1");

--- a/src/modules/bluefish/consumer/bluefish_consumer.h
+++ b/src/modules/bluefish/consumer/bluefish_consumer.h
@@ -35,12 +35,12 @@ namespace caspar { namespace bluefish {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth);
+                              const core::channel_info&                                channel_info);
 
 }} // namespace caspar::bluefish

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -68,7 +68,8 @@ core::color_space get_color_space(const std::wstring& str)
 }
 
 configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
-                               const core::video_format_repository& format_repository)
+                               const core::video_format_repository& format_repository,
+                               const core::channel_info&            channel_info)
 {
     configuration config;
 
@@ -130,23 +131,25 @@ configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
         }
     }
 
+    config.color_space   = channel_info.default_color_space;
+    auto color_space_str = ptree.get(L"color-space", L"bt709");
+    if (!color_space_str.empty())
+        config.color_space = get_color_space(color_space_str);
+
     auto hdr_metadata = ptree.get_child_optional(L"hdr-metadata");
     if (hdr_metadata) {
-        auto color_space = get_color_space(hdr_metadata->get(L"default-color-space", L"bt709"));
-
         config.hdr_meta.min_dml  = hdr_metadata->get(L"min-dml", config.hdr_meta.min_dml);
         config.hdr_meta.max_dml  = hdr_metadata->get(L"max-dml", config.hdr_meta.max_dml);
         config.hdr_meta.max_fall = hdr_metadata->get(L"max-fall", config.hdr_meta.max_fall);
         config.hdr_meta.max_cll  = hdr_metadata->get(L"max-cll", config.hdr_meta.max_cll);
-
-        config.hdr_meta.default_color_space = color_space;
     }
 
     return config;
 }
 
 configuration parse_amcp_config(const std::vector<std::wstring>&     params,
-                                const core::video_format_repository& format_repository)
+                                const core::video_format_repository& format_repository,
+                                const core::channel_info&            channel_info)
 {
     configuration config;
 
@@ -173,6 +176,8 @@ configuration parse_amcp_config(const std::vector<std::wstring>&     params,
 
     config.embedded_audio   = contains_param(L"EMBEDDED_AUDIO", params);
     config.primary.key_only = contains_param(L"KEY_ONLY", params);
+
+    config.color_space = channel_info.default_color_space;
 
     return config;
 }

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -23,6 +23,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+#include <core/consumer/channel_info.h>
 #include <core/frame/pixel_format.h>
 #include <core/video_format.h>
 
@@ -49,11 +50,10 @@ struct port_configuration
 
 struct hdr_meta_configuration
 {
-    float             min_dml             = 0.005f;
-    float             max_dml             = 1000.0f;
-    float             max_fall            = 100.0f;
-    float             max_cll             = 1000.0f;
-    core::color_space default_color_space = core::color_space::bt709;
+    float min_dml  = 0.005f;
+    float max_dml  = 1000.0f;
+    float max_fall = 100.0f;
+    float max_cll  = 1000.0f;
 };
 
 struct configuration
@@ -99,6 +99,7 @@ struct configuration
     port_configuration              primary;
     std::vector<port_configuration> secondaries;
 
+    core::color_space      color_space = core::color_space::bt709;
     hdr_meta_configuration hdr_meta;
 
     [[nodiscard]] int buffer_depth() const
@@ -111,9 +112,11 @@ struct configuration
 };
 
 configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
-                               const core::video_format_repository& format_repository);
+                               const core::video_format_repository& format_repository,
+                               const core::channel_info&            channel_info);
 
 configuration parse_amcp_config(const std::vector<std::wstring>&     params,
-                                const core::video_format_repository& format_repository);
+                                const core::video_format_repository& format_repository,
+                                const core::channel_info&            channel_info);
 
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -711,7 +711,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
             std::shared_ptr<void> image_data = allocate_frame_data(decklink_format_desc_, config_.hdr);
 
-            schedule_next_video(image_data, nb_samples, video_scheduled_, config_.hdr_meta.default_color_space);
+            schedule_next_video(image_data, nb_samples, video_scheduled_, config_.color_space);
             for (auto& context : secondary_port_contexts_) {
                 context->schedule_next_video(image_data, 0, video_scheduled_);
             }
@@ -933,8 +933,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                                                                               mode_->GetFieldDominance(),
                                                                               config_.hdr);
 
-                    schedule_next_video(
-                        image_data, nb_samples, video_display_time, frame1.pixel_format_desc().color_space);
+                    schedule_next_video(image_data, nb_samples, video_display_time, config_.color_space);
 
                     if (config_.embedded_audio) {
                         schedule_next_audio(std::move(audio_data), nb_samples);
@@ -1105,7 +1104,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
         return core::frame_consumer::empty();
     }
 
-    configuration config = parse_amcp_config(params, format_repository);
+    configuration config = parse_amcp_config(params, format_repository, channel_info);
 
     config.hdr = (channel_info.depth != common::bit_depth::bit8);
 
@@ -1123,7 +1122,7 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               const core::channel_info&                                channel_info)
 {
-    configuration config = parse_xml_config(ptree, format_repository);
+    configuration config = parse_xml_config(ptree, format_repository, channel_info);
 
     config.hdr = (channel_info.depth != common::bit_depth::bit8);
 

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -1067,12 +1067,12 @@ struct decklink_consumer_proxy : public core::frame_consumer
         });
     }
 
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         format_desc_ = format_desc;
         executor_.invoke([=] {
             consumer_.reset();
-            consumer_ = std::make_unique<decklink_consumer>(config_, format_desc, channel_index);
+            consumer_ = std::make_unique<decklink_consumer>(config_, format_desc, channel_info.index);
         });
     }
 

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -30,6 +30,7 @@
 
 #include "../util/util.h"
 
+#include <core/consumer/channel_info.h>
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
 #include <core/frame/pixel_format.h>
@@ -1098,7 +1099,7 @@ struct decklink_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"DECKLINK")) {
         return core::frame_consumer::empty();
@@ -1106,7 +1107,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 
     configuration config = parse_amcp_config(params, format_repository);
 
-    config.hdr = (depth != common::bit_depth::bit8);
+    config.hdr = (channel_info.depth != common::bit_depth::bit8);
 
     if (config.hdr && config.primary.key_only) {
         CASPAR_THROW_EXCEPTION(caspar_exception()
@@ -1120,11 +1121,11 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     configuration config = parse_xml_config(ptree, format_repository);
 
-    config.hdr = (depth != common::bit_depth::bit8);
+    config.hdr = (channel_info.depth != common::bit_depth::bit8);
 
     if (config.hdr && config.primary.has_subregion_geometry()) {
         CASPAR_THROW_EXCEPTION(caspar_exception()

--- a/src/modules/decklink/consumer/decklink_consumer.h
+++ b/src/modules/decklink/consumer/decklink_consumer.h
@@ -36,11 +36,11 @@ namespace caspar { namespace decklink {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth);
+                              const core::channel_info&                                channel_info);
 
 }} // namespace caspar::decklink

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -33,6 +33,7 @@
 #include <common/scope_exit.h>
 #include <common/timer.h>
 
+#include <core/consumer/channel_info.h>
 #include <core/frame/frame.h>
 #include <core/video_format.h>
 
@@ -741,7 +742,7 @@ struct ffmpeg_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.size() < 2 || (!boost::iequals(params.at(0), L"STREAM") && !boost::iequals(params.at(0), L"FILE")))
         return core::frame_consumer::empty();
@@ -752,18 +753,18 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
         args.emplace_back(u8(params[n]));
     }
     return spl::make_shared<ffmpeg_consumer>(
-        path, boost::join(args, " "), boost::iequals(params.at(0), L"STREAM"), depth);
+        path, boost::join(args, " "), boost::iequals(params.at(0), L"STREAM"), channel_info.depth);
 }
 
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     return spl::make_shared<ffmpeg_consumer>(u8(ptree.get<std::wstring>(L"path", L"")),
                                              u8(ptree.get<std::wstring>(L"args", L"")),
                                              ptree.get(L"realtime", false),
-                                             depth);
+                                             channel_info.depth);
 }
 }} // namespace caspar::ffmpeg

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -520,14 +520,14 @@ struct ffmpeg_consumer : public core::frame_consumer
 
     // frame consumer
 
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         if (frame_thread_.joinable()) {
             CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Cannot reinitialize ffmpeg-consumer."));
         }
 
         format_desc_   = format_desc;
-        channel_index_ = channel_index;
+        channel_index_ = channel_info.index;
 
         graph_->set_text(print());
 

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.h
@@ -36,11 +36,11 @@ namespace caspar { namespace ffmpeg {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth);
+                              const core::channel_info&                                channel_info);
 
 }} // namespace caspar::ffmpeg

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -71,7 +71,7 @@ struct image_consumer : public core::frame_consumer
     {
     }
 
-    void initialize(const core::video_format_desc& /*format_desc*/, int /*channel_index*/) override {}
+    void initialize(const core::video_format_desc& /*format_desc*/, const core::channel_info& channel_info, int port_index) override {}
 
     std::future<bool> send(core::video_field field, core::const_frame frame) override
     {

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -27,6 +27,7 @@
 #include <common/except.h>
 #include <common/future.h>
 
+#include <core/consumer/channel_info.h>
 #include <core/frame/frame.h>
 
 #include <boost/algorithm/string.hpp>
@@ -165,12 +166,12 @@ struct image_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"IMAGE"))
         return core::frame_consumer::empty();
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Image consumer only supports 8-bit color depth."));
 
     std::wstring filename;

--- a/src/modules/image/consumer/image_consumer.h
+++ b/src/modules/image/consumer/image_consumer.h
@@ -35,6 +35,6 @@ namespace caspar { namespace image {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 
 }} // namespace caspar::image

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -27,6 +27,7 @@
 #include <boost/thread/exceptions.hpp>
 #include <chrono>
 #include <condition_variable>
+#include <core/consumer/channel_info.h>
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
 #include <core/mixer/audio/audio_util.h>
@@ -259,12 +260,12 @@ spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                    common::bit_depth                                        depth)
+                    const core::channel_info&                                channel_info)
 {
     if (params.size() < 1 || !boost::iequals(params.at(0), L"NDI"))
         return core::frame_consumer::empty();
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Newtek NDI consumer only supports 8-bit color depth."));
 
     std::wstring name         = get_param(L"NAME", params, L"");
@@ -276,12 +277,12 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                  common::bit_depth                                        depth)
+                                  const core::channel_info&                                channel_info)
 {
     auto name         = ptree.get(L"name", L"");
     bool allow_fields = ptree.get(L"allow-fields", false);
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Newtek NDI consumer only supports 8-bit color depth."));
 
     return spl::make_shared<newtek_ndi_consumer>(name, allow_fields);

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -107,10 +107,10 @@ struct newtek_ndi_consumer : public core::frame_consumer
 
     // frame_consumer
 
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         format_desc_   = format_desc;
-        channel_index_ = channel_index;
+        channel_index_ = channel_info.index;
 
         NDIlib_send_create_t NDI_send_create_desc;
 

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.h
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.h
@@ -37,11 +37,11 @@ spl::shared_ptr<core::frame_consumer>
 create_ndi_consumer(const std::vector<std::wstring>&                         params,
                     const core::video_format_repository&                     format_repository,
                     const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                    common::bit_depth                                        depth);
+                    const core::channel_info&                                channel_info);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_ndi_consumer(const boost::property_tree::wptree&                      ptree,
                                   const core::video_format_repository&                     format_repository,
                                   const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                  common::bit_depth                                        depth);
+                                  const core::channel_info&                                channel_info);
 
 }} // namespace caspar::newtek

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -400,7 +400,7 @@ struct oal_consumer : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"AUDIO"))
         return core::frame_consumer::empty();
@@ -412,7 +412,7 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     return spl::make_shared<oal_consumer>();
 }

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -32,6 +32,7 @@
 #include <common/utf.h>
 
 #include <core/consumer/frame_consumer.h>
+#include <core/consumer/channel_info.h>
 #include <core/frame/frame.h>
 #include <core/video_format.h>
 
@@ -229,10 +230,10 @@ struct oal_consumer : public core::frame_consumer
 
     // frame consumer
 
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         format_desc_   = format_desc;
-        channel_index_ = channel_index;
+        channel_index_ = channel_info.index;
         graph_->set_text(print());
 
         executor_.begin_invoke([=] {

--- a/src/modules/oal/consumer/oal_consumer.h
+++ b/src/modules/oal/consumer/oal_consumer.h
@@ -35,11 +35,11 @@ namespace caspar { namespace oal {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth);
+                              const core::channel_info&                                channel_info);
 
 }} // namespace caspar::oal

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -34,6 +34,7 @@
 #include <common/timer.h>
 #include <common/utf.h>
 
+#include <core/consumer/channel_info.h>
 #include <core/consumer/frame_consumer.h>
 #include <core/frame/frame.h>
 #include <core/frame/geometry.h>
@@ -609,7 +610,7 @@ struct screen_consumer_proxy : public core::frame_consumer
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth)
+                                                      const core::channel_info& channel_info)
 {
     if (params.empty() || !boost::iequals(params.at(0), L"SCREEN")) {
         return core::frame_consumer::empty();
@@ -617,7 +618,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 
     configuration config;
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Screen consumer only supports 8-bit color depth."));
 
     if (params.size() > 1) {
@@ -662,11 +663,11 @@ spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth)
+                              const core::channel_info&                                channel_info)
 {
     configuration config;
 
-    if (depth != common::bit_depth::bit8)
+    if (channel_info.depth != common::bit_depth::bit8)
         CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info("Screen consumer only supports 8-bit color depth."));
 
     config.name          = ptree.get(L"name", config.name);

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -577,10 +577,10 @@ struct screen_consumer_proxy : public core::frame_consumer
 
     // frame_consumer
 
-    void initialize(const core::video_format_desc& format_desc, int channel_index) override
+    void initialize(const core::video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         consumer_.reset();
-        consumer_ = std::make_unique<screen_consumer>(config_, format_desc, channel_index);
+        consumer_ = std::make_unique<screen_consumer>(config_, format_desc, channel_info.index);
     }
 
     std::future<bool> send(core::video_field field, core::const_frame frame) override

--- a/src/modules/screen/consumer/screen_consumer.h
+++ b/src/modules/screen/consumer/screen_consumer.h
@@ -34,11 +34,11 @@ namespace caspar { namespace screen {
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                                                      common::bit_depth                                        depth);
+                                                      const core::channel_info& channel_info);
 spl::shared_ptr<core::frame_consumer>
 create_preconfigured_consumer(const boost::property_tree::wptree&                      ptree,
                               const core::video_format_repository&                     format_repository,
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
-                              common::bit_depth                                        depth);
+                              const core::channel_info&                                channel_info);
 
 }} // namespace caspar::screen

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -480,10 +480,11 @@ std::wstring add_command(command_context& ctx)
     core::diagnostics::scoped_call_context save;
     core::diagnostics::call_context::for_thread().video_channel = ctx.channel_index + 1;
 
-    auto consumer = ctx.static_context->consumer_registry->create_consumer(ctx.parameters,
-                                                                           ctx.static_context->format_repository,
-                                                                           get_channels(ctx),
-                                                                           ctx.channel.raw_channel->mixer().depth());
+    auto consumer =
+        ctx.static_context->consumer_registry->create_consumer(ctx.parameters,
+                                                               ctx.static_context->format_repository,
+                                                               get_channels(ctx),
+                                                               ctx.channel.raw_channel->get_consumer_channel_info());
     ctx.channel.raw_channel->output().add(ctx.layer_index(consumer->index()), consumer);
 
     return L"202 ADD OK\r\n";
@@ -504,7 +505,7 @@ std::wstring remove_command(command_context& ctx)
                     ->create_consumer(ctx.parameters,
                                       ctx.static_context->format_repository,
                                       get_channels(ctx),
-                                      ctx.channel.raw_channel->mixer().depth())
+                                      ctx.channel.raw_channel->get_consumer_channel_info())
                     ->index();
     }
 
@@ -523,8 +524,11 @@ std::wstring print_command(command_context& ctx)
         std::copy(std::cbegin(ctx.parameters), std::cend(ctx.parameters), params.begin() + 1);
     }
 
-    ctx.channel.raw_channel->output().add(ctx.static_context->consumer_registry->create_consumer(
-        params, ctx.static_context->format_repository, get_channels(ctx), ctx.channel.raw_channel->mixer().depth()));
+    ctx.channel.raw_channel->output().add(
+        ctx.static_context->consumer_registry->create_consumer(params,
+                                                               ctx.static_context->format_repository,
+                                                               get_channels(ctx),
+                                                               ctx.channel.raw_channel->get_consumer_channel_info()));
 
     return L"202 PRINT OK\r\n";
 }
@@ -1389,8 +1393,11 @@ std::wstring channel_grid_command(command_context& ctx)
     params.emplace_back(L"0");
     params.emplace_back(L"NAME");
     params.emplace_back(L"Channel Grid Window");
-    auto screen = ctx.static_context->consumer_registry->create_consumer(
-        params, ctx.static_context->format_repository, get_channels(ctx), ctx.channel.raw_channel->mixer().depth());
+    auto screen =
+        ctx.static_context->consumer_registry->create_consumer(params,
+                                                               ctx.static_context->format_repository,
+                                                               get_channels(ctx),
+                                                               ctx.channel.raw_channel->get_consumer_channel_info());
 
     self.raw_channel->output().add(screen);
 

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -99,12 +99,12 @@
                     <width>0 (width of the region to copy. 0 means no-limit)</width>
                     <height>0 (height of the region to copy. 0 means no-limit)</height>
                 </subregion>
+                <color-space> [bt601|bt709|bt2020](default is to follow channel)</color-space>
                 <hdr-metadata>
                     <max-cll>1000 [1..65535]</max-cll>
                     <max-fall>1000 [50..65535]</max-fall>
                     <min-dml>0.005 [0.0001-6.5535]</min-dml>
                     <max-dml>1000 [1-65535]</max-dml>
-                    <default-color-space>bt709 [bt601|bt709|bt2020]</default-color-space>
                 </hdr-metadata>
 
                 <wait-for-reference>auto [auto|enable|disable]</wait-for-reference>

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -280,11 +280,13 @@ struct server::impl
             auto weak_client = std::weak_ptr<osc::client>(osc_client_);
             auto channel_id  = static_cast<int>(channels_->size() + 1);
             auto depth       = color_depth == 16 ? common::bit_depth::bit16 : common::bit_depth::bit8;
-            auto color_space = color_space_str == L"bt2020" ? core::color_space::bt2020 : core::color_space::bt709;
+            auto default_color_space =
+                color_space_str == L"bt2020" ? core::color_space::bt2020 : core::color_space::bt709;
             auto channel =
                 spl::make_shared<video_channel>(channel_id,
                                                 format_desc,
-                                                accelerator_.create_image_mixer(channel_id, depth, color_space),
+                                                default_color_space,
+                                                accelerator_.create_image_mixer(channel_id, depth),
                                                 [channel_id, weak_client](core::monitor::state channel_state) {
                                                     monitor::state state;
                                                     state[""]["channel"][channel_id] = channel_state;

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -366,7 +366,7 @@ struct server::impl
                                                                     xml_consumer.second,
                                                                     video_format_repository_,
                                                                     channels_vec,
-                                                                    channel.raw_channel->mixer().depth()));
+                                                                    channel.raw_channel->get_consumer_channel_info()));
                     } catch (...) {
                         CASPAR_LOG_CURRENT_EXCEPTION();
                     }


### PR DESCRIPTION
This is a refactoring, to clarify the flow of the `color_space` config field.

The value was being passed into the image_mixer, which would then mark the produced frames as being `rgb + rec2020` (or similar), which is weird as they are actually just rgb frames and some consumers would then output them as rec2020.

Instead, this is now a field passed into the consumer constructors, alongside bit_depth, as a `default_color_space`. 
The decklink consumer will then use this, or the color-space value that can be set in its own config.

Functionally, this should have no impact, it is just a change of how the property gets from the channel config xml into the decklink and other consumers.
A bonus effect of this, is that the decklink can now preroll with the correct color_space without needing it to be set in its config too.

I expect to add more properties to this object 'soon'. I want to be able to do 16bit SDR, so the current 'hdr' guards checking the bit-depth will need to change to something else which can also be defined here.