### PR TITLE
Fixes for Boost 1.88

### DIFF
--- a/src/accelerator/StdAfx.h
+++ b/src/accelerator/StdAfx.h
@@ -5,7 +5,6 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_service.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/property_tree/ptree_fwd.hpp>

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/core/null_deleter.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -71,7 +71,7 @@ struct artnet_consumer : public core::frame_consumer
 
         std::string host_ = u8(this->config.host);
         remote_endpoint =
-            boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(host_), this->config.port);
+            boost::asio::ip::udp::endpoint(boost::asio::ip::make_address(host_), this->config.port);
 
         compute_fixtures();
     }

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -64,8 +64,8 @@ struct artnet_consumer : public core::frame_consumer
 
     explicit artnet_consumer(configuration config)
         : config(std::move(config))
-        , io_service_()
-        , socket(io_service_)
+        , io_context_()
+        , socket(io_context_)
     {
         socket.open(udp::v4());
 
@@ -177,7 +177,7 @@ struct artnet_consumer : public core::frame_consumer
     std::thread       thread_;
     std::atomic<bool> abort_request_{false};
 
-    io_service    io_service_;
+    io_context    io_context_;
     udp::socket   socket;
     udp::endpoint remote_endpoint;
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1716,7 +1716,7 @@ std::wstring osc_subscribe_command(command_context& ctx)
     }
 
     auto subscription = ctx.static_context->osc_client->get_subscription_token(
-        udp::endpoint(address_v4::from_string(u8(ctx.client->address())), port));
+        udp::endpoint(make_address_v4(u8(ctx.client->address())), port));
 
     ctx.client->add_lifecycle_bound_object(get_osc_subscription_token(port), subscription);
 

--- a/src/protocol/osc/client.cpp
+++ b/src/protocol/osc/client.cpp
@@ -65,7 +65,7 @@ struct param_visitor : public boost::static_visitor<void>
 
 struct client::impl : public spl::enable_shared_from_this<client::impl>
 {
-    std::shared_ptr<boost::asio::io_context> service_;
+    std::shared_ptr<boost::asio::io_context> io_context_;
     udp::socket                              socket_;
     std::map<udp::endpoint, int>             reference_counts_by_endpoint_;
     std::vector<char>                        buffer_;
@@ -81,9 +81,9 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
     std::thread       thread_;
 
   public:
-    impl(std::shared_ptr<boost::asio::io_service> service)
-        : service_(std::move(service))
-        , socket_(*service_, udp::v4())
+    impl(std::shared_ptr<boost::asio::io_context> io_context)
+        : io_context_(std::move(io_context))
+        , socket_(*io_context_, udp::v4())
         , buffer_(1000000)
     {
         thread_ = std::thread([=] {
@@ -197,8 +197,8 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
     }
 };
 
-client::client(std::shared_ptr<boost::asio::io_context> service)
-    : impl_(new impl(std::move(service)))
+client::client(std::shared_ptr<boost::asio::io_context> io_context)
+    : impl_(new impl(std::move(io_context)))
 {
 }
 

--- a/src/protocol/osc/client.h
+++ b/src/protocol/osc/client.h
@@ -35,7 +35,7 @@ class client
     client& operator=(const client&);
 
   public:
-    client(std::shared_ptr<boost::asio::io_context> service);
+    client(std::shared_ptr<boost::asio::io_context> context);
 
     client(client&&);
 

--- a/src/protocol/util/AsyncEventServer.h
+++ b/src/protocol/util/AsyncEventServer.h
@@ -36,7 +36,7 @@ using lifecycle_factory_t =
 class AsyncEventServer
 {
   public:
-    explicit AsyncEventServer(std::shared_ptr<boost::asio::io_service>    service,
+    explicit AsyncEventServer(std::shared_ptr<boost::asio::io_context>    io_context,
                               const protocol_strategy_factory<char>::ptr& protocol,
                               unsigned short                              port);
     ~AsyncEventServer();

--- a/src/protocol/util/http_request.cpp
+++ b/src/protocol/util/http_request.cpp
@@ -19,14 +19,13 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
     asio::io_context io_context;
 
     // Get a list of endpoints corresponding to the server name.
-    tcp::resolver           resolver(io_context);
-    tcp::resolver::query    query(host, port, boost::asio::ip::resolver_query_base::numeric_service);
-    tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+    tcp::resolver               resolver(io_context);
+    tcp::resolver::results_type resolver_result = resolver.resolve(host, port, boost::asio::ip::resolver_query_base::numeric_service);
 
     // Try each endpoint until we successfully establish a connection.
     tcp::socket               socket(io_context);
     boost::system::error_code error;
-    asio::connect(socket, endpoint_iterator, error);
+    asio::connect(socket, resolver_result, error);
     if (error == asio::error::connection_refused) {
         res.status_code    = 503;
         res.status_message = "Connection refused";

--- a/src/protocol/util/http_request.cpp
+++ b/src/protocol/util/http_request.cpp
@@ -16,15 +16,15 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
 
     HTTPResponse res;
 
-    asio::io_service io_service;
+    asio::io_context io_context;
 
     // Get a list of endpoints corresponding to the server name.
-    tcp::resolver           resolver(io_service);
+    tcp::resolver           resolver(io_context);
     tcp::resolver::query    query(host, port, boost::asio::ip::resolver_query_base::numeric_service);
     tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 
     // Try each endpoint until we successfully establish a connection.
-    tcp::socket               socket(io_service);
+    tcp::socket               socket(io_context);
     boost::system::error_code error;
     asio::connect(socket, endpoint_iterator, error);
     if (error == asio::error::connection_refused) {

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -321,7 +321,7 @@ struct server::impl
                 const auto port    = ptree_get<unsigned short>(predefined_client.second, L"port");
 
                 boost::system::error_code ec;
-                auto                      ipaddr = address_v4::from_string(u8(address), ec);
+                auto                      ipaddr = make_address_v4(u8(address), ec);
                 if (!ec)
                     predefined_osc_subscriptions_.push_back(
                         osc_client_->get_subscription_token(udp::endpoint(ipaddr, port)));
@@ -337,7 +337,7 @@ struct server::impl
 
                     return std::make_pair(std::wstring(L"osc_subscribe"),
                                           osc_client_->get_subscription_token(
-                                              udp::endpoint(address_v4::from_string(ipv4_address), default_port)));
+                                              udp::endpoint(make_address_v4(ipv4_address), default_port)));
                 });
     }
 


### PR DESCRIPTION
This PR migrates a couple of Boost classes and functions which have been marked deprecated since Boost 1.66 and have been removed with Boost 1.88.

 * **`io_context` replaces ``io_service``:**
   `io_service` has been a `typedef` to `io_context` since Boost 1.66 for backward compatibility (see https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/io_service.html). Also some of its methods have been declared deprecated (e.g. `io_service::dispatch()`, `io_service::post`). In some locations, CasparCG already has been using the replacement type `io_context`. For clarity all variables `service_...` have been renamed to `context_...`.
 * **`ip::make_address()` replaces `ip::address::from_string`:**
  That is an obvious one. The new method is also around since Boost 1.66 (see https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__address/make_address.html)
 * **`ip::basic_resolver::query` deprecated:**
   That type definition has been removed with Boost 1.88 and is marked deprecated since Boost 1.66 (see [ip::basic_resolver::query](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__basic_resolver/query.html)). Instead we need to directly pass the parameters to `resolver.resolve` instead of wrapping them into a `query` object. (See https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__basic_resolver/query.html)
 * **Missing header for `boost::bind`:**
   Another no-brainer. `common::log` uses `boost::bind` and the include for that header was simply missing. The bug becomes apparent with Boost 1.88.