### PR TITLE
feat: decklink support for chosing yuv output i 8-bit mode

### DIFF
--- a/src/common/memory.h
+++ b/src/common/memory.h
@@ -658,6 +658,11 @@ shared_ptr<T> make_shared(P0&& p0)
 {
     return shared_ptr<T>(std::make_shared<U>(std::forward<P0>(p0)));
 }
+template <typename T, typename U, typename P0, typename P1>
+shared_ptr<T> make_shared(P0&& p0, P1&& p1)
+{
+    return shared_ptr<T>(std::make_shared<U>(std::forward<P0>(p0), std::forward<P1>(p1)));
+}
 
 template <typename T, typename P0>
 shared_ptr<T> make_shared(P0&& p0)

--- a/src/modules/decklink/CMakeLists.txt
+++ b/src/modules/decklink/CMakeLists.txt
@@ -4,7 +4,7 @@ project (decklink)
 set(SOURCES
 		consumer/decklink_consumer.cpp
 		consumer/decklink_consumer.h
-		consumer/hdr_v210_strategy.cpp
+		consumer/v210_strategies.cpp
 		consumer/sdr_bgra_strategy.cpp
 		consumer/format_strategy.h
 		consumer/config.cpp

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -87,6 +87,12 @@ struct configuration
         disabled,
     };
 
+    enum class pixel_format_t
+    {
+        rgba,
+        yuv,
+    };
+
     bool                 embedded_audio              = false;
     keyer_t              keyer                       = keyer_t::default_keyer;
     duplex_t             duplex                      = duplex_t::default_duplex;
@@ -95,6 +101,7 @@ struct configuration
     int                  wait_for_reference_duration = 10; // seconds
     int                  base_buffer_depth           = 3;
     bool                 hdr                         = false;
+    pixel_format_t       pixel_format                = pixel_format_t::rgba;
 
     port_configuration              primary;
     std::vector<port_configuration> secondaries;

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -197,7 +197,12 @@ core::video_format_desc get_decklink_format(const port_configuration&      confi
 
 spl::shared_ptr<format_strategy> create_format_strategy(const configuration& config)
 {
-    return config.hdr ? create_hdr_v210_strategy(config.color_space) : create_sdr_bgra_strategy();
+    if (config.hdr) {
+        return create_hdr_v210_strategy(config.color_space);
+    } else {
+        return config.pixel_format == configuration::pixel_format_t::yuv ? create_sdr_v210_strategy(config.color_space)
+                                                                         : create_sdr_bgra_strategy();
+    }
 }
 
 enum EOTF
@@ -1006,9 +1011,7 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
         audio_scheduled_ += nb_samples; // TODO - what if there are too many/few samples in this frame?
     }
 
-    void schedule_next_video(std::shared_ptr<void> image_data,
-                             int                   nb_samples,
-                             BMDTimeValue          display_time)
+    void schedule_next_video(std::shared_ptr<void> image_data, int nb_samples, BMDTimeValue display_time)
     {
         auto fmt        = format_strategy_->get_pixel_format();
         auto row_bytes  = format_strategy_->get_row_bytes(decklink_format_desc_.width);

--- a/src/modules/decklink/consumer/format_strategy.h
+++ b/src/modules/decklink/consumer/format_strategy.h
@@ -41,7 +41,7 @@ class format_strategy
 
   public:
     format_strategy& operator=(const format_strategy&) = delete;
-    virtual ~format_strategy()                       = default;
+    virtual ~format_strategy()                         = default;
 
     format_strategy(const format_strategy&) = delete;
 
@@ -57,6 +57,7 @@ class format_strategy
 };
 
 spl::shared_ptr<format_strategy> create_sdr_bgra_strategy();
+spl::shared_ptr<format_strategy> create_sdr_v210_strategy(core::color_space colorspace);
 spl::shared_ptr<format_strategy> create_hdr_v210_strategy(core::color_space colorspace);
 
 }} // namespace caspar::decklink

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -90,6 +90,7 @@
                 <keyer>external [external|external_separate_device|internal|default]</keyer>
                 <key-only>false [true|false]</key-only>
                 <buffer-depth>3 [1..]</buffer-depth>
+                <pixel-format>[yuv|rgba](default is rgba for 8bit channels, yuv for high bit-depth channels)</pixel-format>
                 <video-mode>(Run the decklink at a different video-mode. Note: the framerate must match that of the channel)</video-mode>
                 <subregion>
                     <src-x>0 (x offset into the channel)</src-x>


### PR DESCRIPTION
Enables users to opt-in to using yuv (v210) instead of rgba in the decklink consumer on standard 8-bit channels. This enables the maximum usage of the decklink cards output bandwidth.