### PR TITLE
Fix for unicode conversion in json UPDATE to html engine. fixing #1106

### DIFF
--- a/src/modules/html/producer/html_cg_proxy.cpp
+++ b/src/modules/html/producer/html_cg_proxy.cpp
@@ -28,8 +28,58 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/format.hpp>
+#include <sstream>
+#include <iomanip>
+#include <common/log.h>
 
 namespace caspar { namespace html {
+
+// Properly escape a string for JavaScript, with safe Unicode handling
+std::wstring escape_javascript_string(const std::wstring& str)
+{
+    std::wostringstream escaped;
+    
+    for (wchar_t c : str) {
+        switch (c) {
+            case L'"':
+                escaped << L"\\\"";
+                break;
+            case L'\\':
+                escaped << L"\\\\";
+                break;
+            case L'\n':
+                escaped << L"\\n";
+                break;
+            case L'\r':
+                escaped << L"\\r";
+                break;
+            case L'\t':
+                escaped << L"\\t";
+                break;
+            case L'\b':
+                escaped << L"\\b";
+                break;
+            case L'\f':
+                escaped << L"\\f";
+                break;
+            default:
+                if (c < 32) {
+                    // Escape control characters only
+                    escaped << L"\\u" << std::hex << std::setfill(L'0') << std::setw(4) << static_cast<int>(c);
+                } else if (c < 127) {
+                    // Safe ASCII characters
+                    escaped << c;
+                } else {
+                    // For Unicode characters (including emojis), use Unicode escape sequences
+                    // This ensures safe transmission through all encoding layers
+                    escaped << L"\\u" << std::hex << std::setfill(L'0') << std::setw(4) << static_cast<int>(c);
+                }
+                break;
+        }
+    }
+    
+    return escaped.str();
+}
 
 html_cg_proxy::html_cg_proxy(const spl::shared_ptr<core::frame_producer>& producer)
     : producer_(producer)
@@ -60,19 +110,108 @@ void html_cg_proxy::next(int layer) { producer_->call({L"next()"}); }
 
 void html_cg_proxy::update(int layer, const std::wstring& data)
 {
-    producer_->call({(boost::wformat(L"update(\"%1%\")") %
-                      boost::algorithm::replace_all_copy(
-                          boost::algorithm::trim_copy_if(data, boost::is_any_of(" \"")), "\"", "\\\""))
-                         .str()});
+    try {
+        // Log what we received for debugging (safely, without logging the actual content)
+        CASPAR_LOG(debug) << L"HTML CG Proxy received data with " << data.length() << L" characters";
+        
+        // Trim the data 
+        std::wstring trimmed_data;
+        try {
+            trimmed_data = boost::algorithm::trim_copy_if(data, boost::is_any_of(" \""));
+            CASPAR_LOG(debug) << L"HTML CG Proxy successfully trimmed data";
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"HTML CG Proxy trim failed: " << e.what();
+            throw;
+        } catch (...) {
+            CASPAR_LOG(error) << L"HTML CG Proxy trim failed with unknown error";
+            throw;
+        }
+        
+        // Pre-validate and clean the JSON to prevent crashes
+        // Remove any control characters that might cause JSON parsing issues
+        std::wstring json_safe_data;
+        try {
+            for (wchar_t c : trimmed_data) {
+                if (c >= 32 && c < 127) { 
+                    // ASCII printable characters - safe to include
+                    json_safe_data += c;
+                } else if (c == '\t' || c == '\n' || c == '\r') {
+                    // Keep legitimate whitespace
+                    json_safe_data += c;
+                } else if (c >= 128) {
+                    // Unicode characters - keep them for emojis etc
+                    // But check if they're valid printable Unicode
+                    if (c != 0xFFFD && c != 0xFEFF) { // Skip replacement char and BOM
+                        json_safe_data += c;
+                    }
+                }
+                // Skip all other control characters (0-31, 127, replacement chars)
+            }
+            CASPAR_LOG(debug) << L"HTML CG Proxy successfully cleaned JSON data";
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"HTML CG Proxy JSON cleaning failed: " << e.what();
+            throw;
+        } catch (...) {
+            CASPAR_LOG(error) << L"HTML CG Proxy JSON cleaning failed with unknown error";
+            throw;
+        }
+        
+        // Now escape for JavaScript
+        std::wstring escaped_data;
+        try {
+            escaped_data = escape_javascript_string(json_safe_data);
+            CASPAR_LOG(debug) << L"HTML CG Proxy successfully escaped data";
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"HTML CG Proxy escape_javascript_string failed: " << e.what();
+            throw;
+        } catch (...) {
+            CASPAR_LOG(error) << L"HTML CG Proxy escape_javascript_string failed with unknown error";
+            throw;
+        }
+        
+        // Log what we're sending for debugging (without content to avoid encoding issues)
+        CASPAR_LOG(debug) << L"HTML CG Proxy sending " << json_safe_data.length() << L" characters of cleaned JSON";
+        
+        // Robust error handling to prevent app crashes
+        std::wstring javascript_call;
+        try {
+            javascript_call = (boost::wformat(L"(function() { try { if (typeof update === 'function') { update(\"%1%\"); } else { console.warn('update function not available'); } } catch(e) { console.error('CasparCG update error:', e.message, 'Data length:', %2%); } })();") % escaped_data % json_safe_data.length()).str();
+            CASPAR_LOG(debug) << L"HTML CG Proxy successfully formatted JavaScript call";
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"HTML CG Proxy boost::wformat failed: " << e.what();
+            throw;
+        } catch (...) {
+            CASPAR_LOG(error) << L"HTML CG Proxy boost::wformat failed with unknown error";
+            throw;
+        }
+        
+        producer_->call({javascript_call});
+    } catch (const std::exception& e) {
+        CASPAR_LOG(error) << L"HTML CG Proxy update failed: " << e.what();
+    } catch (...) {
+        CASPAR_LOG(error) << L"HTML CG Proxy update failed with unknown error";
+    }
 }
 
 std::wstring html_cg_proxy::invoke(int layer, const std::wstring& label)
 {
-    auto function_call = boost::algorithm::trim_copy_if(label, boost::is_any_of(" \""));
+    try {
+        auto function_call = boost::algorithm::trim_copy_if(label, boost::is_any_of(" \""));
 
-    // Append empty () if no parameter list has been given
-    auto javascript = boost::ends_with(function_call, ")") ? function_call : function_call + L"()";
-    return producer_->call({javascript}).get();
+        // Append empty () if no parameter list has been given
+        auto javascript = boost::ends_with(function_call, ")") ? function_call : function_call + L"()";
+        
+        // Wrap in try-catch to prevent JavaScript errors from crashing the command channel
+        auto safe_javascript = L"try { return " + javascript + L"; } catch(e) { console.error('CasparCG invoke error:', e.message, e.stack); return ''; }";
+        
+        return producer_->call({safe_javascript}).get();
+    } catch (const std::exception& e) {
+        CASPAR_LOG(error) << L"HTML CG Proxy invoke failed: " << e.what();
+        return L"";
+    } catch (...) {
+        CASPAR_LOG(error) << L"HTML CG Proxy invoke failed with unknown error";
+        return L"";
+    }
 }
 
 }} // namespace caspar::html

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -38,6 +38,7 @@
 #include <boost/log/keywords/delimiter.hpp>
 
 #include <common/diagnostics/graph.h>
+#include <common/log.h>
 
 #if defined(_MSC_VER)
 #pragma warning(push, 1) // TODO: Legacy code, just disable warnings
@@ -140,7 +141,10 @@ class AMCPProtocolStrategy
             return;
         }
 
-        CASPAR_LOG(info) << L"Received message from " << client->address() << ": " << message << L"\\r\\n";
+        // Sanitize message for logging to prevent conversion errors
+        std::wstring sanitized_log_message = message;
+        caspar::log::replace_nonprintable(sanitized_log_message, L'?');
+        CASPAR_LOG(info) << L"Received message from " << client->address() << ": " << sanitized_log_message << L"\\r\\n";
 
         std::wstring request_id;
         std::wstring command_name;

--- a/src/protocol/util/strategy_adapters.cpp
+++ b/src/protocol/util/strategy_adapters.cpp
@@ -25,6 +25,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/locale.hpp>
+#include <common/log.h>
 
 namespace caspar { namespace IO {
 
@@ -42,9 +43,97 @@ class to_unicode_adapter : public protocol_strategy<char>
 
     void parse(const std::basic_string<char>& data) override
     {
-        auto utf_data = boost::locale::conv::to_utf<wchar_t>(data, codepage_);
-
-        unicode_strategy_->parse(utf_data);
+        try {
+            // Try multiple UTF-8 conversion methods for better emoji support
+            std::wstring utf_data;
+            bool conversion_success = false;
+            
+            // Method 1: Standard conversion with stop method
+            try {
+                utf_data = boost::locale::conv::to_utf<wchar_t>(data, "UTF-8", boost::locale::conv::method_type::stop);
+                conversion_success = true;
+            } catch (...) {
+                // Fall through to next method
+            }
+            
+            // Method 2: Try with default conversion method
+            if (!conversion_success) {
+                try {
+                    utf_data = boost::locale::conv::to_utf<wchar_t>(data, "UTF-8");
+                    conversion_success = true;
+                } catch (...) {
+                    // Fall through to next method
+                }
+            }
+            
+            // Method 3: Use skip method as fallback
+            if (!conversion_success) {
+                try {
+                    utf_data = boost::locale::conv::to_utf<wchar_t>(data, "UTF-8", boost::locale::conv::method_type::skip);
+                    conversion_success = true;
+                } catch (...) {
+                    // Fall through to exception handling
+                }
+            }
+            
+            if (conversion_success) {
+                unicode_strategy_->parse(utf_data);
+            } else {
+                // Trigger fallback methods
+                throw boost::locale::conv::conversion_error();
+            }
+        } catch (const boost::locale::conv::conversion_error& e) {
+            // Log the conversion error for debugging
+            CASPAR_LOG(warning) << L"UTF-8 conversion failed, trying fallback methods. Data size: " << data.size();
+            
+            // Try fallback approaches to preserve UTF-8 characters
+            bool conversion_success = false;
+            
+            // Fallback 1: Try with stop method using original codepage
+            if (!conversion_success) {
+                try {
+                    auto utf_data = boost::locale::conv::to_utf<wchar_t>(data, codepage_, boost::locale::conv::method_type::stop);
+                    unicode_strategy_->parse(utf_data);
+                    conversion_success = true;
+                } catch (...) {
+                    // Continue to next fallback
+                }
+            }
+            
+            // Fallback 2: Try direct UTF-8 to UTF-16 conversion
+            if (!conversion_success) {
+                try {
+                    auto fallback_data = boost::locale::conv::utf_to_utf<wchar_t>(data);
+                    unicode_strategy_->parse(fallback_data);
+                    conversion_success = true;
+                } catch (...) {
+                    // Continue to next fallback
+                }
+            }
+            
+            // Fallback 3: Try with skip method
+            if (!conversion_success) {
+                try {
+                    auto utf_data = boost::locale::conv::to_utf<wchar_t>(data, codepage_, boost::locale::conv::method_type::skip);
+                    unicode_strategy_->parse(utf_data);
+                    conversion_success = true;
+                } catch (...) {
+                    // Continue to last resort
+                }
+            }
+            
+            // Last resort: Treat as Latin-1
+            if (!conversion_success) {
+                CASPAR_LOG(warning) << L"All UTF-8 conversion methods failed, treating as Latin-1";
+                
+                std::wstring fallback_data;
+                fallback_data.reserve(data.size());
+                for (char c : data) {
+                    fallback_data += static_cast<wchar_t>(static_cast<unsigned char>(c));
+                }
+                unicode_strategy_->parse(fallback_data);
+            }
+        }
     }
 };
 
@@ -63,19 +152,39 @@ class from_unicode_client_connection : public client_connection<wchar_t>
 
     void send(std::basic_string<wchar_t>&& data, bool skip_log) override
     {
-        auto str = boost::locale::conv::from_utf<wchar_t>(data, codepage_);
+        try {
+            auto str = boost::locale::conv::from_utf<wchar_t>(data, codepage_);
+            client_->send(std::move(str), skip_log);
+            
+            if (skip_log)
+                return;
 
-        client_->send(std::move(str), skip_log);
-
-        if (skip_log)
-            return;
-
-        if (data.length() < 512) {
-            boost::replace_all(data, L"\n", L"\\n");
-            boost::replace_all(data, L"\r", L"\\r");
-            CASPAR_LOG(info) << L"Sent message to " << client_->address() << L":" << data;
-        } else
-            CASPAR_LOG(info) << L"Sent more than 512 bytes to " << client_->address();
+            if (data.length() < 512) {
+                boost::replace_all(data, L"\n", L"\\n");
+                boost::replace_all(data, L"\r", L"\\r");
+                CASPAR_LOG(info) << L"Sent message to " << client_->address() << L":" << data;
+            } else
+                CASPAR_LOG(info) << L"Sent more than 512 bytes to " << client_->address();
+        } catch (const std::exception& e) {
+            CASPAR_LOG(error) << L"Failed to send message to " << client_->address() << L": " << e.what();
+            // Try to send a simple error message
+            try {
+                std::string simple_error = "500 ENCODING ERROR\r\n";
+                client_->send(std::move(simple_error), true);
+            } catch (...) {
+                // If even that fails, disconnect the client
+                CASPAR_LOG(error) << L"Complete send failure, disconnecting client " << client_->address();
+                client_->disconnect();
+            }
+        } catch (...) {
+            CASPAR_LOG(error) << L"Failed to send message to " << client_->address() << L" with unknown error";
+            // Try to disconnect gracefully
+            try {
+                client_->disconnect();
+            } catch (...) {
+                // Nothing more we can do
+            }
+        }
     }
 
     void disconnect() override { client_->disconnect(); }


### PR DESCRIPTION
This is an attempt to resolve bug #1106, whereby Unicode characters in JSON via an AMCP CG UPDATE command rendered the AMCP channel unusable.
This solution has been extensively tested with many different Unicode payloads, and the AMCP connection now continues to function.
A try/catch has also been added so that the template continues to work even if the JSON is incorrect and no error message is logged.