### PR TITLE
Decklink consumer VANC

### DIFF
--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES
 		consumer/config.h
 		consumer/monitor.cpp
 		consumer/monitor.h
+		consumer/vanc.cpp
+		consumer/vanc.h
 
 		producer/decklink_producer.cpp
 		producer/decklink_producer.h

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
 		consumer/monitor.h
 		consumer/vanc.cpp
 		consumer/vanc.h
+		consumer/vanc_scte104_strategy.cpp
 
 		producer/decklink_producer.cpp
 		producer/decklink_producer.h

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
 		consumer/vanc.cpp
 		consumer/vanc.h
 		consumer/vanc_scte104_strategy.cpp
+		consumer/vanc_op47_strategy.cpp
 
 		producer/decklink_producer.cpp
 		producer/decklink_producer.h

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -57,7 +57,10 @@ port_configuration parse_output_config(const boost::property_tree::wptree&  ptre
 vanc_configuration parse_vanc_config(const boost::property_tree::wptree& vanc_tree)
 {
     vanc_configuration vanc_config;
-    vanc_config.enable = true;
+
+    vanc_config.enable            = true;
+    vanc_config.scte104_line      = vanc_tree.get(L"scte104-line", vanc_config.scte104_line);
+    vanc_config.enable_scte104    = vanc_config.scte104_line > 0;
 
     return vanc_config;
 };

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -59,8 +59,12 @@ vanc_configuration parse_vanc_config(const boost::property_tree::wptree& vanc_tr
     vanc_configuration vanc_config;
 
     vanc_config.enable            = true;
+    vanc_config.op47_line         = vanc_tree.get(L"op47-line", vanc_config.op47_line);
+    vanc_config.op47_line_field2  = vanc_tree.get(L"op47-line-field2", vanc_config.op47_line_field2);
+    vanc_config.enable_op47       = vanc_config.op47_line > 0;
     vanc_config.scte104_line      = vanc_tree.get(L"scte104-line", vanc_config.scte104_line);
     vanc_config.enable_scte104    = vanc_config.scte104_line > 0;
+    vanc_config.op47_dummy_header = vanc_tree.get(L"op47-dummy-header", L"");
 
     return vanc_config;
 };

--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -54,6 +54,14 @@ port_configuration parse_output_config(const boost::property_tree::wptree&  ptre
     return port_config;
 }
 
+vanc_configuration parse_vanc_config(const boost::property_tree::wptree& vanc_tree)
+{
+    vanc_configuration vanc_config;
+    vanc_config.enable = true;
+
+    return vanc_config;
+};
+
 core::color_space get_color_space(const std::wstring& str)
 {
     auto color_space_str = boost::to_lower_copy(str);
@@ -142,6 +150,11 @@ configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
         config.hdr_meta.max_dml  = hdr_metadata->get(L"max-dml", config.hdr_meta.max_dml);
         config.hdr_meta.max_fall = hdr_metadata->get(L"max-fall", config.hdr_meta.max_fall);
         config.hdr_meta.max_cll  = hdr_metadata->get(L"max-cll", config.hdr_meta.max_cll);
+    }
+
+    auto vanc = ptree.get_child_optional(L"vanc");
+    if (vanc) {
+        config.vanc = parse_vanc_config(vanc.get());
     }
 
     return config;

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -48,6 +48,11 @@ struct port_configuration
     }
 };
 
+struct vanc_configuration
+{
+    bool enable = false;
+};
+
 struct hdr_meta_configuration
 {
     float min_dml  = 0.005f;
@@ -101,6 +106,8 @@ struct configuration
 
     core::color_space      color_space = core::color_space::bt709;
     hdr_meta_configuration hdr_meta;
+
+    vanc_configuration vanc;
 
     [[nodiscard]] int buffer_depth() const
     {

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -50,9 +50,13 @@ struct port_configuration
 
 struct vanc_configuration
 {
-    bool         enable         = false;
-    bool         enable_scte104 = false;
-    uint8_t      scte104_line   = 0;
+    bool         enable           = false;
+    bool         enable_op47      = false;
+    bool         enable_scte104   = false;
+    uint8_t      op47_line        = 0;
+    uint8_t      op47_line_field2 = 0;
+    uint8_t      scte104_line     = 0;
+    std::wstring op47_dummy_header;
 };
 
 struct hdr_meta_configuration

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -50,7 +50,9 @@ struct port_configuration
 
 struct vanc_configuration
 {
-    bool enable = false;
+    bool         enable         = false;
+    bool         enable_scte104 = false;
+    uint8_t      scte104_line   = 0;
 };
 
 struct hdr_meta_configuration

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -1058,6 +1058,16 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                     CASPAR_LOG(error) << print() << L" Failed to add ancillary packet.";
                 }
             }
+
+            bool isInterlaced = mode_->GetFieldDominance() != bmdProgressiveFrame;
+            if (isInterlaced) {
+                auto field2_packets = vanc_->pop_packets(true);
+                for (auto& packet : field2_packets) {
+                    if (FAILED(ancillary_packets->AttachPacket(get_raw(packet)))) {
+                        CASPAR_LOG(error) << print() << L" Failed to add ancillary packet.";
+                    }
+                }
+            }
         }
         if (FAILED(output_->ScheduleVideoFrame(
                 get_raw(fill_frame), display_time, decklink_format_desc_.duration, decklink_format_desc_.time_scale))) {

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -27,6 +27,7 @@
 #include "decklink_consumer.h"
 #include "format_strategy.h"
 #include "monitor.h"
+#include "vanc.h"
 
 #include "../util/util.h"
 
@@ -227,16 +228,17 @@ class decklink_frame
     : public IDeckLinkVideoFrame
     , public IDeckLinkVideoFrameMetadataExtensions
 {
-    core::video_format_desc format_desc_;
-    std::shared_ptr<void>   data_;
-    std::atomic<int>        ref_count_{0};
-    int                     nb_samples_;
-    const bool              hdr_;
-    core::color_space       color_space_;
-    hdr_meta_configuration  hdr_metadata_;
-    BMDFrameFlags           flags_;
-    BMDPixelFormat          pix_fmt_;
-    int                     row_bytes_;
+    core::video_format_desc                      format_desc_;
+    std::shared_ptr<void>                        data_;
+    std::atomic<int>                             ref_count_{0};
+    int                                          nb_samples_;
+    const bool                                   hdr_;
+    core::color_space                            color_space_;
+    hdr_meta_configuration                       hdr_metadata_;
+    BMDFrameFlags                                flags_;
+    BMDPixelFormat                               pix_fmt_;
+    int                                          row_bytes_;
+    com_ptr<IDeckLinkVideoFrameAncillaryPackets> vanc_;
 
   public:
     decklink_frame(std::shared_ptr<void>         data,
@@ -245,6 +247,7 @@ class decklink_frame
                    bool                          hdr,
                    BMDPixelFormat                pix_fmt,
                    int                           row_bytes,
+                   bool                          vanc,
                    core::color_space             color_space,
                    const hdr_meta_configuration& hdr_metadata)
         : format_desc_(std::move(format_desc))
@@ -256,6 +259,7 @@ class decklink_frame
         , color_space_(color_space)
         , hdr_metadata_(hdr_metadata)
         , flags_(hdr ? bmdFrameFlagDefault | bmdFrameContainsHDRMetadata : bmdFrameFlagDefault)
+        , vanc_(vanc ? create_ancillary_packets() : nullptr)
     {
     }
 
@@ -277,6 +281,11 @@ class decklink_frame
         } else if (hdr_ && std::memcmp(&iid, &IID_IDeckLinkVideoFrameMetadataExtensions, sizeof(REFIID)) == 0) {
             *ppv = static_cast<IDeckLinkVideoFrameMetadataExtensions*>(this);
             AddRef();
+        } else if (vanc_ && std::memcmp(&iid, &IID_IDeckLinkVideoFrameAncillaryPackets, sizeof(REFIID)) == 0) {
+            auto raw = get_raw(vanc_);
+            raw->AddRef();
+            *ppv = raw;
+
         } else {
             *ppv = nullptr;
             return E_NOINTERFACE;
@@ -567,6 +576,7 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
                                config_.hdr,
                                format_strategy_->get_pixel_format(),
                                format_strategy_->get_row_bytes(decklink_format_desc_.width),
+                               false,
                                config_.color_space,
                                config_.hdr_meta));
         if (FAILED(output_->ScheduleVideoFrame(get_raw(packed_frame),
@@ -637,7 +647,8 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                                                            format_strategy_->get_pixel_format(),
                                                            bmdSupportedVideoModeDefault);
 
-    std::atomic<bool> abort_request_{false};
+    std::atomic<bool>              abort_request_{false};
+    std::shared_ptr<decklink_vanc> vanc_;
 
   public:
     decklink_consumer(const configuration& config, core::video_format_desc channel_format_desc, int channel_index)
@@ -691,6 +702,19 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                                                                                          decklink_format_desc_,
                                                                                          print(),
                                                                                          device_sync_group_));
+        }
+
+        if (config.vanc.enable) {
+            BOOL flag = TRUE;
+            attributes_->GetFlag(BMDDeckLinkVANCRequires10BitYUVVideoFrames, &flag);
+            if (flag) {
+                CASPAR_LOG(warning) << print()
+                                    << L" DeckLink hardware only supports VANC when the active picture and ancillary "
+                                       L"data are both 10-bit YUV pixel format.";
+            } else {
+                CASPAR_LOG(info) << print() << L" DeckLink hardware supports VANC.";
+                vanc_ = create_vanc(config.vanc);
+            }
         }
 
         enable_video();
@@ -813,9 +837,15 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
     void enable_video()
     {
-        if (FAILED(output_->EnableVideoOutput(mode_->GetDisplayMode(),
-                                              device_sync_group_ > 0 ? bmdVideoOutputSynchronizeToPlaybackGroup
-                                                                     : bmdVideoOutputFlagDefault))) {
+        BMDVideoOutputFlags output_flags = bmdVideoOutputFlagDefault;
+        if (device_sync_group_ > 0) {
+            output_flags = static_cast<BMDVideoOutputFlags>(output_flags | bmdVideoOutputSynchronizeToPlaybackGroup);
+        }
+        if (vanc_) {
+            output_flags = static_cast<BMDVideoOutputFlags>(output_flags | bmdVideoOutputVANC);
+        }
+
+        if (FAILED(output_->EnableVideoOutput(mode_->GetDisplayMode(), output_flags))) {
             CASPAR_THROW_EXCEPTION(caspar_exception()
                                    << msg_info(print() + L" Could not enable primary video output."));
         }
@@ -1006,9 +1036,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         audio_scheduled_ += nb_samples; // TODO - what if there are too many/few samples in this frame?
     }
 
-    void schedule_next_video(std::shared_ptr<void> image_data,
-                             int                   nb_samples,
-                             BMDTimeValue          display_time)
+    void schedule_next_video(std::shared_ptr<void> image_data, int nb_samples, BMDTimeValue display_time)
     {
         auto fmt        = format_strategy_->get_pixel_format();
         auto row_bytes  = format_strategy_->get_row_bytes(decklink_format_desc_.width);
@@ -1018,8 +1046,19 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                                                                                     config_.hdr,
                                                                                     fmt,
                                                                                     row_bytes,
+                                                                                    config_.vanc.enable,
                                                                                     config_.color_space,
                                                                                     config_.hdr_meta));
+
+        if (vanc_ && vanc_->has_data()) {
+            auto ancillary_packets = iface_cast<IDeckLinkVideoFrameAncillaryPackets>(fill_frame);
+            auto packets           = vanc_->pop_packets();
+            for (auto& packet : packets) {
+                if (FAILED(ancillary_packets->AttachPacket(get_raw(packet)))) {
+                    CASPAR_LOG(error) << print() << L" Failed to add ancillary packet.";
+                }
+            }
+        }
         if (FAILED(output_->ScheduleVideoFrame(
                 get_raw(fill_frame), display_time, decklink_format_desc_.duration, decklink_format_desc_.time_scale))) {
             CASPAR_LOG(error) << print() << L" Failed to schedule primary video.";
@@ -1046,6 +1085,21 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         buffer_cond_.notify_all();
 
         return !abort_request_;
+    }
+
+    bool call(const std::vector<std::wstring>& params)
+    {
+        try {
+            bool result = vanc_->try_push_data(params);
+            if (!result) {
+                CASPAR_LOG(warning) << print() << L" Unknown command: " << (params.empty() ? L"N/A" : params[0]);
+            }
+
+            return result;
+        } catch (...) {
+            CASPAR_LOG(warning) << print() << L" Failed to apply: " << (params.empty() ? L"N/A" : params[0]);
+        }
+        return false;
     }
 
     [[nodiscard]] std::wstring print() const
@@ -1101,6 +1155,11 @@ struct decklink_consumer_proxy : public core::frame_consumer
     std::future<bool> send(core::video_field field, core::const_frame frame) override
     {
         return executor_.begin_invoke([=] { return consumer_->send(field, frame); });
+    }
+
+    std::future<bool> call(const std::vector<std::wstring>& params) override
+    {
+        return executor_.begin_invoke([=] { return consumer_->call(params); });
     }
 
     [[nodiscard]] std::wstring print() const override

--- a/src/modules/decklink/consumer/vanc.cpp
+++ b/src/modules/decklink/consumer/vanc.cpp
@@ -73,14 +73,16 @@ decklink_vanc::decklink_vanc(const vanc_configuration& config)
     }
 }
 
-std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> decklink_vanc::pop_packets()
+std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> decklink_vanc::pop_packets(bool field2)
 {
     std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> packets;
     for (auto& strategy : strategies_) {
         if (strategy->has_data()) {
             try {
-                packets.push_back(
-                    wrap_raw<com_ptr, IDeckLinkAncillaryPacket>(new decklink_vanc_packet(strategy->pop_packet())));
+                auto packet =
+                    wrap_raw<com_ptr, IDeckLinkAncillaryPacket>(new decklink_vanc_packet(strategy->pop_packet(field2)));
+                if (packet->GetDID() != 0)
+                    packets.push_back(packet);
             } catch (const std::exception& e) {
                 CASPAR_LOG(error) << "Failed to pop " << strategy->get_name() << " VANC packet: " << e.what();
             } catch (...) {

--- a/src/modules/decklink/consumer/vanc.cpp
+++ b/src/modules/decklink/consumer/vanc.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas.andersson@nxtedition.com
+ */
+
+#include "vanc.h"
+#include <boost/lexical_cast.hpp>
+
+namespace caspar { namespace decklink {
+
+class decklink_vanc_packet : public IDeckLinkAncillaryPacket
+{
+    std::atomic<int> ref_count_{0};
+    vanc_packet      pkt_;
+
+  public:
+    explicit decklink_vanc_packet(vanc_packet pkt)
+        : pkt_(pkt)
+    {
+    }
+
+    // IUnknown
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID, LPVOID*) override { return E_NOINTERFACE; }
+    ULONG STDMETHODCALLTYPE   AddRef() override { return ++ref_count_; }
+    ULONG STDMETHODCALLTYPE   Release() override
+    {
+        if (--ref_count_ == 0) {
+            delete this;
+
+            return 0;
+        }
+
+        return ref_count_;
+    }
+
+    // IDeckLinkAncillaryPacket
+    HRESULT STDMETHODCALLTYPE GetBytes(BMDAncillaryPacketFormat format, const void** data, unsigned int* size) override
+    {
+        if (format == bmdAncillaryPacketFormatUInt8) {
+            *data = pkt_.data.data();
+            *size = static_cast<unsigned int>(pkt_.data.size());
+            return S_OK;
+        }
+
+        return E_NOTIMPL;
+    }
+    unsigned char STDMETHODCALLTYPE GetDID(void) override { return pkt_.did; }
+    unsigned char STDMETHODCALLTYPE GetSDID(void) override { return pkt_.sdid; }
+    unsigned int STDMETHODCALLTYPE  GetLineNumber(void) override { return pkt_.line_number; }
+    unsigned char STDMETHODCALLTYPE GetDataStreamIndex(void) override { return 0; }
+};
+
+decklink_vanc::decklink_vanc(const vanc_configuration& config) {}
+
+std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> decklink_vanc::pop_packets()
+{
+    std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> packets;
+    for (auto& strategy : strategies_) {
+        if (strategy->has_data()) {
+            try {
+                packets.push_back(
+                    wrap_raw<com_ptr, IDeckLinkAncillaryPacket>(new decklink_vanc_packet(strategy->pop_packet())));
+            } catch (const std::exception& e) {
+                CASPAR_LOG(error) << "Failed to pop " << strategy->get_name() << " VANC packet: " << e.what();
+            } catch (...) {
+                CASPAR_LOG(error) << "Failed to pop " << strategy->get_name() << " VANC packet.";
+            }
+        }
+    }
+    return packets;
+}
+
+bool decklink_vanc::has_data() const
+{
+    return std::any_of(strategies_.begin(), strategies_.end(), [](auto& strategy) { return strategy->has_data(); });
+}
+
+bool decklink_vanc::try_push_data(const std::vector<std::wstring>& params)
+{
+    if (params.size() < 2) {
+        CASPAR_LOG(error) << " Not enough parameters to apply VANC data.";
+        return false;
+    }
+
+    for (auto& strategy : strategies_) {
+        if (boost::iequals(params.at(0), strategy->get_name())) {
+            return strategy->try_push_data(params);
+        }
+    }
+    return false;
+}
+
+std::shared_ptr<decklink_vanc> create_vanc(const vanc_configuration& config)
+{
+    return std::make_shared<decklink_vanc>(config);
+}
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/vanc.cpp
+++ b/src/modules/decklink/consumer/vanc.cpp
@@ -71,6 +71,10 @@ decklink_vanc::decklink_vanc(const vanc_configuration& config)
     if (config.enable_scte104) {
         strategies_.push_back(create_scte104_strategy(config.scte104_line));
     }
+    if (config.enable_op47) {
+        strategies_.push_back(
+            create_op47_strategy(config.op47_line, config.op47_line_field2, config.op47_dummy_header));
+    }
 }
 
 std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> decklink_vanc::pop_packets(bool field2)

--- a/src/modules/decklink/consumer/vanc.cpp
+++ b/src/modules/decklink/consumer/vanc.cpp
@@ -66,7 +66,12 @@ class decklink_vanc_packet : public IDeckLinkAncillaryPacket
     unsigned char STDMETHODCALLTYPE GetDataStreamIndex(void) override { return 0; }
 };
 
-decklink_vanc::decklink_vanc(const vanc_configuration& config) {}
+decklink_vanc::decklink_vanc(const vanc_configuration& config)
+{
+    if (config.enable_scte104) {
+        strategies_.push_back(create_scte104_strategy(config.scte104_line));
+    }
+}
 
 std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> decklink_vanc::pop_packets()
 {

--- a/src/modules/decklink/consumer/vanc.h
+++ b/src/modules/decklink/consumer/vanc.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas.andersson@nxtedition.com
+ */
+
+#pragma once
+#include "../decklink_api.h"
+#include "config.h"
+#include <common/memory.h>
+
+namespace caspar { namespace decklink {
+
+struct vanc_packet
+{
+    uint8_t              did;
+    uint8_t              sdid;
+    uint32_t             line_number;
+    std::vector<uint8_t> data;
+};
+
+class decklink_vanc_strategy
+{
+  public:
+    virtual ~decklink_vanc_strategy() noexcept = default;
+
+    virtual bool                has_data() const                                       = 0;
+    virtual vanc_packet         pop_packet()                                           = 0;
+    virtual bool                try_push_data(const std::vector<std::wstring>& params) = 0;
+    virtual const std::wstring& get_name() const                                       = 0;
+};
+
+class decklink_vanc
+{
+    std::vector<std::shared_ptr<decklink_vanc_strategy>> strategies_;
+
+  public:
+    explicit decklink_vanc(const vanc_configuration& config);
+    bool                                                             has_data() const;
+    std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> pop_packets();
+    bool try_push_data(const std::vector<std::wstring>& params);
+};
+
+std::shared_ptr<decklink_vanc> create_vanc(const vanc_configuration& config);
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/vanc.h
+++ b/src/modules/decklink/consumer/vanc.h
@@ -40,7 +40,7 @@ class decklink_vanc_strategy
     virtual ~decklink_vanc_strategy() noexcept = default;
 
     virtual bool                has_data() const                                       = 0;
-    virtual vanc_packet         pop_packet()                                           = 0;
+    virtual vanc_packet         pop_packet(bool field2)                                = 0;
     virtual bool                try_push_data(const std::vector<std::wstring>& params) = 0;
     virtual const std::wstring& get_name() const                                       = 0;
 };
@@ -52,7 +52,7 @@ class decklink_vanc
   public:
     explicit decklink_vanc(const vanc_configuration& config);
     bool                                                             has_data() const;
-    std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> pop_packets();
+    std::vector<caspar::decklink::com_ptr<IDeckLinkAncillaryPacket>> pop_packets(bool field2 = false);
     bool try_push_data(const std::vector<std::wstring>& params);
 };
 

--- a/src/modules/decklink/consumer/vanc.h
+++ b/src/modules/decklink/consumer/vanc.h
@@ -56,6 +56,8 @@ class decklink_vanc
     bool try_push_data(const std::vector<std::wstring>& params);
 };
 
+std::shared_ptr<decklink_vanc_strategy>
+create_op47_strategy(uint8_t line_number, uint8_t line_number_2, const std::wstring& dummy_header);
 std::shared_ptr<decklink_vanc_strategy> create_scte104_strategy(uint8_t line_number);
 
 std::shared_ptr<decklink_vanc> create_vanc(const vanc_configuration& config);

--- a/src/modules/decklink/consumer/vanc.h
+++ b/src/modules/decklink/consumer/vanc.h
@@ -56,5 +56,7 @@ class decklink_vanc
     bool try_push_data(const std::vector<std::wstring>& params);
 };
 
+std::shared_ptr<decklink_vanc_strategy> create_scte104_strategy(uint8_t line_number);
+
 std::shared_ptr<decklink_vanc> create_vanc(const vanc_configuration& config);
 }} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/vanc_op47_strategy.cpp
+++ b/src/modules/decklink/consumer/vanc_op47_strategy.cpp
@@ -1,0 +1,137 @@
+#include "vanc.h"
+
+#include <locale>
+
+#include <boost/lexical_cast.hpp>
+#include <common/base64.h>
+#include <common/param.h>
+#include <common/ptree.h>
+#include <mutex>
+#include <numeric>
+#include <queue>
+#include <vector>
+
+namespace caspar { namespace decklink {
+
+const uint8_t OP47_DID  = 0x43;
+const uint8_t OP47_SDID = 0x02;
+
+class vanc_op47_strategy : public decklink_vanc_strategy
+{
+  private:
+    static const std::wstring Name;
+
+    mutable std::mutex mutex_;
+    uint8_t            line_number_;
+    uint8_t            line_number_2_;
+    uint8_t            sd_line_;
+    uint16_t           counter_;
+
+    std::vector<uint8_t>             dummy_header_;
+    std::queue<std::vector<uint8_t>> packets_;
+
+  public:
+    vanc_op47_strategy(uint8_t line_number, uint8_t line_number_2, const std::wstring& dummy_header)
+        : line_number_(line_number)
+        , line_number_2_(line_number_2)
+        , sd_line_(21)
+        , counter_(1)
+        , dummy_header_(dummy_header.empty() ? std::vector<uint8_t>() : base64_decode(dummy_header))
+    {
+    }
+
+    virtual bool has_data() const override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return !packets_.empty() || !dummy_header_.empty();
+    }
+    virtual vanc_packet pop_packet(bool field2) override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (field2 && line_number_2_ == 0) {
+            return {0, 0, 0, {}};
+        }
+
+        if (packets_.empty()) {
+            return {OP47_DID, OP47_SDID, field2 ? line_number_2_ : line_number_, sdp_encode(dummy_header_)};
+        }
+        auto packet = packets_.front();
+        packets_.pop();
+
+        return {OP47_DID, OP47_SDID, field2 ? line_number_2_ : line_number_, packet};
+    }
+
+    virtual bool try_push_data(const std::vector<std::wstring>& params) override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        try {
+            for (size_t index = 1; index < params.size(); ++index) {
+                packets_.push(sdp_encode(base64_decode(params.at(index))));
+            }
+        } catch (const boost::bad_lexical_cast& e) {
+            CASPAR_LOG(error) << "Failed to parse OP47 parameters: " << e.what();
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual const std::wstring& get_name() const override { return vanc_op47_strategy::Name; }
+
+  private:
+    std::vector<uint8_t> sdp_encode(const std::vector<uint8_t>& packet)
+    {
+        if (packet.size() != 45) {
+            throw std::runtime_error("Invalid packet size for OP47: " + std::to_string(packet.size()));
+        }
+
+        // The following is based on the specification "Free TV Australia Operational Practice OP- 47"
+
+        std::vector<uint8_t> result(103);
+        result[0] = 0x51;                                // identifier
+        result[1] = 0x15;                                // identifier
+        result[2] = static_cast<uint8_t>(result.size()); // size of the packet
+        result[3] = 0x02;                                // format-code
+
+        result[4] = sd_line_ | 0xE0; // VBI packet descriptor (odd field)
+        result[5] = sd_line_ | 0x60; // VBI packet descriptor (even field)
+        result[6] = 0;               // VBI packet descriptor (not used)
+        result[7] = 0;               // VBI packet descriptor (not used)
+        result[8] = 0;               // VBI packet descriptor (not used)
+
+        memcpy(result.data() + 9, packet.data(), packet.size());
+        memcpy(result.data() + 9 + packet.size(), packet.data(), packet.size());
+        result[99]  = 0x74;                     // footer id
+        result[100] = (counter_ & 0xFF00) >> 8; // footer sequence counter
+        result[101] = counter_ & 0x00FF;        // footer sequence counter
+        result[102] = 0x0;                      // SPD checksum, will be set when calculated
+
+        auto sum    = accumulate(result.begin(), result.end(), (uint8_t)0);
+        result[102] = ~sum + 1;
+
+        counter_++; // this is rolling over at 65535 by design
+
+        return result;
+    }
+
+    std::vector<uint8_t> base64_decode(const std::wstring& encoded)
+    {
+        std::vector<char> buffer(encoded.size());
+        std::use_facet<std::ctype<wchar_t>>(std::locale())
+            .narrow(encoded.data(), encoded.data() + encoded.size(), '?', buffer.data());
+        auto str = std::string(buffer.data(), buffer.size());
+        return caspar::from_base64(str);
+    }
+};
+
+const std::wstring vanc_op47_strategy::Name = L"OP47";
+
+std::shared_ptr<decklink_vanc_strategy>
+create_op47_strategy(uint8_t line_number, uint8_t line_number_2, const std::wstring& dummy_header)
+{
+    return std::make_shared<vanc_op47_strategy>(line_number, line_number_2, dummy_header);
+}
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/vanc_scte104_strategy.cpp
+++ b/src/modules/decklink/consumer/vanc_scte104_strategy.cpp
@@ -1,0 +1,87 @@
+#include "vanc.h"
+
+#include <common/base64.h>
+#include <mutex>
+
+namespace caspar { namespace decklink {
+
+const uint8_t SCTE104_DID  = 0x41;
+const uint8_t SCTE104_SDID = 0x07;
+
+class vanc_scte104_strategy : public decklink_vanc_strategy
+{
+    static const std::wstring Name;
+
+    mutable std::mutex mutex_;
+    uint8_t            line_number_;
+
+    std::vector<uint8_t> payload_ = {};
+
+  public:
+    explicit vanc_scte104_strategy(uint8_t line_number)
+        : line_number_(line_number)
+    {
+    }
+
+    virtual bool has_data() const override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return !payload_.empty();
+    }
+    virtual vanc_packet pop_packet() override
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            // If we have a payload, return it as a vanc_packet.
+            if (payload_.size() > 0) {
+                auto        data = std::vector<uint8_t>(payload_.begin(), payload_.end());
+                vanc_packet pkt{SCTE104_DID, SCTE104_SDID, line_number_, data};
+                payload_.clear();
+                return pkt;
+            }
+        }
+
+        // If we have no data, return an empty vanc_packet.
+        return {0, 0, 0, {}};
+    }
+
+    virtual bool try_push_data(const std::vector<std::wstring>& params) override
+    {
+        try {
+            if (params.size() == 2) {
+                std::lock_guard<std::mutex> lock(mutex_);
+
+                // try to parse the payload as a base64 encoded raw SCTE-104 packet.
+                auto base64_payload = params.at(1);
+                payload_            = base64_decode(base64_payload);
+            }
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << "Failed to parse SCTE 104 parameters: " << e.what();
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual const std::wstring& get_name() const override { return vanc_scte104_strategy::Name; }
+
+  private:
+    std::vector<uint8_t> base64_decode(const std::wstring& encoded)
+    {
+        std::vector<char> buffer(encoded.size());
+        std::use_facet<std::ctype<wchar_t>>(std::locale())
+            .narrow(encoded.data(), encoded.data() + encoded.size(), '?', buffer.data());
+        auto str = std::string(buffer.data(), buffer.size());
+        return caspar::from_base64(str);
+    }
+};
+
+const std::wstring vanc_scte104_strategy::Name = L"SCTE104";
+
+std::shared_ptr<decklink_vanc_strategy> create_scte104_strategy(uint8_t line_number)
+{
+    return std::make_shared<vanc_scte104_strategy>(line_number);
+}
+
+}} // namespace caspar::decklink

--- a/src/modules/decklink/consumer/vanc_scte104_strategy.cpp
+++ b/src/modules/decklink/consumer/vanc_scte104_strategy.cpp
@@ -28,8 +28,14 @@ class vanc_scte104_strategy : public decklink_vanc_strategy
         std::lock_guard<std::mutex> lock(mutex_);
         return !payload_.empty();
     }
-    virtual vanc_packet pop_packet() override
+
+    virtual vanc_packet pop_packet(bool field2) override
     {
+        if (field2) {
+            // If field2 is requested, we do not return any data.
+            return {0, 0, 0, {}};
+        }
+
         {
             std::lock_guard<std::mutex> lock(mutex_);
 

--- a/src/modules/decklink/decklink_api.h
+++ b/src/modules/decklink/decklink_api.h
@@ -82,6 +82,15 @@ static com_ptr<IDeckLinkIterator> create_iterator()
     return pDecklinkIterator;
 }
 
+static com_ptr<IDeckLinkVideoFrameAncillaryPackets> create_ancillary_packets()
+{
+    CComPtr<IDeckLinkVideoFrameAncillaryPackets> pDecklinkAncillaryPackets;
+    if (FAILED(pDecklinkAncillaryPackets.CoCreateInstance(CLSID_CDeckLinkVideoFrameAncillaryPackets)))
+        CASPAR_THROW_EXCEPTION(not_supported()
+                               << msg_info("Could not create IDeckLinkVideoFrameAncillaryPackets instance."));
+    return pDecklinkAncillaryPackets;
+}
+
 template <typename I, typename T>
 static com_iface_ptr<I> iface_cast(const com_ptr<T>& ptr, bool optional = false)
 {
@@ -114,8 +123,8 @@ T* get_raw(const CComPtr<T>& ptr)
 
 namespace caspar { namespace decklink {
 
-using String   = const char*;
-using BOOL     = bool;
+using String = const char*;
+using BOOL   = bool;
 #define TRUE true
 #define FALSE false
 using UINT32   = uint32_t;
@@ -162,6 +171,17 @@ static com_ptr<IDeckLinkIterator> create_iterator()
         CASPAR_THROW_EXCEPTION(not_supported() << msg_info("Decklink drivers not found."));
 
     return wrap_raw<com_ptr>(iterator, true);
+}
+
+static com_ptr<IDeckLinkVideoFrameAncillaryPackets> create_ancillary_packets()
+{
+    IDeckLinkVideoFrameAncillaryPackets* ancillaryPackets = CreateVideoFrameAncillaryPacketsInstance();
+
+    if (ancillaryPackets == nullptr)
+        CASPAR_THROW_EXCEPTION(not_supported()
+                               << msg_info("Could not create IDeckLinkVideoFrameAncillaryPackets instance."));
+
+    return wrap_raw<com_ptr>(ancillaryPackets, true);
 }
 
 template <typename T>


### PR DESCRIPTION
Add support for adding VANC packets to decklink frames

* Separate Vanc class that handles vanc related logic
* Strategy based approach to isolate different types of ancilliary data 
* Only support for a push based workflow atm (via amcp APPLY, se separate PR #1638 ), but should be fairly easy to extend with support for data arriving from other sources (ie. the producer/consumer-pipeline)