### PR TITLE
feat: support 'call' commands to consumers ('apply')

### DIFF
--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -51,6 +51,12 @@ class frame_consumer
 
     virtual std::future<bool> send(const core::video_field field, const_frame frame)              = 0;
     virtual void              initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) = 0;
+    virtual std::future<bool> call(const std::vector<std::wstring>& params) const
+    {
+        std::promise<bool> p;
+        p.set_value(false);
+        return p.get_future();
+    }
 
     virtual core::monitor::state state() const = 0;
 

--- a/src/core/consumer/output.cpp
+++ b/src/core/consumer/output.cpp
@@ -82,6 +82,22 @@ struct output::impl
 
     bool remove(const spl::shared_ptr<frame_consumer>& consumer) { return remove(consumer->index()); }
 
+    std::future<bool> call(int index, const std::vector<std::wstring>& params)
+    {
+        std::lock_guard<std::mutex> lock(consumers_mutex_);
+        auto                        it = consumers_.find(index);
+        if (it != consumers_.end()) {
+            try {
+                return it->second->call(params);
+            } catch (...) {
+                CASPAR_LOG_CURRENT_EXCEPTION();
+            }
+        }
+        std::promise<bool> p;
+        p.set_value(false);
+        return p.get_future();
+    }
+
     size_t consumer_count()
     {
         std::lock_guard<std::mutex> lock(consumers_mutex_);
@@ -219,12 +235,16 @@ output::output(const spl::shared_ptr<diagnostics::graph>& graph,
 {
 }
 output::~output() {}
-void   output::add(int index, const spl::shared_ptr<frame_consumer>& consumer) { impl_->add(index, consumer); }
-void   output::add(const spl::shared_ptr<frame_consumer>& consumer) { impl_->add(consumer); }
-bool   output::remove(int index) { return impl_->remove(index); }
-bool   output::remove(const spl::shared_ptr<frame_consumer>& consumer) { return impl_->remove(consumer); }
+void output::add(int index, const spl::shared_ptr<frame_consumer>& consumer) { impl_->add(index, consumer); }
+void output::add(const spl::shared_ptr<frame_consumer>& consumer) { impl_->add(consumer); }
+bool output::remove(int index) { return impl_->remove(index); }
+bool output::remove(const spl::shared_ptr<frame_consumer>& consumer) { return impl_->remove(consumer); }
+std::future<bool> output::call(int index, const std::vector<std::wstring>& params)
+{
+    return impl_->call(index, params);
+}
 size_t output::consumer_count() const { return impl_->consumer_count(); }
-void   output::operator()(const const_frame& frame, const const_frame& frame2, const video_format_desc& format_desc)
+void output::operator()(const const_frame& frame, const const_frame& frame2, const video_format_desc& format_desc)
 {
     return (*impl_)(frame, frame2, format_desc);
 }

--- a/src/core/consumer/output.h
+++ b/src/core/consumer/output.h
@@ -54,6 +54,8 @@ class output final
     bool remove(const spl::shared_ptr<frame_consumer>& consumer);
     bool remove(int index);
 
+    std::future<bool> call(int index, const std::vector<std::wstring>& params);
+
     size_t consumer_count() const;
 
     core::monitor::state state() const;


### PR DESCRIPTION
This adds an "APPLY" amcp-command which is the equivalent to CALL, but for consumers. 

This is needed to support pushing data to consumers. For example data to be added as VANC in the decklink consumer