### PR TITLE
ffmpeg producer native yuv444 10- and 12-bit support

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -565,6 +565,8 @@ struct Filter
                                               AV_PIX_FMT_RGBA,
                                               AV_PIX_FMT_ABGR,
                                               AV_PIX_FMT_YUV444P,
+                                              AV_PIX_FMT_YUV444P10,
+                                              AV_PIX_FMT_YUV444P12,
                                               AV_PIX_FMT_YUV422P,
                                               AV_PIX_FMT_YUV422P10,
                                               AV_PIX_FMT_YUV422P12,

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -129,6 +129,10 @@ std::tuple<core::pixel_format, common::bit_depth> get_pixel_format(AVPixelFormat
             return {core::pixel_format::abgr, common::bit_depth::bit8};
         case AV_PIX_FMT_YUV444P:
             return {core::pixel_format::ycbcr, common::bit_depth::bit8};
+        case AV_PIX_FMT_YUV444P10:
+            return {core::pixel_format::ycbcr, common::bit_depth::bit10};
+        case AV_PIX_FMT_YUV444P12:
+            return {core::pixel_format::ycbcr, common::bit_depth::bit12};
         case AV_PIX_FMT_YUV422P:
             return {core::pixel_format::ycbcr, common::bit_depth::bit8};
         case AV_PIX_FMT_YUV422P10:


### PR DESCRIPTION
Adds native support in ffmpeg producer for the yuv444p10 and yuv444p12 pixel formats