### PR TITLE
fix bug where path was crashing http request

### DIFF
--- a/.github/workflows/linux-system.yml
+++ b/.github/workflows/linux-system.yml
@@ -27,7 +27,7 @@ jobs:
 
                   # Build a version number for this build
                   GH_REF="${GITHUB_REF##*/}"
-                  GH_REF=$(echo "$GH_REF" | sed 's/[\/]/_/g' | sed 's/ /_/g')
+                  GH_REF=$(echo "$GH_REF" | sed 's/[\/]/-/g' | sed 's/ /-/g' | sed 's/_/-/g')
 
                   VERSION_MAJOR=$(grep -oPi 'set\(CONFIG_VERSION_MAJOR \K\d+' src/CMakeLists.txt)
                   VERSION_MINOR=$(grep -oPi 'set\(CONFIG_VERSION_MINOR \K\d+' src/CMakeLists.txt)

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1463,13 +1463,13 @@ std::wstring thumbnail_list_command(command_context& ctx)
 std::wstring thumbnail_retrieve_command(command_context& ctx)
 {
     return make_request(
-        ctx, "/thumbnail/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL RETRIEVE FAILED\r\n");
+        ctx, "/thumbnail/" + http::url_encode_path(u8(ctx.parameters.at(0))), L"501 THUMBNAIL RETRIEVE FAILED\r\n");
 }
 
 std::wstring thumbnail_generate_command(command_context& ctx)
 {
     return make_request(
-        ctx, "/thumbnail/generate/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL GENERATE FAILED\r\n");
+        ctx, "/thumbnail/generate/" + http::url_encode_path(u8(ctx.parameters.at(0))), L"501 THUMBNAIL GENERATE FAILED\r\n");
 }
 
 std::wstring thumbnail_generateall_command(command_context& ctx)
@@ -1481,7 +1481,7 @@ std::wstring thumbnail_generateall_command(command_context& ctx)
 
 std::wstring cinf_command(command_context& ctx)
 {
-    return make_request(ctx, "/cinf/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 CINF FAILED\r\n");
+    return make_request(ctx, "/cinf/" + http::url_encode_path(u8(ctx.parameters.at(0))), L"501 CINF FAILED\r\n");
 }
 
 std::wstring cls_command(command_context& ctx) { return make_request(ctx, "/cls", L"501 CLS FAILED\r\n"); }

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1806,13 +1806,14 @@ std::wstring thumbnail_list_command(command_context& ctx)
 std::wstring thumbnail_retrieve_command(command_context& ctx)
 {
     return make_request(
-        ctx, "/thumbnail/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL RETRIEVE FAILED\r\n");
+        ctx, "/thumbnail/" + http::url_encode_path(u8(ctx.parameters.at(0))), L"501 THUMBNAIL RETRIEVE FAILED\r\n");
 }
 
 std::wstring thumbnail_generate_command(command_context& ctx)
 {
-    return make_request(
-        ctx, "/thumbnail/generate/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 THUMBNAIL GENERATE FAILED\r\n");
+    return make_request(ctx,
+                        "/thumbnail/generate/" + http::url_encode_path(u8(ctx.parameters.at(0))),
+                        L"501 THUMBNAIL GENERATE FAILED\r\n");
 }
 
 std::wstring thumbnail_generateall_command(command_context& ctx)
@@ -1824,7 +1825,7 @@ std::wstring thumbnail_generateall_command(command_context& ctx)
 
 std::wstring cinf_command(command_context& ctx)
 {
-    return make_request(ctx, "/cinf/" + http::url_encode(u8(ctx.parameters.at(0))), L"501 CINF FAILED\r\n");
+    return make_request(ctx, "/cinf/" + http::url_encode_path(u8(ctx.parameters.at(0))), L"501 CINF FAILED\r\n");
 }
 
 std::wstring cls_command(command_context& ctx) { return make_request(ctx, "/cls", L"501 CLS FAILED\r\n"); }

--- a/src/protocol/util/http_request.cpp
+++ b/src/protocol/util/http_request.cpp
@@ -1,6 +1,7 @@
 #include "http_request.h"
 
 #include <common/except.h>
+#include <common/log.h>
 
 #include <boost/asio.hpp>
 #include <sstream>
@@ -14,6 +15,9 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
     using namespace boost;
 
     HTTPResponse res;
+
+    // Debug log the URL being requested
+    CASPAR_LOG(debug) << "HTTP request: GET " << path;
 
     asio::io_context io_context;
 

--- a/src/protocol/util/http_request.cpp
+++ b/src/protocol/util/http_request.cpp
@@ -16,8 +16,8 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
 
     HTTPResponse res;
 
-    // Debug log the URL being requested
-    CASPAR_LOG(debug) << "HTTP request: GET " << path;
+    // Log the URL being requested for debugging
+    CASPAR_LOG(info) << "HTTP GET: " << path;
 
     asio::io_context io_context;
 

--- a/src/protocol/util/http_request.cpp
+++ b/src/protocol/util/http_request.cpp
@@ -1,9 +1,9 @@
 #include "http_request.h"
 
 #include <common/except.h>
+#include <common/log.h>
 
 #include <boost/asio.hpp>
-#include <iomanip>
 #include <sstream>
 #include <string>
 
@@ -15,6 +15,9 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
     using namespace boost;
 
     HTTPResponse res;
+
+    // Log the URL being requested for debugging
+    CASPAR_LOG(debug) << "HTTP GET: " << path;
 
     asio::io_context io_context;
 
@@ -63,13 +66,12 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
     std::getline(response_stream, res.status_message);
 
     if (!response_stream || http_version.substr(0, 5) != "HTTP/") {
-        // TODO
-        CASPAR_THROW_EXCEPTION(io_error() << msg_info("Invalid Response"));
+        CASPAR_THROW_EXCEPTION(io_error() << msg_info("Invalid HTTP response"));
     }
 
     if (res.status_code < 200 || res.status_code >= 300) {
-        // TODO
-        CASPAR_THROW_EXCEPTION(io_error() << msg_info("Invalid Response"));
+        CASPAR_THROW_EXCEPTION(io_error()
+                               << msg_info("HTTP request failed with status " + std::to_string(res.status_code)));
     }
 
     // Read the response headers, which are terminated by a blank line.
@@ -102,21 +104,30 @@ HTTPResponse request(const std::string& host, const std::string& port, const std
     return res;
 }
 
-std::string url_encode(const std::string& str)
+// URL-encode a file path. Normalizes '\' to '/' (Windows-style paths) before encoding,
+// so lookups match the scanner's internally stored id regardless of client OS.
+// The scanner's routes take the whole id as a single path segment, so '/' is percent-encoded
+// like any other reserved character rather than left as a literal separator.
+std::string url_encode_path(const std::string& path)
 {
-    std::stringstream escaped;
-    escaped.fill('0');
-    escaped << std::hex;
+    std::string result;
+    result.reserve(path.size() * 2); // Reserve space to avoid reallocations
 
-    for (auto c : str) {
-        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
-            escaped << c;
+    for (auto c : path) {
+        unsigned char uc = (c == '\\') ? '/' : static_cast<unsigned char>(c);
+
+        if ((uc >= 'A' && uc <= 'Z') || (uc >= 'a' && uc <= 'z') || (uc >= '0' && uc <= '9') || uc == '-' ||
+            uc == '_' || uc == '.' || uc == '~') {
+            result += static_cast<char>(uc);
         } else {
-            escaped << std::uppercase << '%' << std::setw(2) << int((unsigned char)c) << std::nouppercase;
+            // Encode special character (including '/') as %XX
+            result += '%';
+            result += "0123456789ABCDEF"[uc >> 4];
+            result += "0123456789ABCDEF"[uc & 0x0F];
         }
     }
 
-    return escaped.str();
+    return result;
 }
 
 }} // namespace caspar::http

--- a/src/protocol/util/http_request.h
+++ b/src/protocol/util/http_request.h
@@ -15,6 +15,8 @@ struct HTTPResponse
 
 HTTPResponse request(const std::string& host, const std::string& port, const std::string& path);
 
-std::string url_encode(const std::string& str);
+// URL-encode a file path, preserving '/' and '\' as path separators.
+// Encodes special characters in each path component per RFC 3986.
+std::string url_encode_path(const std::string& path);
 
 }} // namespace caspar::http

--- a/src/protocol/util/http_request.h
+++ b/src/protocol/util/http_request.h
@@ -15,6 +15,8 @@ struct HTTPResponse
 
 HTTPResponse request(const std::string& host, const std::string& port, const std::string& path);
 
-std::string url_encode(const std::string& str);
+// URL-encode a file path. Normalizes '\' to '/' before encoding, so lookups match
+// regardless of client OS; '/' is percent-encoded like any other character.
+std::string url_encode_path(const std::string& path);
 
 }} // namespace caspar::http


### PR DESCRIPTION
This is a rough but successful attempt at fixing url path encoding errors with thumbnail retrieval.  Thumbnail retrieval was broken on windows for files with some special characters.  This was an AI assisted patch so please review changes closely.