### PR TITLE
fix: ffmpeg consumer pts on frame-drop

### DIFF
--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -376,16 +376,18 @@ struct Stream
         return std::shared_ptr<SwsContext>(sws.get(), [this, sws](SwsContext*) { sws_.push(sws); });
     }
 
-    void send(std::pair<core::const_frame, std::int64_t>&    in_frame,
+    void send(std::tuple<core::const_frame, std::int64_t, std::int64_t>&    data,
               const core::video_format_desc&                 format_desc,
               std::function<void(std::shared_ptr<AVPacket>)> cb)
     {
         std::shared_ptr<AVFrame>  frame;
         std::shared_ptr<AVPacket> pkt;
 
-        if (in_frame.first) {
+        const auto [in_frame, video_pts, audio_pts] = data;
+
+        if (in_frame) {
             if (enc->codec_type == AVMEDIA_TYPE_VIDEO) {
-                frame = make_av_video_frame(in_frame.first, format_desc);
+                frame = make_av_video_frame(in_frame, format_desc);
 
                 {
                     auto frame2                 = alloc_frame();
@@ -423,10 +425,10 @@ struct Stream
                     frame = std::move(frame2);
                 }
 
-                frame->pts = in_frame.second;
+                frame->pts = video_pts;
             } else if (enc->codec_type == AVMEDIA_TYPE_AUDIO) {
-                frame      = make_av_audio_frame(in_frame.first, format_desc);
-                frame->pts = in_frame.second * frame->nb_samples;
+                frame      = make_av_audio_frame(in_frame, format_desc);
+                frame->pts = audio_pts;
             } else {
                 // TODO
             }
@@ -470,7 +472,8 @@ struct ffmpeg_consumer : public core::frame_consumer
     int                     channel_index_ = -1;
     core::video_format_desc format_desc_;
     bool                    realtime_ = false;
-    std::int64_t            frame_number = 0;
+    std::int64_t            video_pts = 0;
+    std::int64_t            audio_pts = 0;
 
     spl::shared_ptr<diagnostics::graph> graph_;
 
@@ -480,7 +483,7 @@ struct ffmpeg_consumer : public core::frame_consumer
     std::exception_ptr exception_;
     std::mutex         exception_mutex_;
 
-    tbb::concurrent_bounded_queue<std::pair<core::const_frame, std::int64_t> > frame_buffer_;
+    tbb::concurrent_bounded_queue<std::tuple<core::const_frame, std::int64_t, std::int64_t> > frame_buffer_;
     std::thread                                      frame_thread_;
 
     common::bit_depth depth_;
@@ -510,7 +513,7 @@ struct ffmpeg_consumer : public core::frame_consumer
     ~ffmpeg_consumer()
     {
         if (frame_thread_.joinable()) {
-            frame_buffer_.push(std::make_pair(core::const_frame{}, -1));
+            frame_buffer_.push({ core::const_frame{}, -1, -1 });
             frame_thread_.join();
         }
     }
@@ -669,8 +672,8 @@ struct ffmpeg_consumer : public core::frame_consumer
                         state_["file/frame"] = frame_number++;
                     }
 
-                    std::pair<core::const_frame, std::int64_t> frame;
-                    frame_buffer_.pop(frame);
+                    std::tuple<core::const_frame, std::int64_t, std::int64_t> data;
+                    frame_buffer_.pop(data);
                     graph_->set_value("input",
                                       static_cast<double>(frame_buffer_.size() + 0.001) / frame_buffer_.capacity());
 
@@ -678,17 +681,17 @@ struct ffmpeg_consumer : public core::frame_consumer
                     tbb::parallel_invoke(
                         [&] {
                             if (video_stream) {
-                                video_stream->send(frame, format_desc, packet_cb);
+                                video_stream->send(data, format_desc, packet_cb);
                             }
                         },
                         [&] {
                             if (audio_stream) {
-                                audio_stream->send(frame, format_desc, packet_cb);
+                                audio_stream->send(data, format_desc, packet_cb);
                             }
                         });
                     graph_->set_value("frame-time", frame_timer.elapsed() * format_desc.fps * 0.5);
 
-                    if (!frame.first) {
+                    if (!std::get<0>(data)) {
                         packet_buffer.push(nullptr);
                         break;
                     }
@@ -713,9 +716,13 @@ struct ffmpeg_consumer : public core::frame_consumer
             }
         }
 
-        if (!frame_buffer_.try_push(std::make_pair(frame, this->frame_number++))) {
+        if (!frame_buffer_.try_push({ frame, video_pts, audio_pts })) {
             graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
         }
+
+        video_pts += 1;
+        audio_pts += frame.audio_data().size() / format_desc_.audio_channels;
+
         graph_->set_value("input", static_cast<double>(frame_buffer_.size() + 0.001) / frame_buffer_.capacity());
 
         return make_ready_future(true);


### PR DESCRIPTION
If the `frame_buffer_` gets full and we start dropping frames, the timestamps will become incorrect and the playback will speed up. This changes so the frame counter is passed along with the frame, making the timestamp correct even when frames are dropped.