### PR TITLE
amcp: add APPLY command, similar to CALL but for consumers

### DIFF
--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -27,6 +27,7 @@
 #include <common/bit_depth.h>
 #include <common/memory.h>
 
+#include <common/future.h>
 #include <core/video_format.h>
 
 #include <boost/property_tree/ptree_fwd.hpp>
@@ -49,8 +50,10 @@ class frame_consumer
     frame_consumer() {}
     virtual ~frame_consumer() {}
 
-    virtual std::future<bool> send(const core::video_field field, const_frame frame)              = 0;
-    virtual void              initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) = 0;
+    virtual std::future<bool> send(const core::video_field field, const_frame frame) = 0;
+    virtual void
+    initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) = 0;
+    virtual std::future<bool> call(const std::vector<std::wstring>& params) { return caspar::make_ready_future(false); }
 
     virtual core::monitor::state state() const = 0;
 

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -90,10 +90,12 @@ class destroy_consumer_proxy : public frame_consumer
     {
         return consumer_->send(field, std::move(frame));
     }
-    void initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
+    void
+    initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         return consumer_->initialize(format_desc, channel_info, port_index);
     }
+    std::future<bool>    call(const std::vector<std::wstring>& params) override { return consumer_->call(params); }
     std::wstring         print() const override { return consumer_->print(); }
     std::wstring         name() const override { return consumer_->name(); }
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }
@@ -123,11 +125,13 @@ class print_consumer_proxy : public frame_consumer
     {
         return consumer_->send(field, std::move(frame));
     }
-    void initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
+    void
+    initialize(const video_format_desc& format_desc, const core::channel_info& channel_info, int port_index) override
     {
         consumer_->initialize(format_desc, channel_info, port_index);
         CASPAR_LOG(info) << consumer_->print() << L" Initialized.";
     }
+    std::future<bool>    call(const std::vector<std::wstring>& params) override { return consumer_->call(params); }
     std::wstring         print() const override { return consumer_->print(); }
     std::wstring         name() const override { return consumer_->name(); }
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }

--- a/src/core/consumer/output.h
+++ b/src/core/consumer/output.h
@@ -54,6 +54,8 @@ class output final
     bool remove(const spl::shared_ptr<frame_consumer>& consumer);
     bool remove(int index);
 
+    std::future<bool> call(int index, const std::vector<std::wstring>& params);
+
     size_t consumer_count() const;
 
     core::monitor::state state() const;


### PR DESCRIPTION
Add an amcp 'APPLY' command. This allows clients to "call" consumers.

* Useful if you need to apply some kind of state or setting to a single consumer
* Could be used in any consumer to allow clients to on the fly update parameters 
* This is specifically in preparation for pushing VANC data to the decklink consumer from a client
