### PR TITLE
Compile with ffmpeg master

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -361,11 +361,20 @@ struct Decoder
                 frame->height      = video->GetHeight();
                 frame->data[0]     = reinterpret_cast<uint8_t*>(video_bytes);
                 frame->linesize[0] = video->GetRowBytes();
-                frame->key_frame   = 1;
+#if LIBAVCODEC_VERSION_MAJOR < 61
+                frame->key_frame = 1;
+#else
+                frame->flags |= AV_FRAME_FLAG_KEY;
+#endif
             }
 
+#if LIBAVCODEC_VERSION_MAJOR < 61
             frame->interlaced_frame = mode->GetFieldDominance() != bmdProgressiveFrame;
             frame->top_field_first  = mode->GetFieldDominance() == bmdUpperFieldFirst ? 1 : 0;
+#else
+            frame->flags |= mode->GetFieldDominance() != bmdProgressiveFrame ? AV_FRAME_FLAG_INTERLACED : 0;
+            frame->flags |= mode->GetFieldDominance() == bmdUpperFieldFirst ? AV_FRAME_FLAG_TOP_FIELD_FIRST : 0;
+#endif
 
             return frame;
         }

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -193,10 +193,18 @@ class Decoder
                     } else {
                         FF_RET(ret, "avcodec_receive_frame");
 
+                        // TODO: Maybe Fixed in:
+                        // https://github.com/FFmpeg/FFmpeg/commit/33203a08e0a26598cb103508327a1dc184b27bc6
                         // NOTE This is a workaround for DVCPRO HD.
+#if LIBAVCODEC_VERSION_MAJOR < 61
                         if (av_frame->width > 1024 && av_frame->interlaced_frame) {
                             av_frame->top_field_first = 1;
                         }
+#else
+                        if (av_frame->width > 1024 && (av_frame->flags & AV_FRAME_FLAG_INTERLACED)) {
+                            av_frame->flags |= AV_FRAME_FLAG_TOP_FIELD_FIRST;
+                        }
+#endif
 
                         // TODO (fix) is this always best?
                         av_frame->pts = av_frame->best_effort_timestamp;


### PR DESCRIPTION
ffmpeg master removed a bunch of fields that were deprecated, add `#if` version checks so casparcg compiles with ffmpeg master.

~~I just disabled a workaround for DVCPRO HD, since afaict it was fixed in ffmpeg a while ago. I put it in an `#if` version check so it can still be used for old versions of ffmpeg.~~

I have not verified that it was fixed, so I'm not sure how to proceed here...~~should I figure out how to verify that?~~ should I change the code to apply the workaround to new versions of ffmpeg too? (edit: I just applied the workaround for new versions too)