### PR TITLE
feat: add new image scaling modes

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -140,10 +140,30 @@ struct image_kernel::impl
                     transform.fill_scale[1] *= target_scale / height_scale;
                     break;
 
+                case core::frame_geometry::scale_mode::fit_center:
+                    target_scale = std::min(width_scale, height_scale);
+
+                    transform.fill_scale[0] *= target_scale / width_scale;
+                    transform.fill_scale[1] *= target_scale / height_scale;
+
+                    transform.fill_translation[0] = (1.0 - transform.fill_scale[0]) * 0.5;
+                    transform.fill_translation[1] = (1.0 - transform.fill_scale[1]) * 0.5;
+                    break;
+
                 case core::frame_geometry::scale_mode::fill:
                     target_scale = std::max(width_scale, height_scale);
                     transform.fill_scale[0] *= target_scale / width_scale;
                     transform.fill_scale[1] *= target_scale / height_scale;
+                    break;
+
+                case core::frame_geometry::scale_mode::fill_center:
+                    target_scale = std::max(width_scale, height_scale);
+                    transform.fill_scale[0] *= target_scale / width_scale;
+                    transform.fill_scale[1] *= target_scale / height_scale;
+
+                    transform.fill_translation[0] = (1.0 - transform.fill_scale[0]) * 0.5;
+                    transform.fill_translation[1] = (1.0 - transform.fill_scale[1]) * 0.5;
+
                     break;
 
                 case core::frame_geometry::scale_mode::original:
@@ -151,12 +171,35 @@ struct image_kernel::impl
                     transform.fill_scale[1] /= height_scale;
                     break;
 
+                case core::frame_geometry::scale_mode::original_center:
+                    transform.fill_scale[0] /= width_scale;
+                    transform.fill_scale[1] /= height_scale;
+
+                    transform.fill_translation[0] = (1.0 - transform.fill_scale[0]) * 0.5;
+                    transform.fill_translation[1] = (1.0 - transform.fill_scale[1]) * 0.5;
+
+                    break;
+
                 case core::frame_geometry::scale_mode::hfill:
                     transform.fill_scale[1] *= width_scale / height_scale;
                     break;
 
+                case core::frame_geometry::scale_mode::hfill_center:
+                    transform.fill_scale[1] *= width_scale / height_scale;
+
+                    transform.fill_translation[0] = (1.0 - transform.fill_scale[0]) * 0.5;
+                    transform.fill_translation[1] = (1.0 - transform.fill_scale[1]) * 0.5;
+                    break;
+
                 case core::frame_geometry::scale_mode::vfill:
                     transform.fill_scale[0] *= height_scale / width_scale;
+                    break;
+
+                case core::frame_geometry::scale_mode::vfill_center:
+                    transform.fill_scale[0] *= height_scale / width_scale;
+
+                    transform.fill_translation[0] = (1.0 - transform.fill_scale[0]) * 0.5;
+                    transform.fill_translation[1] = (1.0 - transform.fill_scale[1]) * 0.5;
                     break;
 
                 default:;

--- a/src/core/frame/geometry.cpp
+++ b/src/core/frame/geometry.cpp
@@ -92,14 +92,24 @@ frame_geometry::scale_mode scale_mode_from_string(const std::wstring& str)
     auto str2 = boost::to_lower_copy(str);
     if (str2 == L"fit") {
         return frame_geometry::scale_mode::fit;
+    } else if (str2 == L"fit_center") {
+        return frame_geometry::scale_mode::fit_center;
     } else if (str2 == L"fill") {
         return frame_geometry::scale_mode::fill;
+    } else if (str2 == L"fill_center") {
+        return frame_geometry::scale_mode::fill_center;
     } else if (str2 == L"original") {
         return frame_geometry::scale_mode::original;
+    } else if (str2 == L"original_center") {
+        return frame_geometry::scale_mode::original_center;
     } else if (str2 == L"hfill") {
         return frame_geometry::scale_mode::hfill;
+    } else if (str2 == L"hfill_center") {
+        return frame_geometry::scale_mode::hfill_center;
     } else if (str2 == L"vfill") {
         return frame_geometry::scale_mode::vfill;
+    } else if (str2 == L"vfill_center") {
+        return frame_geometry::scale_mode::vfill_center;
     } else {
         return frame_geometry::scale_mode::stretch;
     }
@@ -110,14 +120,24 @@ std::wstring scale_mode_to_string(frame_geometry::scale_mode mode)
     switch (mode) {
         case frame_geometry::scale_mode::fit:
             return L"FIT";
+        case frame_geometry::scale_mode::fit_center:
+            return L"FIT_CENTER";
         case frame_geometry::scale_mode::fill:
             return L"FILL";
+        case frame_geometry::scale_mode::fill_center:
+            return L"FILL_CENTER";
         case frame_geometry::scale_mode::original:
             return L"ORIGINAL";
+        case frame_geometry::scale_mode::original_center:
+            return L"ORIGINAL_CENTER";
         case frame_geometry::scale_mode::hfill:
             return L"HFILL";
+        case frame_geometry::scale_mode::hfill_center:
+            return L"HFILL_CENTER";
         case frame_geometry::scale_mode::vfill:
             return L"VFILL";
+        case frame_geometry::scale_mode::vfill_center:
+            return L"VFILL_CENTER";
         default:
             return L"STRETCH";
     }

--- a/src/core/frame/geometry.h
+++ b/src/core/frame/geometry.h
@@ -39,10 +39,15 @@ class frame_geometry
     {
         stretch, // default
         fit,
+        fit_center,
         fill,
+        fill_center,
         original,
+        original_center,
         hfill,
+        hfill_center,
         vfill,
+        vfill_center,
     };
 
     struct coord


### PR DESCRIPTION
CasparCG#1566 added support for new scaling modes, allowing for images' aspect ratios to be transformed in standard ways to get scaling modes like fit, fill, original, hfill, and vfill.

However, often with content that does not match the aspect ratio of the consumer, the image must be centered. This PR adds support for new scaling modes that are the same as the 5 added in #1566 but include a `_CENTER` eg. `FIT_CENTER`, which both fits and centers the image.