### PR TITLE
Transition improvements and additions

### DIFF
--- a/src/core/frame/draw_frame.cpp
+++ b/src/core/frame/draw_frame.cpp
@@ -164,6 +164,7 @@ draw_frame draw_frame::pop(const draw_frame& frame)
 draw_frame draw_frame::still(draw_frame frame)
 {
     frame.transform().audio_transform.volume = 0.0;
+    frame.transform().audio_transform.immediate_volume = true;
     return frame;
 }
 

--- a/src/core/frame/frame.cpp
+++ b/src/core/frame/frame.cpp
@@ -84,6 +84,7 @@ array<std::uint8_t>&       mutable_frame::image_data(std::size_t index) { return
 array<std::int32_t>&       mutable_frame::audio_data() { return impl_->audio_data_; }
 std::size_t                mutable_frame::width() const { return impl_->desc_.planes.at(0).width; }
 std::size_t                mutable_frame::height() const { return impl_->desc_.planes.at(0).height; }
+const void*                mutable_frame::stream_tag() const { return impl_->tag_; }
 const frame_geometry&      mutable_frame::geometry() const { return impl_->geometry_; }
 frame_geometry&            mutable_frame::geometry() { return impl_->geometry_; }
 
@@ -92,6 +93,7 @@ struct const_frame::impl
     std::vector<array<const std::uint8_t>> image_data_;
     array<const std::int32_t>              audio_data_;
     core::pixel_format_desc                desc_     = core::pixel_format_desc(pixel_format::invalid);
+    const void*                            tag_ = nullptr;
     frame_geometry                         geometry_ = frame_geometry::get_default();
     std::any                               opaque_;
 
@@ -124,6 +126,7 @@ struct const_frame::impl
                       std::make_move_iterator(other.impl_->image_data_.end()))
         , audio_data_(std::move(other.impl_->audio_data_))
         , desc_(std::move(other.impl_->desc_))
+        , tag_(other.stream_tag())
         , geometry_(std::move(other.impl_->geometry_))
     {
         if (desc_.planes.size() != image_data_.size() && !other.impl_->commit_) {
@@ -174,6 +177,12 @@ const array<const std::int32_t>& const_frame::audio_data() const { return impl_-
 std::size_t                      const_frame::width() const { return impl_->width(); }
 std::size_t                      const_frame::height() const { return impl_->height(); }
 std::size_t                      const_frame::size() const { return impl_->size(); }
+const void*                      const_frame::stream_tag() const { return impl_->tag_; }
+const_frame                      const_frame::with_tag(const void* new_tag) const {
+    const_frame copy(*this);
+    copy.impl_->tag_ = new_tag;
+    return copy;
+}
 const frame_geometry&            const_frame::geometry() const { return impl_->geometry_; }
 const std::any&                  const_frame::opaque() const { return impl_->opaque_; }
 const_frame::operator bool() const { return impl_ != nullptr && impl_->desc_.format != core::pixel_format::invalid; }

--- a/src/core/frame/frame.h
+++ b/src/core/frame/frame.h
@@ -45,6 +45,8 @@ class mutable_frame final
 
     std::size_t height() const;
 
+    const void* stream_tag() const;
+
     class frame_geometry&       geometry();
     const class frame_geometry& geometry() const;
 
@@ -78,6 +80,9 @@ class const_frame final
     std::size_t height() const;
 
     std::size_t size() const;
+
+    const void* stream_tag() const;
+    const_frame with_tag(const void* new_tag) const;
 
     const std::any& opaque() const;
 

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -116,6 +116,7 @@ bool operator!=(const image_transform& lhs, const image_transform& rhs);
 struct audio_transform final
 {
     double volume = 1.0;
+    bool   immediate_volume = false;  // When false, intra-frame samples are ramped from previous volume in audio mixer
 
     audio_transform& operator*=(const audio_transform& other);
     audio_transform  operator*(const audio_transform& other) const;

--- a/src/core/mixer/audio/audio_mixer.cpp
+++ b/src/core/mixer/audio/audio_mixer.cpp
@@ -42,6 +42,7 @@ using namespace boost::container;
 
 struct audio_item
 {
+    const void*          tag = nullptr;
     audio_transform      transform;
     array<const int32_t> samples;
 };
@@ -50,11 +51,13 @@ using audio_buffer_ps = std::vector<double>;
 
 struct audio_mixer::impl
 {
-    monitor::state                      state_;
-    std::stack<core::audio_transform>   transform_stack_;
-    std::vector<audio_item>             items_;
-    std::atomic<float>                  master_volume_{1.0f};
-    spl::shared_ptr<diagnostics::graph> graph_;
+    monitor::state                              state_;
+    std::stack<core::audio_transform>           transform_stack_;
+    std::vector<audio_item>                     items_;
+    std::map<const void*, std::vector<int32_t>> audio_streams_;
+    video_format_desc                           format_desc_;
+    std::atomic<float>                          master_volume_{1.0f};
+    spl::shared_ptr<diagnostics::graph>         graph_;
 
     impl(const impl&)            = delete;
     impl& operator=(const impl&) = delete;
@@ -77,11 +80,7 @@ struct audio_mixer::impl
         if (transform_stack_.top().volume < 0.002 || !frame.audio_data())
             return;
 
-        audio_item item;
-        item.transform = transform_stack_.top();
-        item.samples   = frame.audio_data();
-
-        items_.push_back(std::move(item));
+        items_.push_back(std::move(audio_item{frame.stream_tag(), transform_stack_.top(), frame.audio_data()}));
     }
 
     void pop() { transform_stack_.pop(); }
@@ -92,24 +91,66 @@ struct audio_mixer::impl
 
     array<const int32_t> mix(const video_format_desc& format_desc, int nb_samples)
     {
+        if (format_desc_ != format_desc) {
+            audio_streams_.clear();
+            format_desc_ = format_desc;
+        }
+
         auto channels = format_desc.audio_channels;
         auto items    = std::move(items_);
-        auto result   = std::vector<int32_t>(nb_samples * channels, 0);
+        auto result   = std::vector<int32_t>(size_t(nb_samples) * channels, 0);
 
-        auto mixed = std::vector<double>(nb_samples * channels, 0.0f);
+        auto mixed = std::vector<double>(size_t(nb_samples) * channels, 0.0f);
+
+        std::map<const void*, std::vector<int32_t>> next_audio_streams;
 
         for (auto& item : items) {
-            auto ptr  = item.samples.data();
-            auto size = result.size();
-            for (auto n = 0; n < size; ++n) {
-                if (n < item.samples.size()) {
-                    mixed[n] = static_cast<double>(ptr[n]) * item.transform.volume + mixed[n];
+            auto ptr       = item.samples.data();
+            auto item_size = item.samples.size();
+            auto dst_size  = result.size();
+
+            size_t last_size = 0;
+            const int32_t* last_ptr = nullptr;
+            bool fix_1001 = (1001 == format_desc.framerate.denominator());
+            if (fix_1001) {
+                auto audio_stream = audio_streams_.find(item.tag);
+                if (audio_stream != audio_streams_.end()) {
+                    last_size = audio_stream->second.size();
+                    last_ptr = audio_stream->second.data();
+                } else if (nullptr != item.tag) {
+                    // Insert a sample of silence at startup
+                    // Covers the startup case where eg dst_size is 801 and item_size is 800
+                    // The sample of silence will be output before any valid audio data from the source
+                    last_size = channels;
+                    std::vector<int32_t> buf(last_size);
+                    std::memset(buf.data(), 0, last_size * sizeof(int32_t));
+                    last_ptr = buf.data();
+                }
+            }
+
+            for (auto n = 0; n < dst_size; ++n) {
+                if (last_ptr && n < last_size) {
+                    mixed[n] = static_cast<double>(last_ptr[n]) * item.transform.volume + mixed[n];
+                } else if (n < last_size + item_size) {
+                    mixed[n] = static_cast<double>(ptr[n - last_size]) * item.transform.volume + mixed[n];
                 } else {
-                    auto offset = (item.samples.size()) - (channels - (n % channels));
+                    auto offset = int(item_size) - (channels - (n % channels));
                     mixed[n]    = static_cast<double>(ptr[offset]) * item.transform.volume + mixed[n];
                 }
             }
+
+            if (fix_1001 && item.tag) {
+                if (item_size + last_size > dst_size) {
+                    auto                 buf_size = item_size + last_size - dst_size;
+                    std::vector<int32_t> buf(buf_size);
+                    std::memcpy(buf.data(), item.samples.data() + dst_size - last_size, buf_size * sizeof(int32_t));
+                    next_audio_streams[item.tag] = std::move(buf);
+                } else
+                    next_audio_streams[item.tag] = std::vector<int32_t>();
+            }
         }
+
+        audio_streams_ = std::move(next_audio_streams);
 
         auto master_volume = master_volume_.load();
         for (auto n = 0; n < mixed.size(); ++n) {

--- a/src/core/producer/transition/transition_producer.h
+++ b/src/core/producer/transition/transition_producer.h
@@ -37,6 +37,9 @@ enum class transition_type
     push,
     slide,
     wipe,
+    fadecut,
+    cutfade,
+    vfade,
     count
 };
 

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -236,7 +236,7 @@ struct oal_consumer : public core::frame_consumer
         graph_->set_text(print());
 
         executor_.begin_invoke([=] {
-            duration_ = format_desc_.audio_cadence[0];
+            duration_ = *std::min_element(format_desc_.audio_cadence.begin(), format_desc_.audio_cadence.end());
             buffers_.resize(8);
             alGenBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
             alGenSources(1, &source_);


### PR DESCRIPTION
Improve transitions and add fadecut, cutfade and vfade transitions
-depends on https://github.com/CasparCG/server/pull/1615
-improved auto_play_delta for all transitions so that the last frame of a producer is displayed on the last visible frame of the transition
-modified audio mixer to track previous volumes for a producer and to interpolate volume changes across all samples in the frame
-introduced frame immediate_volume (defaults to false) so that audio volume changes are always ramped over the range of samples in a frame unless a transition or layer(still) needs to prevent volume ramping within a frame.