### PR TITLE
fix: This commit fixes the Docker build so it can run headless in docker

### DIFF
--- a/tools/linux/Dockerfile
+++ b/tools/linux/Dockerfile
@@ -17,13 +17,14 @@ FROM docker.io/buildpack-deps:jammy AS build-casparcg
 
 	RUN cmake --build .
 
-    RUN cmake --install . --prefix staging
+	RUN cmake --install . --prefix staging
 
 	# Find a better way to copy deps
 	RUN ln -s /build/staging /staging && \
-		/source/shell/copy_deps.sh /staging/bin/casparcg /staging/lib
+		/source/shell/copy_deps.sh /build/shell/casparcg /staging/lib
 
 FROM docker.io/nvidia/opengl:1.2-glvnd-devel-ubuntu22.04
+
 	COPY --from=build-casparcg /staging /opt/casparcg
 
 	RUN set -ex; \
@@ -37,6 +38,6 @@ FROM docker.io/nvidia/opengl:1.2-glvnd-devel-ubuntu22.04
 			rm -rf /var/lib/apt/lists/*
 
 	WORKDIR /opt/casparcg
-
+	RUN chmod 755 run.sh
 	ADD tools/linux/run_docker.sh ./
 	CMD ["./run_docker.sh"]

--- a/tools/linux/run_docker.sh
+++ b/tools/linux/run_docker.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 
 if [ -z "$DISPLAY" ]; then 
-  echo "DISPLAY is not set"
-  exit 9
+  echo "WARNING: DISPLAY is not set"
 fi
 
 if [ ! -d /tmp/.X11-unix ]; then
-  echo "X11 socket not found"
-  exit 9
+  echo "WARNING: X11 socket not found"
 fi
 
 if [ ! -f /root/.Xauthority ]; then
-  echo "Xauthority not found"
-  exit 9
+  echo "WARNING: Xauthority not found"
 fi
 
 ./run.sh


### PR DESCRIPTION
When building the provided Dockerfile the needed runtime dependencies were not available on runtime causing CasparCG not to start. 

Also checks in run_docker.sh for X, DISPLAY and Xauthority should not be fatat in case of running ccg headless without X.