### PR TITLE
fix: prevent AMCP channel crash on Unicode/emoji in CG UPDATE (#1106)

### DIFF
--- a/src/modules/html/producer/html_cg_proxy.cpp
+++ b/src/modules/html/producer/html_cg_proxy.cpp
@@ -60,10 +60,9 @@ void html_cg_proxy::next(int layer) { producer_->call({L"next()"}); }
 
 void html_cg_proxy::update(int layer, const std::wstring& data)
 {
-    producer_->call({(boost::wformat(L"update(\"%1%\")") %
-                      boost::algorithm::replace_all_copy(
-                          boost::algorithm::trim_copy_if(data, boost::is_any_of(" \"")), "\"", "\\\""))
-                         .str()});
+    auto escaped = boost::algorithm::replace_all_copy(
+        boost::algorithm::trim_copy_if(data, boost::is_any_of(" \"")), "\"", "\\\"");
+    producer_->call({L"update(\"" + escaped + L"\")"});
 }
 
 std::wstring html_cg_proxy::invoke(int layer, const std::wstring& label)

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -404,16 +404,17 @@ class html_client
                           const CefString&      source,
                           int                   line) override
     {
+        auto msg = log::replace_nonprintable_copy(message.ToWString(), L'?');
         if (level == cef_log_severity_t::LOGSEVERITY_DEBUG)
-            CASPAR_LOG(debug) << print() << L" Log: " << message.ToWString();
+            CASPAR_LOG(debug) << print() << L" Log: " << msg;
         else if (level == cef_log_severity_t::LOGSEVERITY_WARNING)
-            CASPAR_LOG(warning) << print() << L" Log: " << message.ToWString();
+            CASPAR_LOG(warning) << print() << L" Log: " << msg;
         else if (level == cef_log_severity_t::LOGSEVERITY_ERROR)
-            CASPAR_LOG(error) << print() << L" Log: " << message.ToWString();
+            CASPAR_LOG(error) << print() << L" Log: " << msg;
         else if (level == cef_log_severity_t::LOGSEVERITY_FATAL)
-            CASPAR_LOG(fatal) << print() << L" Log: " << message.ToWString();
+            CASPAR_LOG(fatal) << print() << L" Log: " << msg;
         else
-            CASPAR_LOG(info) << print() << L" Log: " << message.ToWString();
+            CASPAR_LOG(info) << print() << L" Log: " << msg;
         return true;
     }
 
@@ -484,7 +485,7 @@ class html_client
         if (name == LOG_MESSAGE_NAME) {
             auto args     = message->GetArgumentList();
             auto severity = static_cast<boost::log::trivial::severity_level>(args->GetInt(0));
-            auto msg      = args->GetString(1).ToWString();
+            auto msg = log::replace_nonprintable_copy(args->GetString(1).ToWString(), L'?');
 
             BOOST_LOG_SEV(log::logger::get(), severity) << print() << L" [renderer_process] " << msg;
         }

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -140,7 +140,8 @@ class AMCPProtocolStrategy
             return;
         }
 
-        CASPAR_LOG(info) << L"Received message from " << client->address() << ": " << message << L"\\r\\n";
+        CASPAR_LOG(info) << L"Received message from " << client->address() << ": "
+                         << log::replace_nonprintable_copy(message, L'?') << L"\\r\\n";
 
         std::wstring request_id;
         std::wstring command_name;

--- a/src/protocol/util/strategy_adapters.cpp
+++ b/src/protocol/util/strategy_adapters.cpp
@@ -42,7 +42,7 @@ class to_unicode_adapter : public protocol_strategy<char>
 
     void parse(const std::basic_string<char>& data) override
     {
-        auto utf_data = boost::locale::conv::to_utf<wchar_t>(data, codepage_);
+        auto utf_data = boost::locale::conv::to_utf<wchar_t>(data, codepage_, boost::locale::conv::skip);
 
         unicode_strategy_->parse(utf_data);
     }
@@ -73,7 +73,8 @@ class from_unicode_client_connection : public client_connection<wchar_t>
         if (data.length() < 512) {
             boost::replace_all(data, L"\n", L"\\n");
             boost::replace_all(data, L"\r", L"\\r");
-            CASPAR_LOG(info) << L"Sent message to " << client_->address() << L":" << data;
+            CASPAR_LOG(info) << L"Sent message to " << client_->address() << L":"
+                             << log::replace_nonprintable_copy(data, L'?');
         } else
             CASPAR_LOG(info) << L"Sent more than 512 bytes to " << client_->address();
     }


### PR DESCRIPTION
boost::log throws conversion_error when logging wide strings containing characters outside the system locale's encoding (e.g. emojis on C locale). Since this exception is unhandled in the AMCP protocol handler, it kills the connection when running CasparCG in Docker.

Fix by sanitizing log output with replace_nonprintable() in the three places where user-supplied wide strings are logged:
- AMCPProtocolStrategy: received AMCP messages
- html_producer: CEF console messages and renderer process messages
- strategy_adapters: sent response messages

Also replace boost::wformat with string concatenation in html_cg_proxy::update() to avoid a secondary crash path, and use explicit skip method for UTF-8 conversion to gracefully handle any invalid sequences.

This is a minimal rework of the earlier #1673 PR, addressing the review feedback to reduce code changes.

## Test plan

- [x] Send `CG UPDATE` with emoji content (e.g. `{"message": "Hello 😀 World"}`) — connection stays alive
- [x] Send complex multi-byte emojis (flags 🇳🇱, families 👨‍👩‍👧‍👦, skin tones 👋🏻) — no crash
- [x] Send mixed ASCII + Unicode + emoji content — works correctly
- [x] Verify emojis render correctly in the HTML template
- [x] Verify AMCP connection remains stable after multiple emoji updates

Test template: [debug.html](https://github.com/user-attachments/files/25441266/debug.html)
Test script: [emoji_utf8_test.js](https://github.com/user-attachments/files/25441276/emoji_utf8_test.js)  (use: node emoji_utf8_test.js localhost 5250)

