### PR TITLE
fix: leave thread_type to any

### DIFF
--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -158,10 +158,6 @@ class Decoder
 #endif
         }
 
-        if (codec->capabilities & AV_CODEC_CAP_SLICE_THREADS) {
-            ctx->thread_type = FF_THREAD_SLICE;
-        }
-
         FF(avcodec_open2(ctx.get(), codec, nullptr));
 
         thread = boost::thread([=]() {


### PR DESCRIPTION
Just because the codec supports slice-threads, doesn't mean the file we're opening do. If I understand correctly, for many formats a file must have been encoded using slices to be able to be decoded in slices.

By forcing thread-slicing, we make it almost impossible to decode media that cant be slice-decoded, as it's forcing single-threaded decoding.