### PR TITLE
Fixes #1616

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -99,4 +99,8 @@ source_group(sources\\producer\\route producer/route/*)
 source_group(sources\\producer\\transition producer/transition/*)
 source_group(sources\\producer\\separated producer/separated/*)
 
-target_link_libraries(core common)
+target_link_libraries(
+	core
+	${SFML_LIBRARIES}
+	common
+)

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -82,7 +82,6 @@ else ()
 	target_link_libraries(casparcg
 		${Boost_LIBRARIES}
 		${TBB_LIBRARIES}
-		${SFML_LIBRARIES}
 		${GLEW_LIBRARIES}
 		OpenGL::GL
 		${X11_LIBRARIES}


### PR DESCRIPTION
This PR fixes issue #1616.

libcore requires the SFML librearies, not the main file.

I try to compile the project under Gentoo Linux which as a rolling release uses a rather recent toolchain. It is not sufficient to link all necessary libraries into the main binary in a single batch, but each library must link its required libraries recursively. Newer versions of GCC seems to be less forgiving.

Note, I am a Linux only user. Hence I do not know if we need another MSVC-condition here.