### PR TITLE
Add missing `cstdint` include

### DIFF
--- a/src/common/bit_depth.h
+++ b/src/common/bit_depth.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <cstdint>
 
 namespace caspar { namespace common {
 


### PR DESCRIPTION
On some environments, `cstdint` isn't included through `memory`, causing a compile error due to missing `uint8_t` typedef.