### PR TITLE
add websocket servers for amcp and monitor data

### DIFF
--- a/src/CMakeModules/Bootstrap_Linux.cmake
+++ b/src/CMakeModules/Bootstrap_Linux.cmake
@@ -39,6 +39,13 @@ find_package(OpenAL REQUIRED)
 find_package(SFML 2 COMPONENTS graphics window REQUIRED)
 find_package(X11 REQUIRED)
 
+# nlohmann/json
+FetchContent_Declare(nlohmann_json
+	URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+	DOWNLOAD_DIR ${CASPARCG_DOWNLOAD_CACHE}
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 # support for Ubuntu 22.04
 if (NOT TARGET OpenAL::OpenAL)
     add_library(OpenAL::OpenAL INTERFACE IMPORTED)

--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -198,6 +198,13 @@ file(COPY_FILE ${openal_SOURCE_DIR}/bin/Win64/soft_oal.dll ${openal_SOURCE_DIR}/
 add_library(OpenAL::OpenAL INTERFACE IMPORTED)
 target_include_directories(OpenAL::OpenAL INTERFACE ${openal_SOURCE_DIR}/include)
 target_link_directories(OpenAL::OpenAL INTERFACE ${openal_SOURCE_DIR}/libs/Win64)
+
+# nlohmann/json
+FetchContent_Declare(nlohmann_json
+	URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+	DOWNLOAD_DIR ${CASPARCG_DOWNLOAD_CACHE}
+)
+FetchContent_MakeAvailable(nlohmann_json)
 target_link_libraries(OpenAL::OpenAL INTERFACE OpenAL32)
 casparcg_add_runtime_dependency("${openal_SOURCE_DIR}/bin/Win64/OpenAL32.dll")
 
@@ -286,6 +293,6 @@ add_definitions("-DBOOST_ALLOW_DEPRECATED_HEADERS")
 # Ensure /EHsc is not defined as it clashes with EHa below
 string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHa /Zi /W4 /WX /MP /fp:fast /Zm192 /FIcommon/compiler/vs/disable_silly_warnings.h")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHa /Zi /W4 /MP /fp:fast /Zm192 /FIcommon/compiler/vs/disable_silly_warnings.h")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}	/D TBB_USE_ASSERT=1 /D TBB_USE_DEBUG /bigobj")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}	/Oi /arch:AVX2 /Ot /Gy /bigobj")

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -22,6 +22,9 @@ set(SOURCES
 		util/strategy_adapters.cpp
 		util/http_request.cpp
 		util/tokenize.cpp
+		util/websocket_server.cpp
+		util/websocket_monitor_client.cpp
+		util/websocket_monitor_server.cpp
 )
 
 set(HEADERS
@@ -54,6 +57,9 @@ set(HEADERS
 		util/strategy_adapters.h
 		util/http_request.h
 		util/tokenize.h
+		util/websocket_server.h
+		util/websocket_monitor_client.h
+		util/websocket_monitor_server.h
 
 		StdAfx.h
 )
@@ -73,4 +79,4 @@ source_group(sources\\osc osc/*)
 source_group(sources\\util util/*)
 source_group(sources ./*)
 
-target_link_libraries(protocol PRIVATE common core)
+target_link_libraries(protocol PRIVATE common core nlohmann_json::nlohmann_json)

--- a/src/protocol/util/strategy_adapters.h
+++ b/src/protocol/util/strategy_adapters.h
@@ -79,7 +79,7 @@ class delimiter_based_chunking_strategy : public protocol_strategy<CharT>
             strategy_->parse(input_.substr(0, delim_pos));
 
             input_    = std::move(input_.substr(delim_pos + delimiter_.size()));
-            delim_pos = input_.find_first_of(delimiter_);
+            delim_pos = input_.find(delimiter_);
         }
     }
 };

--- a/src/protocol/util/websocket_monitor_client.cpp
+++ b/src/protocol/util/websocket_monitor_client.cpp
@@ -1,0 +1,500 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../StdAfx.h"
+
+#include "websocket_monitor_client.h"
+#include "websocket_monitor_server.h"
+
+#include <common/log.h>
+#include <common/utf.h>
+
+#include <boost/algorithm/string.hpp>
+#include <nlohmann/json.hpp>
+
+#include <tbb/concurrent_hash_map.h>
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
+
+namespace caspar { namespace protocol { namespace websocket {
+
+using json = nlohmann::json;
+
+namespace {
+
+// Convert variant to JSON value
+json variant_to_json_value(const core::monitor::data_t& value)
+{
+    if (auto bool_val = boost::get<bool>(&value)) {
+        return *bool_val;
+    } else if (auto int32_val = boost::get<std::int32_t>(&value)) {
+        return *int32_val;
+    } else if (auto int64_val = boost::get<std::int64_t>(&value)) {
+        return *int64_val;
+    } else if (auto uint32_val = boost::get<std::uint32_t>(&value)) {
+        return *uint32_val;
+    } else if (auto uint64_val = boost::get<std::uint64_t>(&value)) {
+        return *uint64_val;
+    } else if (auto float_val = boost::get<float>(&value)) {
+        return *float_val;
+    } else if (auto double_val = boost::get<double>(&value)) {
+        return *double_val;
+    } else if (auto string_val = boost::get<std::string>(&value)) {
+        return *string_val;
+    } else if (auto wstring_val = boost::get<std::wstring>(&value)) {
+        return u8(*wstring_val);
+    }
+    return nullptr; // JSON null
+}
+
+// Convert OSC-style path to nested JSON structure
+void set_nested_json_value(json& root, const std::string& path, const core::monitor::vector_t& values)
+{
+    std::vector<std::string> parts;
+    boost::split(parts, path, boost::is_any_of("/"));
+
+    // Remove empty parts (from leading slash)
+    parts.erase(std::remove_if(parts.begin(), parts.end(), [](const std::string& s) { return s.empty(); }),
+                parts.end());
+
+    json* current = &root;
+
+    // Navigate to the parent node, creating nodes as needed
+    for (size_t i = 0; i < parts.size() - 1; ++i) {
+        if (!current->contains(parts[i])) {
+            (*current)[parts[i]] = json::object();
+        }
+        current = &(*current)[parts[i]];
+    }
+
+    // Set the value(s)
+    if (!parts.empty()) {
+        const std::string& key = parts.back();
+        if (values.empty()) {
+            (*current)[key] = nullptr; // JSON null
+        } else if (values.size() == 1) {
+            (*current)[key] = variant_to_json_value(values[0]);
+        } else {
+            json array = json::array();
+            for (const auto& value : values) {
+                array.push_back(variant_to_json_value(value));
+            }
+            (*current)[key] = array;
+        }
+    }
+}
+
+// Convert monitor state to OSC-style JSON structure
+std::string monitor_state_to_osc_json(const core::monitor::state& state, const std::string& message_type)
+{
+    json root;
+
+    // Add message metadata
+    root["type"] = message_type;
+    root["timestamp"] =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    // Convert monitor state to nested JSON structure
+    json data_node = json::object();
+    for (const auto& [path, values] : state) {
+        set_nested_json_value(data_node, path, values);
+    }
+
+    root["data"] = data_node;
+
+    return root.dump();
+}
+
+// Generate delta changes between two monitor states
+std::vector<std::pair<std::string, core::monitor::vector_t>> generate_deltas(const core::monitor::state& old_state,
+                                                                             const core::monitor::state& new_state)
+{
+    std::vector<std::pair<std::string, core::monitor::vector_t>> deltas;
+
+    // Find changed/new values
+    for (const auto& [path, new_values] : new_state) {
+        // Find the corresponding value in old_state using linear search
+        auto old_it =
+            std::find_if(old_state.begin(), old_state.end(), [&path](const auto& pair) { return pair.first == path; });
+
+        if (old_it == old_state.end() || old_it->second != new_values) {
+            deltas.emplace_back(path, new_values);
+        }
+    }
+
+    // Find removed values (set to null/empty)
+    for (const auto& [path, old_values] : old_state) {
+        auto new_it =
+            std::find_if(new_state.begin(), new_state.end(), [&path](const auto& pair) { return pair.first == path; });
+
+        if (new_it == new_state.end()) {
+            deltas.emplace_back(path, core::monitor::vector_t{}); // Empty vector indicates removal
+        }
+    }
+
+    return deltas;
+}
+
+// Convert deltas to RFC 6902 JSON Patch format
+std::string deltas_to_json_patch(const std::vector<std::pair<std::string, core::monitor::vector_t>>& deltas)
+{
+    json root;
+
+    root["type"] = "patch";
+    root["timestamp"] =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    // Build the JSON Patch array
+    json patch_array = json::array();
+
+    for (const auto& [path, values] : deltas) {
+        std::vector<std::string> parts;
+        boost::split(parts, path, boost::is_any_of("/"));
+
+        // Remove empty parts (from leading slash)
+        parts.erase(std::remove_if(parts.begin(), parts.end(), [](const std::string& s) { return s.empty(); }),
+                    parts.end());
+
+        if (values.empty()) {
+            // Remove operation
+            json patch_op;
+            patch_op["op"]   = "remove";
+            patch_op["path"] = "/" + boost::join(parts, "/");
+            patch_array.push_back(patch_op);
+        } else {
+            // Add/replace operation
+            json patch_op;
+
+            // Determine if this is an add or replace operation
+            // For simplicity, we'll use "replace" for existing paths and "add" for new ones
+            // In practice, you might want to track which paths existed in the previous state
+            patch_op["op"] = "replace"; // or "add" depending on your logic
+
+            // Build the path
+            patch_op["path"] = "/" + boost::join(parts, "/");
+
+            // Set the value
+            if (values.size() == 1) {
+                patch_op["value"] = variant_to_json_value(values[0]);
+            } else {
+                json array = json::array();
+                for (const auto& value : values) {
+                    array.push_back(variant_to_json_value(value));
+                }
+                patch_op["value"] = array;
+            }
+
+            patch_array.push_back(patch_op);
+        }
+    }
+
+    root["data"] = patch_array;
+
+    return root.dump();
+}
+
+// Generate heartbeat message
+std::string generate_heartbeat()
+{
+    json root;
+    root["type"] = "heartbeat";
+    root["timestamp"] =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count();
+
+    return root.dump();
+}
+
+} // namespace
+
+struct connection_state
+{
+    std::string                             connection_id;
+    std::function<void(const std::string&)> send_callback;
+    connection_config                       config;
+    core::monitor::state                    last_state;
+    std::chrono::steady_clock::time_point   last_full_state_time;
+    std::chrono::steady_clock::time_point   last_heartbeat_time;
+    bool                                    needs_full_state;
+
+    connection_state(const std::string&                      id,
+                     std::function<void(const std::string&)> callback,
+                     const connection_config&                cfg)
+        : connection_id(id)
+        , send_callback(std::move(callback))
+        , config(cfg)
+        , last_full_state_time(std::chrono::steady_clock::now())
+        , last_heartbeat_time(std::chrono::steady_clock::now())
+        , needs_full_state(true)
+    {
+    }
+};
+
+struct websocket_monitor_client::impl
+{
+    std::shared_ptr<boost::asio::io_service>                                  service_;
+    std::mutex                                                                connections_mutex_;
+    std::unordered_map<std::string, std::unique_ptr<connection_state>>        connections_;
+    std::unordered_map<std::string, std::weak_ptr<websocket_monitor_session>> sessions_;
+
+    // Subscription management
+    tbb::concurrent_hash_map<std::string, std::weak_ptr<void>> subscriptions_;
+
+    // Timer for periodic tasks
+    std::unique_ptr<boost::asio::deadline_timer> timer_;
+    std::atomic<bool>                            running_{true};
+
+    explicit impl(std::shared_ptr<boost::asio::io_service> service)
+        : service_(std::move(service))
+        , timer_(std::make_unique<boost::asio::deadline_timer>(*service_))
+    {
+        schedule_periodic_tasks();
+    }
+
+    ~impl()
+    {
+        running_ = false;
+        if (timer_) {
+            timer_->cancel();
+        }
+    }
+
+    void schedule_periodic_tasks()
+    {
+        if (!running_)
+            return;
+
+        timer_->expires_from_now(boost::posix_time::seconds(1));
+        timer_->async_wait([this](const boost::system::error_code& ec) {
+            if (!ec && running_) {
+                handle_periodic_tasks();
+                schedule_periodic_tasks();
+            }
+        });
+    }
+
+    void handle_periodic_tasks()
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        auto                        now = std::chrono::steady_clock::now();
+
+        for (auto& [id, conn] : connections_) {
+            try {
+                // Check if we need to send full state (only if interval > 0)
+                if (conn->config.full_state_interval.count() > 0 &&
+                    std::chrono::duration_cast<std::chrono::seconds>(now - conn->last_full_state_time) >=
+                        conn->config.full_state_interval) {
+                    conn->needs_full_state = true;
+                }
+
+                // Check if we need to send heartbeat
+                if (conn->config.send_heartbeat &&
+                    std::chrono::duration_cast<std::chrono::seconds>(now - conn->last_heartbeat_time) >=
+                        conn->config.heartbeat_interval) {
+                    std::string heartbeat = generate_heartbeat();
+                    conn->send_callback(heartbeat);
+                    conn->last_heartbeat_time = now;
+                }
+            } catch (const std::exception& e) {
+                CASPAR_LOG(info) << L"WebSocket monitor: Removing failed connection " << u16(id) << L": "
+                                 << u16(e.what());
+                // Connection will be removed in next iteration
+            }
+        }
+    }
+
+    void send(const core::monitor::state& state)
+    {
+        if (connections_.empty()) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+
+        // Send to all connected clients
+        auto it = connections_.begin();
+        while (it != connections_.end()) {
+            try {
+                auto& conn = it->second;
+
+                if (conn->needs_full_state) {
+                    // Send full state
+                    std::string full_state_json = monitor_state_to_osc_json(state, "full_state");
+                    conn->send_callback(full_state_json);
+                    conn->last_state           = state;
+                    conn->last_full_state_time = std::chrono::steady_clock::now();
+                    conn->needs_full_state     = false;
+                } else {
+                    // Send delta
+                    auto deltas = generate_deltas(conn->last_state, state);
+                    if (!deltas.empty()) {
+                        std::string delta_json = deltas_to_json_patch(deltas);
+                        conn->send_callback(delta_json);
+                        conn->last_state = state;
+                    }
+                }
+
+                ++it;
+            } catch (const std::exception& e) {
+                CASPAR_LOG(info) << L"WebSocket monitor: Removing failed connection " << u16(it->first) << L": "
+                                 << u16(e.what());
+                it = connections_.erase(it);
+            }
+        }
+    }
+
+    void add_connection(const std::string&                      connection_id,
+                        std::function<void(const std::string&)> send_callback,
+                        const connection_config&                config)
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        connections_[connection_id] =
+            std::make_unique<connection_state>(connection_id, std::move(send_callback), config);
+        CASPAR_LOG(info) << L"WebSocket monitor: Added connection " << u16(connection_id) << L" ("
+                         << connections_.size() << L" total connections)";
+    }
+
+    void remove_connection(const std::string& connection_id)
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        connections_.erase(connection_id);
+        CASPAR_LOG(info) << L"WebSocket monitor: Removed connection " << u16(connection_id) << L" ("
+                         << connections_.size() << L" total connections)";
+    }
+
+    void force_full_state()
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        for (auto& [id, conn] : connections_) {
+            conn->needs_full_state = true;
+        }
+        CASPAR_LOG(info) << L"WebSocket monitor: Forced full state for all connections";
+    }
+
+    void add_session(const std::string& connection_id, std::weak_ptr<websocket_monitor_session> session)
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        sessions_[connection_id] = std::move(session);
+    }
+
+    void remove_session(const std::string& connection_id)
+    {
+        std::lock_guard<std::mutex> lock(connections_mutex_);
+        sessions_.erase(connection_id);
+    }
+
+    void force_disconnect_all();
+
+    std::shared_ptr<void> get_subscription_token(const std::string& connection_id)
+    {
+        // Create a token that when destroyed will clean up the subscription
+        auto token = std::shared_ptr<void>(nullptr, [this, connection_id](void*) {
+            // Remove subscription when token is destroyed
+            subscriptions_.erase(connection_id);
+        });
+
+        // Store weak reference to token
+        subscriptions_.insert(std::make_pair(connection_id, token));
+
+        return token;
+    }
+};
+
+void caspar::protocol::websocket::websocket_monitor_client::impl::force_disconnect_all()
+{
+    std::lock_guard<std::mutex> lock(connections_mutex_);
+    auto                        connection_count = sessions_.size();
+    for (auto& [id, weak_session] : sessions_) {
+        if (auto session = weak_session.lock()) {
+            session->close();
+        }
+    }
+    connections_.clear();
+    sessions_.clear();
+    subscriptions_.clear();
+    // Stop the periodic timer to ensure clean shutdown
+    running_ = false;
+    if (timer_) {
+        timer_->cancel();
+    }
+    CASPAR_LOG(info) << L"WebSocket monitor: Force disconnected " << connection_count << L" connections";
+}
+
+websocket_monitor_client::websocket_monitor_client(std::shared_ptr<boost::asio::io_service> service)
+    : impl_(spl::make_shared<impl>(std::move(service)))
+{
+}
+
+websocket_monitor_client::websocket_monitor_client(websocket_monitor_client&& other)
+    : impl_(std::move(other.impl_))
+{
+}
+
+websocket_monitor_client& websocket_monitor_client::operator=(websocket_monitor_client&& other)
+{
+    impl_ = std::move(other.impl_);
+    return *this;
+}
+
+websocket_monitor_client::~websocket_monitor_client() = default;
+
+std::shared_ptr<void> websocket_monitor_client::get_subscription_token(const std::string& connection_id)
+{
+    return impl_->get_subscription_token(connection_id);
+}
+
+void websocket_monitor_client::send(const core::monitor::state& state) { impl_->send(state); }
+
+void websocket_monitor_client::add_connection(const std::string&                      connection_id,
+                                              std::function<void(const std::string&)> send_callback,
+                                              const connection_config&                config)
+{
+    impl_->add_connection(connection_id, std::move(send_callback), config);
+}
+
+void websocket_monitor_client::remove_connection(const std::string& connection_id)
+{
+    impl_->remove_connection(connection_id);
+}
+
+void websocket_monitor_client::force_full_state() { impl_->force_full_state(); }
+
+void websocket_monitor_client::force_disconnect_all() { impl_->force_disconnect_all(); }
+
+void websocket_monitor_client::add_session(const std::string&                       connection_id,
+                                           std::weak_ptr<websocket_monitor_session> session)
+{
+    impl_->add_session(connection_id, std::move(session));
+}
+
+void websocket_monitor_client::remove_session(const std::string& connection_id)
+{
+    impl_->remove_session(connection_id);
+}
+
+}}} // namespace caspar::protocol::websocket

--- a/src/protocol/util/websocket_monitor_client.h
+++ b/src/protocol/util/websocket_monitor_client.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/io_service.hpp>
+
+#include <common/memory.h>
+#include <core/monitor/monitor.h>
+
+#include <chrono>
+#include <string>
+
+namespace caspar { namespace protocol { namespace websocket {
+
+struct monitor_message
+{
+    enum class type
+    {
+        full_state,
+        delta,
+        heartbeat
+    };
+
+    type                      message_type;
+    std::chrono::milliseconds timestamp;
+    std::string               json_data;
+};
+
+struct connection_config
+{
+    std::chrono::seconds full_state_interval{0}; // Disable periodic full state (0 = disabled)
+    bool                 send_heartbeat{true};
+    std::chrono::seconds heartbeat_interval{10}; // Send heartbeat every 10 seconds
+};
+
+class websocket_monitor_session; // forward declaration
+
+class websocket_monitor_client
+{
+    websocket_monitor_client(const websocket_monitor_client&)            = delete;
+    websocket_monitor_client& operator=(const websocket_monitor_client&) = delete;
+
+  public:
+    explicit websocket_monitor_client(std::shared_ptr<boost::asio::io_service> service);
+
+    websocket_monitor_client(websocket_monitor_client&&);
+
+    /**
+     * Get a subscription token that ensures that WebSocket monitor messages are sent to the
+     * given connection as long as the token is alive. It will stop sending when
+     * the token is dropped unless another token to the same connection has
+     * previously been checked out.
+     *
+     * @param connection_id The unique identifier for the WebSocket connection.
+     *
+     * @return The token. It is ok for the token to outlive the client
+     */
+    std::shared_ptr<void> get_subscription_token(const std::string& connection_id);
+
+    ~websocket_monitor_client();
+
+    websocket_monitor_client& operator=(websocket_monitor_client&&);
+
+    void send(const core::monitor::state& state);
+
+    // Called by WebSocket server to register/unregister connections
+    void add_connection(const std::string&                      connection_id,
+                        std::function<void(const std::string&)> send_callback,
+                        const connection_config&                config = {});
+    void remove_connection(const std::string& connection_id);
+
+    // Force send full state to all connections (useful for debugging)
+    void force_full_state();
+
+    // Force disconnect all connections (for clean shutdown)
+    void force_disconnect_all();
+
+    void add_session(const std::string& connection_id, std::weak_ptr<websocket_monitor_session> session);
+    void remove_session(const std::string& connection_id);
+
+  private:
+    struct impl;
+    spl::shared_ptr<impl> impl_;
+};
+
+}}} // namespace caspar::protocol::websocket

--- a/src/protocol/util/websocket_monitor_server.cpp
+++ b/src/protocol/util/websocket_monitor_server.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../StdAfx.h"
+
+#include "websocket_monitor_server.h"
+
+#include <common/log.h>
+#include <common/utf.h>
+
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+namespace beast = boost::beast;
+namespace http  = beast::http;
+namespace ws    = beast::websocket;
+namespace net   = boost::asio;
+using tcp       = net::ip::tcp;
+
+namespace caspar { namespace protocol { namespace websocket {
+
+// WebSocket monitor listener
+class websocket_monitor_listener : public std::enable_shared_from_this<websocket_monitor_listener>
+{
+    net::io_context&                          ioc_;
+    tcp::acceptor                             acceptor_;
+    std::shared_ptr<websocket_monitor_client> monitor_client_;
+    std::atomic<bool>                         running_{false};
+
+  public:
+    websocket_monitor_listener(net::io_context&                          ioc,
+                               tcp::endpoint                             endpoint,
+                               std::shared_ptr<websocket_monitor_client> monitor_client)
+        : ioc_(ioc)
+        , acceptor_(ioc)
+        , monitor_client_(std::move(monitor_client))
+    {
+        beast::error_code ec;
+
+        // Open the acceptor
+        acceptor_.open(endpoint.protocol(), ec);
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor listener open error: " << u16(ec.message());
+            return;
+        }
+
+        // Allow address reuse
+        acceptor_.set_option(net::socket_base::reuse_address(true), ec);
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor listener set_option error: " << u16(ec.message());
+            return;
+        }
+
+        // Bind to the server address
+        acceptor_.bind(endpoint, ec);
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor listener bind error: " << u16(ec.message());
+            return;
+        }
+
+        // Start listening for connections
+        acceptor_.listen(net::socket_base::max_listen_connections, ec);
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor listener listen error: " << u16(ec.message());
+            return;
+        }
+
+        CASPAR_LOG(info) << L"WebSocket monitor listener started on port " << endpoint.port();
+    }
+
+    void run()
+    {
+        running_ = true;
+        do_accept();
+    }
+
+    void stop()
+    {
+        running_ = false;
+        acceptor_.close();
+    }
+
+  private:
+    void do_accept()
+    {
+        if (!running_)
+            return;
+
+        // The new connection gets its own strand
+        acceptor_.async_accept(net::make_strand(ioc_),
+                               beast::bind_front_handler(&websocket_monitor_listener::on_accept, shared_from_this()));
+    }
+
+    void on_accept(beast::error_code ec, tcp::socket socket)
+    {
+        if (ec) {
+            if (running_) {
+                CASPAR_LOG(error) << L"WebSocket monitor listener accept error: " << u16(ec.message());
+            }
+        } else {
+            // Create the session and run it
+            std::make_shared<websocket_monitor_session>(ioc_, std::move(socket), monitor_client_)->run();
+        }
+
+        // Accept another connection
+        do_accept();
+    }
+};
+
+struct websocket_monitor_server::impl
+{
+    std::shared_ptr<boost::asio::io_service>    service_;
+    std::shared_ptr<websocket_monitor_client>   monitor_client_;
+    uint16_t                                    port_;
+    std::shared_ptr<websocket_monitor_listener> listener_;
+    std::atomic<bool>                           running_{false};
+
+    impl(std::shared_ptr<boost::asio::io_service>  service,
+         std::shared_ptr<websocket_monitor_client> monitor_client,
+         uint16_t                                  port)
+        : service_(std::move(service))
+        , monitor_client_(std::move(monitor_client))
+        , port_(port)
+    {
+    }
+
+    void start()
+    {
+        if (running_)
+            return;
+
+        try {
+            auto const address  = net::ip::make_address("0.0.0.0");
+            auto const endpoint = tcp::endpoint{address, port_};
+
+            // Create and launch a listening port
+            listener_ = std::make_shared<websocket_monitor_listener>(*service_, endpoint, monitor_client_);
+            listener_->run();
+
+            running_ = true;
+            CASPAR_LOG(info) << L"WebSocket monitor server started on port " << port_;
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"Failed to start WebSocket monitor server: " << u16(e.what());
+            throw;
+        }
+    }
+
+    void stop()
+    {
+        if (!running_)
+            return;
+
+        running_ = false;
+        if (listener_) {
+            listener_->stop();
+        }
+
+        // Force close all monitor connections to ensure clean shutdown
+        if (monitor_client_) {
+            monitor_client_->force_disconnect_all();
+        }
+
+        CASPAR_LOG(info) << L"WebSocket monitor server stopped";
+    }
+};
+
+websocket_monitor_server::websocket_monitor_server(std::shared_ptr<boost::asio::io_service>  service,
+                                                   std::shared_ptr<websocket_monitor_client> monitor_client,
+                                                   uint16_t                                  port)
+    : impl_(spl::make_shared<impl>(std::move(service), std::move(monitor_client), port))
+{
+}
+
+websocket_monitor_server::~websocket_monitor_server() { impl_->stop(); }
+
+void websocket_monitor_server::start() { impl_->start(); }
+
+void websocket_monitor_server::stop() { impl_->stop(); }
+
+}}} // namespace caspar::protocol::websocket

--- a/src/protocol/util/websocket_monitor_server.h
+++ b/src/protocol/util/websocket_monitor_server.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "websocket_monitor_client.h"
+
+#include <atomic>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <common/memory.h>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_set>
+
+namespace beast = boost::beast;
+namespace http  = beast::http;
+namespace ws    = beast::websocket;
+namespace net   = boost::asio;
+using tcp       = net::ip::tcp;
+
+namespace caspar { namespace protocol { namespace websocket {
+
+class websocket_monitor_session : public std::enable_shared_from_this<websocket_monitor_session>
+{
+    ws::stream<beast::tcp_stream>                ws_;
+    beast::flat_buffer                           buffer_;
+    std::shared_ptr<websocket_monitor_client>    monitor_client_;
+    std::string                                  connection_id_;
+    std::shared_ptr<void>                        subscription_token_;
+    std::atomic<bool>                            is_open_{false};
+    std::unique_ptr<boost::asio::deadline_timer> force_close_timer_;
+    boost::asio::io_context&                     io_context_;
+
+  public:
+    explicit websocket_monitor_session(boost::asio::io_context&                  io_context,
+                                       tcp::socket&&                             socket,
+                                       std::shared_ptr<websocket_monitor_client> monitor_client)
+        : ws_(std::move(socket))
+        , monitor_client_(std::move(monitor_client))
+        , connection_id_(generate_connection_id())
+        , io_context_(io_context)
+    {
+    }
+
+    ~websocket_monitor_session()
+    {
+        if (is_open_) {
+            monitor_client_->remove_connection(connection_id_);
+        }
+        monitor_client_->remove_session(connection_id_);
+    }
+
+    void run()
+    {
+        // Set suggested timeout settings for the websocket
+        ws_.set_option(ws::stream_base::timeout::suggested(beast::role_type::server));
+
+        // Set a decorator to change the Server of the handshake
+        ws_.set_option(ws::stream_base::decorator([](ws::response_type& res) {
+            res.set(http::field::server, std::string(BOOST_BEAST_VERSION_STRING) + " CasparCG-Monitor");
+        }));
+
+        // Accept the websocket handshake
+        ws_.async_accept(beast::bind_front_handler(&websocket_monitor_session::on_accept, shared_from_this()));
+    }
+
+    void send(const std::string& message)
+    {
+        // Post the work to the correct executor
+        net::post(ws_.get_executor(), [self = shared_from_this(), message]() {
+            if (self->is_open_) {
+                self->ws_.async_write(net::buffer(message),
+                                      beast::bind_front_handler(&websocket_monitor_session::on_write, self));
+            }
+        });
+    }
+
+    bool is_connection_open() const { return is_open_; }
+
+    void close()
+    {
+        if (is_open_) {
+            is_open_ = false;
+            monitor_client_->remove_connection(connection_id_);
+            monitor_client_->remove_session(connection_id_);
+
+            // Graceful close
+            ws_.async_close(ws::close_code::normal, [self = shared_from_this()](beast::error_code ec) {
+                if (ec) {
+                    CASPAR_LOG(error) << L"WebSocket monitor session close error: " << u16(ec.message());
+                } else {
+                    CASPAR_LOG(info) << L"WebSocket monitor session closed gracefully: " << u16(self->connection_id_);
+                }
+            });
+
+            // Start force close timer (1 second)
+            if (!force_close_timer_)
+                force_close_timer_ = std::make_unique<boost::asio::deadline_timer>(io_context_);
+            force_close_timer_->expires_from_now(boost::posix_time::seconds(1));
+            force_close_timer_->async_wait([self = shared_from_this()](const boost::system::error_code& ec) {
+                if (!ec && self->ws_.is_open()) {
+                    CASPAR_LOG(warning) << L"WebSocket monitor session forcefully closed: "
+                                        << u16(self->connection_id_);
+                    self->ws_.next_layer().close();
+                }
+            });
+        }
+    }
+
+  private:
+    std::string generate_connection_id()
+    {
+        static std::atomic<uint64_t> counter{0};
+        return "monitor_" + std::to_string(counter++);
+    }
+
+    void on_accept(beast::error_code ec)
+    {
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor session accept error: " << u16(ec.message());
+            return;
+        }
+
+        is_open_ = true;
+
+        // Register this connection with the monitor client
+        auto weak_self = std::weak_ptr<websocket_monitor_session>(shared_from_this());
+        monitor_client_->add_connection(connection_id_, [weak_self](const std::string& message) {
+            auto self = weak_self.lock();
+            if (self) {
+                self->send(message);
+            }
+        });
+        monitor_client_->add_session(connection_id_, weak_self);
+
+        // Get subscription token
+        subscription_token_ = monitor_client_->get_subscription_token(connection_id_);
+
+        CASPAR_LOG(info) << L"WebSocket monitor session connected: " << u16(connection_id_);
+
+        // Start reading for potential close messages
+        do_read();
+    }
+
+    void do_read()
+    {
+        // Read a message into our buffer
+        ws_.async_read(buffer_, beast::bind_front_handler(&websocket_monitor_session::on_read, shared_from_this()));
+    }
+
+    void on_read(beast::error_code ec, std::size_t bytes_transferred)
+    {
+        boost::ignore_unused(bytes_transferred);
+
+        if (ec == ws::error::closed) {
+            // Connection closed normally
+            CASPAR_LOG(info) << L"WebSocket monitor session closed: " << u16(connection_id_);
+            is_open_ = false;
+            monitor_client_->remove_connection(connection_id_);
+            return;
+        }
+
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor session read error: " << u16(ec.message());
+            is_open_ = false;
+            monitor_client_->remove_connection(connection_id_);
+            return;
+        }
+
+        // Monitor connections are read-only, so we just ignore any incoming messages
+        // and continue reading
+        buffer_.consume(buffer_.size());
+        do_read();
+    }
+
+    void on_write(beast::error_code ec, std::size_t bytes_transferred)
+    {
+        boost::ignore_unused(bytes_transferred);
+
+        if (ec) {
+            CASPAR_LOG(error) << L"WebSocket monitor session write error: " << u16(ec.message());
+            is_open_ = false;
+            monitor_client_->remove_connection(connection_id_);
+            return;
+        }
+
+        // Continue processing (write completed successfully)
+    }
+};
+
+class websocket_monitor_server
+{
+    websocket_monitor_server(const websocket_monitor_server&)            = delete;
+    websocket_monitor_server& operator=(const websocket_monitor_server&) = delete;
+
+  public:
+    websocket_monitor_server(std::shared_ptr<boost::asio::io_service>  service,
+                             std::shared_ptr<websocket_monitor_client> monitor_client,
+                             uint16_t                                  port);
+
+    ~websocket_monitor_server();
+
+    void start();
+    void stop();
+
+  private:
+    struct impl;
+    spl::shared_ptr<impl> impl_;
+};
+
+}}} // namespace caspar::protocol::websocket

--- a/src/protocol/util/websocket_server.cpp
+++ b/src/protocol/util/websocket_server.cpp
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2024 CasparCG (www.casparcg.com).
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "../StdAfx.h"
+
+#include "websocket_server.h"
+
+#include <common/log.h>
+#include <common/utf.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <thread>
+
+namespace beast     = boost::beast;
+namespace http      = beast::http;
+namespace websocket = beast::websocket;
+namespace net       = boost::asio;
+using tcp           = net::ip::tcp;
+
+namespace caspar { namespace IO {
+
+// Convert monitor state to JSON string
+std::string monitor_state_to_json(const core::monitor::state& state)
+{
+    boost::property_tree::wptree json_tree;
+
+    // Add timestamp
+    json_tree.put(
+        L"timestamp",
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
+
+    // Convert monitor state to JSON structure
+    // The monitor state contains various performance and status information
+    boost::property_tree::wptree channels_tree;
+
+    for (const auto& channel_pair : state) {
+        const auto& path   = channel_pair.first;
+        const auto& values = channel_pair.second;
+
+        boost::property_tree::wptree channel_tree;
+        for (size_t i = 0; i < values.size(); ++i) {
+            const auto& value = values[i];
+
+            // Convert boost::variant to appropriate JSON value
+            if (auto int_val = boost::get<int>(&value)) {
+                channel_tree.put(u16(path + "/" + std::to_string(i)), *int_val);
+            } else if (auto double_val = boost::get<double>(&value)) {
+                channel_tree.put(u16(path + "/" + std::to_string(i)), *double_val);
+            } else if (auto string_val = boost::get<std::string>(&value)) {
+                channel_tree.put(u16(path + "/" + std::to_string(i)), u16(*string_val));
+            } else if (auto wstring_val = boost::get<std::wstring>(&value)) {
+                channel_tree.put(u16(path + "/" + std::to_string(i)), *wstring_val);
+            } else if (auto bool_val = boost::get<bool>(&value)) {
+                channel_tree.put(u16(path + "/" + std::to_string(i)), *bool_val);
+            }
+        }
+
+        if (!channel_tree.empty()) {
+            channels_tree.add_child(u16(path), channel_tree);
+        }
+    }
+
+    json_tree.add_child(L"data", channels_tree);
+
+    // Convert to JSON string
+    std::wstringstream json_stream;
+    boost::property_tree::write_json(json_stream, json_tree, false);
+    return u8(json_stream.str());
+}
+
+// WebSocket session for AMCP connections
+class websocket_amcp_session : public spl::enable_shared_from_this<websocket_amcp_session>
+{
+    websocket::stream<tcp::socket>                ws_;
+    std::string                                   address_;
+    std::map<std::wstring, std::shared_ptr<void>> lifecycle_objects_;
+    std::mutex                                    mutex_;
+    beast::flat_buffer                            buffer_;
+    std::shared_ptr<protocol_strategy<wchar_t>>   strategy_;
+
+    // Client connection holder for protocol strategy
+    class connection_holder : public client_connection<wchar_t>
+    {
+        std::weak_ptr<websocket_amcp_session> session_;
+
+      public:
+        explicit connection_holder(std::weak_ptr<websocket_amcp_session> session)
+            : session_(std::move(session))
+        {
+        }
+
+        void send(std::basic_string<wchar_t>&& data, bool skip_log) override
+        {
+            auto session = session_.lock();
+            if (session) {
+                session->send(std::move(data), skip_log);
+            }
+        }
+
+        void disconnect() override
+        {
+            auto session = session_.lock();
+            if (session) {
+                session->disconnect();
+            }
+        }
+
+        std::wstring address() const override
+        {
+            auto session = session_.lock();
+            if (session) {
+                return session->address();
+            }
+            return L"[destroyed-session]";
+        }
+
+        void add_lifecycle_bound_object(const std::wstring& key, const std::shared_ptr<void>& lifecycle_bound) override
+        {
+            auto session = session_.lock();
+            if (session) {
+                session->add_lifecycle_bound_object(key, lifecycle_bound);
+            }
+        }
+
+        std::shared_ptr<void> remove_lifecycle_bound_object(const std::wstring& key) override
+        {
+            auto session = session_.lock();
+            if (session) {
+                return session->remove_lifecycle_bound_object(key);
+            }
+            return std::shared_ptr<void>();
+        }
+    };
+
+  public:
+    websocket_amcp_session(tcp::socket socket)
+        : ws_(std::move(socket))
+    {
+        auto endpoint = ws_.next_layer().remote_endpoint();
+        address_      = endpoint.address().to_string() + ":" + std::to_string(endpoint.port());
+    }
+
+    void start(const protocol_strategy_factory<wchar_t>::ptr& strategy_factory)
+    {
+        // Create protocol strategy using the factory
+        auto client_connection = spl::make_shared<connection_holder>(shared_from_this());
+        strategy_              = strategy_factory->create(client_connection);
+
+        // Accept the websocket handshake
+        ws_.async_accept([self = shared_from_this()](beast::error_code ec) {
+            if (!ec) {
+                self->do_read();
+            } else {
+                CASPAR_LOG(error) << L"WebSocket AMCP accept failed: " << u16(ec.message());
+            }
+        });
+    }
+
+    void send(std::wstring&& data, bool skip_log)
+    {
+        auto self = shared_from_this();
+        net::post(ws_.get_executor(), [self, data = std::move(data), skip_log]() mutable {
+            try {
+                if (self->ws_.is_open()) {
+                    std::string utf8_data = u8(data);
+                    self->ws_.write(net::buffer(utf8_data));
+
+                    if (!skip_log) {
+                        if (data.length() < 512) {
+                            boost::replace_all(data, L"\n", L"\\n");
+                            boost::replace_all(data, L"\r", L"\\r");
+                            CASPAR_LOG(info) << L"Sent WebSocket message to " << u16(self->address_) << L": " << data;
+                        } else {
+                            CASPAR_LOG(info) << L"Sent WebSocket message (>512 bytes) to " << u16(self->address_);
+                        }
+                    }
+                }
+            } catch (const std::exception& e) {
+                CASPAR_LOG(error) << L"Failed to send WebSocket message: " << u16(e.what());
+            }
+        });
+    }
+
+    void disconnect()
+    {
+        auto self = shared_from_this();
+        net::post(ws_.get_executor(), [self]() {
+            try {
+                if (self->ws_.is_open()) {
+                    self->ws_.close(websocket::close_code::normal);
+                }
+            } catch (const std::exception& e) {
+                CASPAR_LOG(error) << L"Failed to close WebSocket connection: " << u16(e.what());
+            }
+        });
+    }
+
+    std::wstring address() const { return u16(address_); }
+
+    void add_lifecycle_bound_object(const std::wstring& key, const std::shared_ptr<void>& lifecycle_bound)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lifecycle_objects_[key] = lifecycle_bound;
+    }
+
+    std::shared_ptr<void> remove_lifecycle_bound_object(const std::wstring& key)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto                        it = lifecycle_objects_.find(key);
+        if (it != lifecycle_objects_.end()) {
+            auto result = it->second;
+            lifecycle_objects_.erase(it);
+            return result;
+        }
+        return std::shared_ptr<void>();
+    }
+
+  private:
+    void do_read()
+    {
+        auto self = shared_from_this();
+        ws_.async_read(buffer_, [self](beast::error_code ec, std::size_t bytes_transferred) {
+            if (!ec) {
+                try {
+                    std::string message = beast::buffers_to_string(self->buffer_.data());
+                    self->buffer_.consume(bytes_transferred);
+
+                    // Convert UTF-8 message to wide string for AMCP protocol
+                    std::wstring wide_msg = u16(message);
+
+                    // Debug logging
+                    CASPAR_LOG(info) << L"WebSocket received message: [" << wide_msg << L"] (length: "
+                                     << wide_msg.length() << L")";
+
+                    if (self->strategy_.get()) {
+                        // Ensure the message ends with AMCP delimiter
+                        if (!wide_msg.empty() && !boost::algorithm::ends_with(wide_msg, L"\r\n")) {
+                            wide_msg += L"\r\n";
+                        }
+                        self->strategy_->parse(wide_msg);
+                    }
+
+                    // Continue reading
+                    self->do_read();
+                } catch (const std::exception& e) {
+                    CASPAR_LOG(error) << L"Error processing AMCP WebSocket message: " << u16(e.what());
+                }
+            } else if (ec != websocket::error::closed) {
+                CASPAR_LOG(error) << L"WebSocket AMCP read error: " << u16(ec.message());
+            }
+        });
+    }
+};
+
+// WebSocket session for monitor connections
+class websocket_monitor_session : public spl::enable_shared_from_this<websocket_monitor_session>
+{
+    websocket::stream<tcp::socket> ws_;
+    std::string                    address_;
+
+  public:
+    websocket_monitor_session(tcp::socket socket)
+        : ws_(std::move(socket))
+    {
+        auto endpoint = ws_.next_layer().remote_endpoint();
+        address_      = endpoint.address().to_string() + ":" + std::to_string(endpoint.port());
+    }
+
+    void start()
+    {
+        // Accept the websocket handshake
+        ws_.async_accept([self = shared_from_this()](beast::error_code ec) {
+            if (!ec) {
+                CASPAR_LOG(info) << L"WebSocket Monitor client connected: " << u16(self->address_);
+                self->do_read();
+            } else {
+                CASPAR_LOG(error) << L"WebSocket Monitor accept failed: " << u16(ec.message());
+            }
+        });
+    }
+
+    void send_monitor_data(const std::string& json_data)
+    {
+        auto self = shared_from_this();
+        net::post(ws_.get_executor(), [self, json_data]() {
+            try {
+                if (self->ws_.is_open()) {
+                    self->ws_.write(net::buffer(json_data));
+                }
+            } catch (const std::exception& e) {
+                CASPAR_LOG(error) << L"Failed to send monitor data to WebSocket client: " << u16(e.what());
+            }
+        });
+    }
+
+    bool is_open() const { return ws_.is_open(); }
+
+    std::string address() const { return address_; }
+
+  private:
+    void do_read()
+    {
+        auto self = shared_from_this();
+        // Monitor connections are read-only, but we still need to handle close events
+        ws_.async_read(buffer_, [self](beast::error_code ec, std::size_t) {
+            if (ec == websocket::error::closed) {
+                CASPAR_LOG(info) << L"WebSocket Monitor client disconnected: " << u16(self->address_);
+            } else if (ec) {
+                CASPAR_LOG(error) << L"WebSocket Monitor read error: " << u16(ec.message());
+            } else {
+                // Ignore incoming messages from monitor clients
+                self->buffer_.clear();
+                self->do_read();
+            }
+        });
+    }
+
+    beast::flat_buffer buffer_;
+};
+
+struct websocket_server::impl : public spl::enable_shared_from_this<websocket_server::impl>
+{
+    std::shared_ptr<boost::asio::io_service> service_;
+    protocol_strategy_factory<wchar_t>::ptr  amcp_protocol_factory_;
+    uint16_t                                 amcp_port_;
+    uint16_t                                 monitor_port_;
+
+    tcp::acceptor amcp_acceptor_;
+    tcp::acceptor monitor_acceptor_;
+
+    std::set<spl::shared_ptr<websocket_monitor_session>>                                           monitor_sessions_;
+    std::vector<std::function<std::pair<std::wstring, std::shared_ptr<void>>(const std::string&)>> lifecycle_factories_;
+
+    std::mutex sessions_mutex_;
+
+    impl(std::shared_ptr<boost::asio::io_service>       service,
+         const protocol_strategy_factory<wchar_t>::ptr& amcp_protocol_factory,
+         uint16_t                                       amcp_port,
+         uint16_t                                       monitor_port)
+        : service_(service)
+        , amcp_protocol_factory_(amcp_protocol_factory)
+        , amcp_port_(amcp_port)
+        , monitor_port_(monitor_port)
+        , amcp_acceptor_(*service)
+        , monitor_acceptor_(*service)
+    {
+    }
+
+    void start()
+    {
+        try {
+            // Start AMCP server
+            tcp::endpoint amcp_endpoint{tcp::v4(), amcp_port_};
+            amcp_acceptor_.open(amcp_endpoint.protocol());
+            amcp_acceptor_.set_option(net::socket_base::reuse_address(true));
+            amcp_acceptor_.bind(amcp_endpoint);
+            amcp_acceptor_.listen();
+            do_accept_amcp();
+            CASPAR_LOG(info) << L"WebSocket AMCP server listening on port " << amcp_port_;
+
+            // Start Monitor server only if monitor_port is not 0
+            if (monitor_port_ != 0) {
+                tcp::endpoint monitor_endpoint{tcp::v4(), monitor_port_};
+                monitor_acceptor_.open(monitor_endpoint.protocol());
+                monitor_acceptor_.set_option(net::socket_base::reuse_address(true));
+                monitor_acceptor_.bind(monitor_endpoint);
+                monitor_acceptor_.listen();
+                do_accept_monitor();
+                CASPAR_LOG(info) << L"WebSocket Monitor server listening on port " << monitor_port_;
+            }
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"Failed to start WebSocket servers: " << u16(e.what());
+            throw;
+        }
+    }
+
+    void stop()
+    {
+        try {
+            amcp_acceptor_.close();
+            if (monitor_port_ != 0) {
+                monitor_acceptor_.close();
+            }
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"Error stopping WebSocket servers: " << u16(e.what());
+        }
+    }
+
+    void do_accept_amcp()
+    {
+        amcp_acceptor_.async_accept([self = shared_from_this()](beast::error_code ec, tcp::socket socket) {
+            if (!ec) {
+                auto session = spl::make_shared<websocket_amcp_session>(std::move(socket));
+
+                // Apply lifecycle factories
+                for (const auto& factory : self->lifecycle_factories_) {
+                    auto lifecycle_obj = factory(u8(session->address()));
+                    session->add_lifecycle_bound_object(lifecycle_obj.first, lifecycle_obj.second);
+                }
+
+                CASPAR_LOG(info) << L"WebSocket AMCP client connected: " << session->address();
+                session->start(self->amcp_protocol_factory_);
+            }
+
+            if (self->amcp_acceptor_.is_open()) {
+                self->do_accept_amcp();
+            }
+        });
+    }
+
+    void do_accept_monitor()
+    {
+        monitor_acceptor_.async_accept([self = shared_from_this()](beast::error_code ec, tcp::socket socket) {
+            if (!ec) {
+                auto session = spl::make_shared<websocket_monitor_session>(std::move(socket));
+
+                {
+                    std::lock_guard<std::mutex> lock(self->sessions_mutex_);
+                    self->monitor_sessions_.insert(session);
+                }
+
+                session->start();
+            }
+
+            if (self->monitor_acceptor_.is_open()) {
+                self->do_accept_monitor();
+            }
+        });
+    }
+
+    void send_monitor_data(const core::monitor::state& state)
+    {
+        if (monitor_sessions_.empty()) {
+            return;
+        }
+
+        try {
+            std::string json_data = monitor_state_to_json(state);
+
+            std::lock_guard<std::mutex> lock(sessions_mutex_);
+
+            // Send to all connected monitor clients and remove closed ones
+            auto it = monitor_sessions_.begin();
+            while (it != monitor_sessions_.end()) {
+                if ((*it)->is_open()) {
+                    (*it)->send_monitor_data(json_data);
+                    ++it;
+                } else {
+                    it = monitor_sessions_.erase(it);
+                }
+            }
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"Failed to convert monitor state to JSON: " << u16(e.what());
+        }
+    }
+
+    void add_client_lifecycle_object_factory(
+        const std::function<std::pair<std::wstring, std::shared_ptr<void>>(const std::string&)>& factory)
+    {
+        lifecycle_factories_.push_back(factory);
+    }
+};
+
+websocket_server::websocket_server(std::shared_ptr<boost::asio::io_service>       service,
+                                   const protocol_strategy_factory<wchar_t>::ptr& amcp_protocol_factory,
+                                   uint16_t                                       amcp_port,
+                                   uint16_t                                       monitor_port)
+    : impl_(spl::make_shared<impl>(service, amcp_protocol_factory, amcp_port, monitor_port))
+{
+}
+
+websocket_server::websocket_server(std::shared_ptr<boost::asio::io_service>       service,
+                                   const protocol_strategy_factory<wchar_t>::ptr& amcp_protocol_factory,
+                                   uint16_t                                       amcp_port)
+    : impl_(spl::make_shared<impl>(service, amcp_protocol_factory, amcp_port, 0))
+{
+}
+
+websocket_server::~websocket_server()
+{
+    if (impl_.get()) {
+        impl_->stop();
+    }
+}
+
+void websocket_server::start() { impl_->start(); }
+
+void websocket_server::stop() { impl_->stop(); }
+
+void websocket_server::send_monitor_data(const core::monitor::state& state) { impl_->send_monitor_data(state); }
+
+void websocket_server::add_client_lifecycle_object_factory(
+    const std::function<std::pair<std::wstring, std::shared_ptr<void>>(const std::string& address)>& factory)
+{
+    impl_->add_client_lifecycle_object_factory(factory);
+}
+
+}} // namespace caspar::IO

--- a/src/protocol/util/websocket_server.h
+++ b/src/protocol/util/websocket_server.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 CasparCG (www.casparcg.com).
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "protocol_strategy.h"
+
+#include <common/memory.h>
+#include <core/monitor/monitor.h>
+
+#include <boost/asio.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+
+#include <functional>
+#include <memory>
+#include <set>
+#include <string>
+
+namespace caspar { namespace IO {
+
+/**
+ * WebSocket server that handles both AMCP protocol commands and monitor data streaming.
+ */
+class websocket_server
+{
+  public:
+    // Constructor for AMCP + Monitor (legacy)
+    websocket_server(std::shared_ptr<boost::asio::io_service>       service,
+                     const protocol_strategy_factory<wchar_t>::ptr& amcp_protocol_factory,
+                     uint16_t                                       amcp_port,
+                     uint16_t                                       monitor_port);
+
+    // Constructor for AMCP only (new)
+    websocket_server(std::shared_ptr<boost::asio::io_service>       service,
+                     const protocol_strategy_factory<wchar_t>::ptr& amcp_protocol_factory,
+                     uint16_t                                       amcp_port);
+
+    ~websocket_server();
+
+    void start();
+    void stop();
+
+    // Send monitor data to all connected monitor clients
+    void send_monitor_data(const core::monitor::state& state);
+
+    // Add lifecycle factory for AMCP clients
+    void add_client_lifecycle_object_factory(
+        const std::function<std::pair<std::wstring, std::shared_ptr<void>>(const std::string& address)>& factory);
+
+  private:
+    struct impl;
+    spl::shared_ptr<impl> impl_;
+
+    websocket_server(const websocket_server&)            = delete;
+    websocket_server& operator=(const websocket_server&) = delete;
+};
+
+}} // namespace caspar::IO

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -23,6 +23,10 @@
             <protocol>AMCP</protocol>
         </tcp>
     </controllers>
+    <websocket>
+        <amcp-port>5251</amcp-port>
+        <monitor-port>5252</monitor-port>
+    </websocket>
     <amcp>
         <media-server>
             <host>localhost</host>
@@ -205,4 +209,8 @@
     </predefined-client>
   </predefined-clients>
 </osc>
+<websocket>
+  <amcp-port>5251 [1..65535]</amcp-port>
+  <monitor-port>5252 [1..65535]</monitor-port>
+</websocket>
 -->


### PR DESCRIPTION
WIP implement websocket server using boost beast for AMCP and monitoring

Exposes 2 websocket ports…One for AMCP…the other port for monitoring.  When a client connects to the monitor websocket, the full state is sent and then subsequent updates will be the charge deltas in RFC6902 format.

The monitor client can request a full_state message by sending {“command”:”request_full_state”}