### PR TITLE
fix: Solving problem that only limited number of CEF layers work in Docker environment. Fixes  #1675

### DIFF
--- a/src/modules/html/html.cpp
+++ b/src/modules/html/html.cpp
@@ -166,6 +166,10 @@ class renderer_application
 
     void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line) override
     {
+
+        command_line->AppendSwitchWithValue("renderer-process-limit", "20");
+        command_line->AppendSwitch("disable-dev-shm-usage");
+
         if (enable_gpu_) {
             command_line->AppendSwitch("enable-webgl");
 


### PR DESCRIPTION
When running CasparCG in headless mode in Docker only limited number of html layers work (2 with gpu enabled, 4 without gpu). 

This fix increases the number of CEF processes and disables shared memory, which migh be to limited in Docker environments.

// FIX 1: Increase renderer process limit to support more concurrent HTML layers
// Default CEF limit is ~3-6 processes, which limits HTML layer count
command_line->AppendSwitchWithValue("renderer-process-limit", "20");

// FIX 2: Prevent shared memory exhaustion on Linux (especially in Docker)
// /dev/shm is limited to 64MB by default in most Docker containers
command_line->AppendSwitch("disable-dev-shm-usage");