### PR TITLE
OAL + screen consumer fixes

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -56,6 +56,7 @@ set(HEADERS
 		scope_exit.h
 		stdafx.h
 		timer.h
+		timespan.h
 		tweener.h
 		utf.h
 )

--- a/src/common/timespan.h
+++ b/src/common/timespan.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Dimitry Ishenko <dimitry (dot) ishenko (at) (gee) mail (dot) com>
+ */
+
+#pragma once
+
+#include "except.h"
+
+#include <chrono>
+#include <cmath> // std::floor
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace caspar {
+
+struct timespan
+{
+    using duration = std::chrono::high_resolution_clock::duration;
+    using storage  = std::variant<int, duration>;
+
+    timespan() : timespan{0} { }
+    explicit timespan(int frames) : value_{frames} { }
+
+    template<typename Rep, typename Period>
+    explicit timespan(std::chrono::duration<Rep, Period> d)
+        : value_{std::chrono::duration_cast<duration>(d)}
+    { }
+
+    // accepts: "42s", "42ms", "42us", "42µs", "42ns" or "42" (frames)
+    explicit timespan(std::string_view s)
+    try
+    {
+        std::istringstream ss{ std::string{s} };
+        double v;
+        if (!(ss >> v)) throw std::invalid_argument{"Expected a number"};
+
+        std::string suffix;
+        ss >> suffix;
+        if (!suffix.empty() && !(ss >> std::ws).eof())
+            throw std::invalid_argument{"Unexpected characters after suffix"};
+
+        if (suffix.empty()) {
+            if (v != std::trunc(v)) throw std::invalid_argument{"Fractional frame count"};
+            value_ = static_cast<int>(v);
+        } else if (suffix ==  "s") {
+            value_ = std::chrono::duration_cast<duration>(std::chrono::duration<double>{v});
+        } else if (suffix == "ms") {
+            value_ = std::chrono::duration_cast<duration>(std::chrono::duration<double, std::milli>{v});
+        } else if (suffix == "us" || suffix == "µs" || suffix == "μs") {
+            value_ = std::chrono::duration_cast<duration>(std::chrono::duration<double, std::micro>{v});
+        } else if (suffix == "ns") {
+            value_ = std::chrono::duration_cast<duration>(std::chrono::duration<double, std::nano >{v});
+        } else {
+            throw std::invalid_argument{
+                "Invalid suffix '" + suffix + "' - expected s, ms, us/µs, ns, or nothing (frames)"
+            };
+        }
+    } catch (...) {
+        CASPAR_THROW_EXCEPTION(user_error()
+            << msg_info("Failed to parse timespan '" + std::string{s} + "'")
+            << nested_exception(std::current_exception())
+        );
+    }
+
+    int in_frames(double fps) const
+    {
+        if (std::holds_alternative<int>(value_)) return std::get<int>(value_);
+
+        auto dura  = std::chrono::duration<double>{1. / fps};
+        auto total = std::chrono::duration<double>{std::get<duration>(value_)};
+        return static_cast<int>(total / dura + .5);
+    }
+
+    duration as_duration(double fps) const
+    {
+        if (std::holds_alternative<duration>(value_))
+            return std::get<duration>(value_);
+
+        auto dura = std::chrono::duration<double>(1. / fps);
+        return std::chrono::duration_cast<duration>(dura * std::get<int>(value_));
+    }
+
+private:
+    storage value_;
+};
+
+}

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -193,7 +193,7 @@ public:
 struct oal_consumer : public core::frame_consumer
 {
     spl::shared_ptr<diagnostics::graph> graph_;
-    caspar::timer                       perf_timer_;
+    caspar::timer                       tick_timer_, frame_timer_;
     int                                 channel_index_ = -1;
 
     core::video_format_desc format_desc_;
@@ -217,9 +217,11 @@ struct oal_consumer : public core::frame_consumer
     explicit oal_consumer(const std::string& device_name, const delay_value& delay) :
         device_{ device::open(device_name) }, delay_{delay}
     {
-        graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
-        graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
-        graph_->set_color("late-frame", diagnostics::color(0.6f, 0.3f, 0.3f));
+        using diagnostics::color;
+        graph_->set_color("tick-time",  color(0.0, 0.6, 0.9));
+        graph_->set_color("queue-size", color(0.2, 0.9, 0.9));
+        graph_->set_color("frame-time", color(0.1, 1.0, 0.1));
+        graph_->set_color("drop-out",   color(0.6, 0.3, 0.3));
         diagnostics::register_graph(graph_);
     }
 
@@ -312,6 +314,8 @@ struct oal_consumer : public core::frame_consumer
             auto to = reinterpret_cast<std::uint8_t*>(audio_out.data());
             swr_convert(swr_.get(), &to, num_samples, &from, num_samples);
 
+            double free_size;
+            bool dropout = false;
             {
                 // submit to OAL queue
                 std::unique_lock lock{mutex_};
@@ -325,14 +329,20 @@ struct oal_consumer : public core::frame_consumer
                     format_desc_.audio_sample_rate
                 );
                 alSourceQueueBuffers(source_, 1, &buf);
+                free_size = free_.size();
 
                 ALenum state = 0;
                 alGetSourcei(source_, AL_SOURCE_STATE, &state);
-                if (state != AL_PLAYING) alSourcePlay(source_);
+                if (state != AL_PLAYING) {
+                    dropout = true;
+                    alSourcePlay(source_);
+                }
             }
 
-            graph_->set_value("tick-time", perf_timer_.elapsed() * format_desc_.fps * 0.5);
-            perf_timer_.restart();
+            graph_->set_value("tick-time", tick_timer_.elapsed() * format_desc_.fps * 0.5);
+            tick_timer_.restart();
+            graph_->set_value("queue-size", 1 - free_size / buffers_.size());
+            if (dropout) graph_->set_tag(diagnostics::tag_severity::WARNING, "drop-out");
         });
 
         return std::async(std::launch::deferred, [this] {
@@ -352,6 +362,8 @@ struct oal_consumer : public core::frame_consumer
                 }
                 if (done) {
                     free_cv_.notify_one();
+                    graph_->set_value("frame-time", frame_timer_.elapsed() * format_desc_.fps * 0.5);
+                    frame_timer_.restart();
                     return true;
                 }
                 std::this_thread::sleep_for(100us);

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -65,8 +65,7 @@ class device
     const std::wstring device_name_;
 
   public:
-    explicit device(std::wstring device_name)
-        : device_name_(std::move(device_name))
+    explicit device(std::wstring device_name) : device_name_(std::move(device_name))
     {
         ALCchar* deviceName = nullptr;
 
@@ -164,18 +163,6 @@ class device
     }
 };
 
-void init_device()
-{
-    static std::unique_ptr<device> instance;
-    static std::once_flag          f;
-
-    std::call_once(f, [&] {
-        std::wstring device_name =
-            env::properties().get(L"configuration.system-audio.producer.default-device-name", L"");
-        instance = std::make_unique<device>(device_name);
-    });
-}
-
 struct oal_consumer : public core::frame_consumer
 {
     spl::shared_ptr<diagnostics::graph> graph_;
@@ -184,6 +171,7 @@ struct oal_consumer : public core::frame_consumer
 
     core::video_format_desc format_desc_;
 
+    device              device_;
     ALuint              source_ = 0;
     std::vector<ALuint> buffers_;
     bool                started_  = false;
@@ -194,10 +182,8 @@ struct oal_consumer : public core::frame_consumer
     executor executor_{L"oal_consumer"};
 
   public:
-    explicit oal_consumer()
+    explicit oal_consumer(std::wstring device_name) : device_{std::move(device_name)}
     {
-        init_device();
-
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
         graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
         graph_->set_color("late-frame", diagnostics::color(0.6f, 0.3f, 0.3f));
@@ -386,10 +372,10 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                                                       const core::channel_info& channel_info)
 {
-    if (params.empty() || !boost::iequals(params.at(0), L"AUDIO"))
+    if (params.empty() || !(boost::iequals(params.at(0), L"AUDIO") || boost::iequals(params.at(0), L"SYSTEM-AUDIO")))
         return core::frame_consumer::empty();
 
-    return spl::make_shared<oal_consumer>();
+    return spl::make_shared<oal_consumer>(get_param(L"DEVICE_NAME", params, L""));
 }
 
 spl::shared_ptr<core::frame_consumer>
@@ -398,7 +384,7 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               const core::channel_info&                                channel_info)
 {
-    return spl::make_shared<oal_consumer>();
+    return spl::make_shared<oal_consumer>(ptree.get(L"device-name", L""));
 }
 
 }} // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -56,6 +56,7 @@ extern "C" {
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -67,13 +68,49 @@ namespace caspar::oal {
 
 using namespace std::chrono_literals;
 
+struct delay_value
+{
+    int value;
+    enum { frames, msec } type;
+
+    auto in_frames(const core::video_format_desc& desc) {
+        return (type == msec) ? static_cast<int>(value * desc.fps / 1000. + .5) : value;
+    }
+
+    static delay_value from_string(const std::string& s)
+    {
+        try {
+            std::istringstream ss{s};
+
+            int value;
+            if (!(ss >> value)) throw std::invalid_argument{"Invalid delay value"};
+
+            std::string suffix;
+            ss >> suffix;
+
+            if (suffix.size())
+            {
+                if (suffix != "ms") throw std::invalid_argument{"Invalid suffix - expected 'ms' or nothing"};
+                if (!(ss >> std::ws).eof()) throw std::invalid_argument{"Trailing garbage"};
+                return {value, msec};
+            }
+            else return {value, frames};
+
+        } catch (...) {
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info("Failed to parse delay " + s)
+                << nested_exception(std::current_exception())
+            );
+        }
+    }
+};
+
 class device
 {
     ALCdevice*  device_  = nullptr;
     ALCcontext* context_ = nullptr;
 
   public:
-    explicit device(std::wstring device_name)
+    explicit device(const std::string& device_name)
     {
         auto norm = [](std::string s) {
             s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
@@ -86,7 +123,7 @@ class device
         if (device_name.size()) {
             if (alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT")) {
 
-                auto match = norm(u8(device_name));
+                auto name = norm(device_name);
 
                 auto enum_all_ext = alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT");
                 auto names = alcGetString(nullptr, enum_all_ext ? ALC_ALL_DEVICES_SPECIFIER : ALC_DEVICE_SPECIFIER);
@@ -98,7 +135,7 @@ class device
                     std::string found{p};
                     CASPAR_LOG(info) << found;
 
-                    if (match == norm(found)) found_name = found;
+                    if (name == norm(found)) found_name = found;
                 }
 
                 CASPAR_LOG(info) << "-------- OpenAL Devices -------";
@@ -148,6 +185,7 @@ struct oal_consumer : public core::frame_consumer
     ALuint              source_ = 0;
     std::vector<ALuint> buffers_;
     std::queue<ALuint>  free_;
+    delay_value         delay_;
 
     std::mutex          mutex_;
     std::condition_variable free_cv_;
@@ -159,7 +197,8 @@ struct oal_consumer : public core::frame_consumer
     executor executor_{L"oal_consumer"};
 
   public:
-    explicit oal_consumer(std::wstring device_name) : device_{std::move(device_name)}
+    explicit oal_consumer(const std::string& device_name, const delay_value& delay) :
+        device_{device_name}, delay_{delay}
     {
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
         graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));
@@ -207,24 +246,35 @@ struct oal_consumer : public core::frame_consumer
             swr_.reset(raw);
             swr_init(raw);
 
+            auto num_silence = delay_.in_frames(format_desc_);
+            num_silence = std::clamp(num_silence, 1, static_cast<int>(format_desc_.fps));
+
+            CASPAR_LOG(info) << print() << " Latency: " << num_silence << " frames";
+
             std::lock_guard guard{mutex_};
 
-            buffers_.resize(16);
+            buffers_.resize(num_silence + 2);
             alGenBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
-            for (auto buf : buffers_) free_.push(buf);
 
             alGenSources(1, &source_);
 
-            // queue one frame worth of silence to ensure there is something
-            // in the OAL queue until we get the next frame
-            std::vector<int16_t> silence(format_desc_.audio_cadence[0] * 2, 0); // stereo
-            auto buf = free_.front();
-            free_.pop();
-            alBufferData(buf, AL_FORMAT_STEREO16, silence.data(),
-                static_cast<ALsizei>(silence.size() * sizeof(std::int16_t)),
-                format_desc_.audio_sample_rate
-            );
-            alSourceQueueBuffers(source_, 1, &buf);
+            std::vector<std::int16_t> silence;
+            for (auto n = 0; n < buffers_.size(); ++n) {
+                auto buf = buffers_[n];
+
+                if (n < num_silence) {
+                    auto cadence = format_desc_.audio_cadence[n % format_desc_.audio_cadence.size()];
+                    silence.resize(cadence * 2); // stereo
+
+                    alBufferData(buf, AL_FORMAT_STEREO16, silence.data(),
+                        static_cast<ALsizei>(silence.size() * sizeof(std::int16_t)),
+                        format_desc_.audio_sample_rate
+                    );
+                    alSourceQueueBuffers(source_, 1, &buf);
+                } else {
+                    free_.push(buf);
+                }
+            }
         });
     }
 
@@ -312,7 +362,9 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     if (params.empty() || !(boost::iequals(params.at(0), L"AUDIO") || boost::iequals(params.at(0), L"SYSTEM-AUDIO")))
         return core::frame_consumer::empty();
 
-    return spl::make_shared<oal_consumer>(get_param(L"DEVICE_NAME", params, L""));
+    auto device_name = u8(get_param(L"DEVICE_NAME", params, L""));
+    auto s = u8(get_param(L"DELAY", params, L"0"));
+    return spl::make_shared<oal_consumer>(device_name, delay_value::from_string(s));
 }
 
 spl::shared_ptr<core::frame_consumer>
@@ -321,7 +373,9 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               const core::channel_info&                                channel_info)
 {
-    return spl::make_shared<oal_consumer>(ptree.get(L"device-name", L""));
+    auto device_name = u8(ptree.get(L"device-name", L""));
+    auto s = u8(ptree.get(L"delay", L"0"));
+    return spl::make_shared<oal_consumer>(device_name, delay_value::from_string(s));
 }
 
 } // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -53,6 +53,7 @@ extern "C" {
 #include <cctype>
 #include <condition_variable>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -109,7 +110,6 @@ class device
     ALCdevice*  device_  = nullptr;
     ALCcontext* context_ = nullptr;
 
-  public:
     explicit device(const std::string& device_name)
     {
         auto norm = [](std::string s) {
@@ -163,6 +163,9 @@ class device
             CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to activate audio context."));
     }
 
+    inline static std::map<std::string, std::weak_ptr<device>> devices_;
+
+public:
     ~device()
     {
         alcMakeContextCurrent(nullptr);
@@ -170,7 +173,13 @@ class device
         if (device_) alcCloseDevice(device_);
     }
 
-    ALCdevice* get() { return device_; }
+    static std::shared_ptr<device> open(const std::string& device_name)
+    {
+        auto& weak = devices_[device_name];
+        auto shared = weak.lock();
+        if (!shared) weak = shared = std::shared_ptr<device>{new device{device_name}};
+        return shared;
+    }
 };
 
 struct oal_consumer : public core::frame_consumer
@@ -181,7 +190,7 @@ struct oal_consumer : public core::frame_consumer
 
     core::video_format_desc format_desc_;
 
-    device              device_;
+    std::shared_ptr<device> device_;
     ALuint              source_ = 0;
     std::vector<ALuint> buffers_;
     std::queue<ALuint>  free_;
@@ -198,7 +207,7 @@ struct oal_consumer : public core::frame_consumer
 
   public:
     explicit oal_consumer(const std::string& device_name, const delay_value& delay) :
-        device_{device_name}, delay_{delay}
+        device_{ device::open(device_name) }, delay_{delay}
     {
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
         graph_->set_color("dropped-frame", diagnostics::color(0.3f, 0.6f, 0.3f));

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -36,8 +36,6 @@
 #include <core/frame/frame.h>
 #include <core/video_format.h>
 
-#include <boost/algorithm/string/erase.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <tbb/concurrent_queue.h>
@@ -50,7 +48,10 @@ extern "C" {
 #include <libswresample/swresample.h>
 }
 
+#include <algorithm>
+#include <cctype>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <AL/al.h>
@@ -60,107 +61,71 @@ namespace caspar { namespace oal {
 
 class device
 {
-    ALCdevice*         device_  = nullptr;
-    ALCcontext*        context_ = nullptr;
-    const std::wstring device_name_;
+    ALCdevice*  device_  = nullptr;
+    ALCcontext* context_ = nullptr;
 
   public:
-    explicit device(std::wstring device_name) : device_name_(std::move(device_name))
+    explicit device(std::wstring device_name)
     {
-        ALCchar* deviceName = nullptr;
+        auto norm = [](std::string s) {
+            s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+            std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+            return s;
+        };
 
-        if (!device_name_.empty()) {
-            ALboolean enumeration = alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT");
+        std::string found_name;
 
-            if (enumeration == AL_FALSE) {
-                // enumeration not supported
-                CASPAR_LOG(info) << L"Unable to enumerate OpenAL devices. Using system default device";
-            } else {
-                char* s;
+        if (device_name.size()) {
+            if (alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT")) {
 
-                if (alcIsExtensionPresent(nullptr, "ALC_enumerate_all_EXT") == AL_FALSE)
-                    s = (char*)alcGetString(nullptr, ALC_DEVICE_SPECIFIER);
-                else
-                    s = (char*)alcGetString(nullptr, ALC_ALL_DEVICES_SPECIFIER);
+                auto match = norm(u8(device_name));
 
-                deviceName = iterate_and_find_device(s, device_name_);
+                auto enum_all_ext = alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT");
+                auto names = alcGetString(nullptr, enum_all_ext ? ALC_ALL_DEVICES_SPECIFIER : ALC_DEVICE_SPECIFIER);
 
-                if (deviceName == nullptr) {
-                    CASPAR_LOG(warning)
-                        << L"Failed to find specified OpenAL output device. Using system default device";
-                } else {
-                    CASPAR_LOG(debug) << L"Found specified OpenAL output device";
+                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+
+                // `names` contains multiple null-terminated device names
+                for (auto p = names; *p; p += strlen(p) + 1) {
+                    std::string found{p};
+                    CASPAR_LOG(info) << found;
+
+                    if (match == norm(found)) found_name = found;
                 }
+
+                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+
+                if (found_name.size())
+                    CASPAR_LOG(info) << "Using OpenAL device: " << found_name;
+                else
+                    CASPAR_LOG(warning) << "Specified OpenAL device not found - using default";
+            } else {
+                CASPAR_LOG(info) << "OpenAL device enumeration not supported - using default";
             }
+        } else {
+            CASPAR_LOG(info) << "Using default OpenAL device";
         }
 
-        device_ = alcOpenDevice(deviceName);
-
-        if (device_ == nullptr)
+        device_ = alcOpenDevice(found_name.size() ? found_name.data() : nullptr);
+        if (!device_)
             CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize audio device."));
 
         context_ = alcCreateContext(device_, nullptr);
-
-        if (context_ == nullptr)
+        if (!context_)
             CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to create audio context."));
 
-        if (alcMakeContextCurrent(context_) == ALC_FALSE)
+        if (!alcMakeContextCurrent(context_))
             CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to activate audio context."));
     }
 
     ~device()
     {
         alcMakeContextCurrent(nullptr);
-
-        if (context_ != nullptr)
-            alcDestroyContext(context_);
-
-        if (device_ != nullptr)
-            alcCloseDevice(device_);
+        if (context_) alcDestroyContext(context_);
+        if (device_) alcCloseDevice(device_);
     }
 
     ALCdevice* get() { return device_; }
-
-  private:
-    static ALCchar* iterate_and_find_device(const char* list, const std::wstring& device_name)
-    {
-        ALCchar* result = nullptr;
-
-        // generate ascii string for comparison purposes vs what openAL provides
-        std::string short_device_name = u8(device_name);
-        boost::algorithm::erase_all(short_device_name, " ");
-
-        CASPAR_LOG(info) << L"------- OpenAL Device List -----";
-
-        if (!list) {
-            CASPAR_LOG(info) << L"No device names found";
-        } else {
-            // iterate through all device names
-            // -> buffer contains multiple null-terminated device name strings
-            ALCchar* ptr = (ALCchar*)list;
-
-            while (strlen(ptr) > 0) {
-                // log each device name, so we can see what options are available
-                CASPAR_LOG(info) << ptr;
-
-                // store matching device name address if found
-                // -> device name will be empty string if not provided
-                std::string tmpStr = ptr;
-                boost::algorithm::erase_all(tmpStr, " ");
-
-                if (boost::iequals(short_device_name, tmpStr)) {
-                    result = ptr;
-                }
-
-                // point to next device name start (or null if no more device names)
-                ptr += strlen(ptr) + 1;
-            }
-        }
-
-        CASPAR_LOG(info) << L"------ OpenAL Devices List done -----";
-
-        return result;
-    }
 };
 
 struct oal_consumer : public core::frame_consumer

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -50,9 +50,7 @@ extern "C" {
 #include <libswresample/swresample.h>
 }
 
-#include <algorithm>
 #include <atomic>
-#include <cctype>
 #include <condition_variable>
 #include <cstdint>
 #include <map>
@@ -117,49 +115,44 @@ class device
     struct context_deleter { void operator()(ALCcontext* p) { alcDestroyContext(p); } };
     std::unique_ptr<ALCcontext, context_deleter> context_;
 
-    explicit device(const std::string& device_name)
+    explicit device(std::string device_name)
     {
-        auto norm = [](std::string s) {
-            s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
-            std::transform(s.begin(), s.end(), s.begin(), ::tolower);
-            return s;
-        };
-
-        std::string found_name;
-
-        if (device_name.size()) {
-            if (alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT")) {
-
-                auto name = norm(device_name);
-
-                auto enum_all_ext = alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT");
-                auto names = alcGetString(nullptr, enum_all_ext ? ALC_ALL_DEVICES_SPECIFIER : ALC_DEVICE_SPECIFIER);
-
-                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
-
-                // `names` contains multiple null-terminated device names
-                for (auto p = names; *p; p += strlen(p) + 1) {
-                    std::string found{p};
-                    CASPAR_LOG(info) << found;
-
-                    if (name == norm(found)) found_name = found;
-                }
-
-                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
-
-                if (found_name.size())
-                    CASPAR_LOG(info) << "Using OpenAL device: " << found_name;
-                else
-                    CASPAR_LOG(warning) << "Specified OpenAL device not found - using default";
-            } else {
-                CASPAR_LOG(info) << "OpenAL device enumeration not supported - using default";
-            }
-        } else {
-            CASPAR_LOG(info) << "Using default OpenAL device";
+        int def_device = 0, enum_devices = 0;
+        if (alcIsExtensionPresent(nullptr, "ALC_ENUMERATE_ALL_EXT")) {
+            def_device = ALC_DEFAULT_ALL_DEVICES_SPECIFIER;
+            enum_devices = ALC_ALL_DEVICES_SPECIFIER;
+        } else if (alcIsExtensionPresent(nullptr, "ALC_ENUMERATION_EXT")) {
+            def_device = ALC_DEFAULT_DEVICE_SPECIFIER;
+            enum_devices = ALC_DEVICE_SPECIFIER;
         }
 
-        device_.reset(alcOpenDevice(found_name.size() ? found_name.data() : nullptr));
-        if (!device_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize device."));
+        if (device_name.empty()) {
+            if (!def_device)
+                CASPAR_THROW_EXCEPTION(not_supported() << msg_info("OpenAL device enumeration not supported"));
+
+            auto name = alcGetString(NULL, def_device);
+            if (!name || !*name)
+                CASPAR_THROW_EXCEPTION(operation_failed() << msg_info("Default OpenAL device not found"));
+
+            device_name = name;
+            CASPAR_LOG(info) << "Using default OpenAL device: " << device_name;
+        }
+
+        device_.reset(alcOpenDevice(device_name.data()));
+        if (!device_) {
+            CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+
+            if (auto names = alcGetString(nullptr, enum_devices)) {
+                std::string name;
+                for (; *names; names += name.size() + 1) {
+                    name = names;
+                    CASPAR_LOG(info) << name;
+                }
+            }
+            CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+
+            CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize device."));
+        }
 
         context_.reset(alcCreateContext(device_.get(), nullptr));
         if (!context_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to create context."));

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -241,7 +241,7 @@ struct oal_consumer : public core::frame_consumer
             av_channel_layout_default(&from, format_desc_.audio_channels);
             av_channel_layout_default(&to, 2); // stereo
 
-            SwrContext* raw;
+            SwrContext* raw = nullptr;
             swr_alloc_set_opts2(&raw,
                 &to,   AV_SAMPLE_FMT_S16, format_desc_.audio_sample_rate,
                 &from, AV_SAMPLE_FMT_S32, format_desc_.audio_sample_rate,

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -125,14 +125,18 @@ class device
             CASPAR_THROW_EXCEPTION(not_supported() << msg_info("Device does not support ALC_EXT_thread_local_context"));
     }
 
+    inline static std::mutex mutex_;
     inline static std::map<std::string, std::weak_ptr<device>> devices_;
 
 public:
     static std::shared_ptr<device> open(const std::string& device_name)
     {
+        std::lock_guard guard{mutex_};
+
         auto& weak = devices_[device_name];
         auto shared = weak.lock();
         if (!shared) weak = shared = std::shared_ptr<device>{new device{device_name}};
+
         return shared;
     }
 

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -64,6 +64,8 @@ extern "C" {
 
 #include <AL/al.h>
 #include <AL/alc.h>
+#define AL_ALEXT_PROTOTYPES
+#include <AL/alext.h>
 
 namespace caspar::oal {
 
@@ -107,8 +109,11 @@ struct delay_value
 
 class device
 {
-    ALCdevice*  device_  = nullptr;
-    ALCcontext* context_ = nullptr;
+    struct device_deleter { void operator()(ALCdevice* p) { alcCloseDevice(p); } };
+    std::unique_ptr<ALCdevice, device_deleter> device_;
+
+    struct context_deleter { void operator()(ALCcontext* p) { alcDestroyContext(p); } };
+    std::unique_ptr<ALCcontext, context_deleter> context_;
 
     explicit device(const std::string& device_name)
     {
@@ -151,34 +156,37 @@ class device
             CASPAR_LOG(info) << "Using default OpenAL device";
         }
 
-        device_ = alcOpenDevice(found_name.size() ? found_name.data() : nullptr);
-        if (!device_)
-            CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize audio device."));
+        device_.reset(alcOpenDevice(found_name.size() ? found_name.data() : nullptr));
+        if (!device_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize device."));
 
-        context_ = alcCreateContext(device_, nullptr);
-        if (!context_)
-            CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to create audio context."));
+        context_.reset(alcCreateContext(device_.get(), nullptr));
+        if (!context_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to create context."));
 
-        if (!alcMakeContextCurrent(context_))
-            CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to activate audio context."));
+        if (!alcIsExtensionPresent(device_.get(), "ALC_EXT_thread_local_context"))
+            CASPAR_THROW_EXCEPTION(not_supported() << msg_info("Device does not support ALC_EXT_thread_local_context"));
     }
 
     inline static std::map<std::string, std::weak_ptr<device>> devices_;
 
 public:
-    ~device()
-    {
-        alcMakeContextCurrent(nullptr);
-        if (context_) alcDestroyContext(context_);
-        if (device_) alcCloseDevice(device_);
-    }
-
     static std::shared_ptr<device> open(const std::string& device_name)
     {
         auto& weak = devices_[device_name];
         auto shared = weak.lock();
         if (!shared) weak = shared = std::shared_ptr<device>{new device{device_name}};
         return shared;
+    }
+
+    void activate_context()
+    {
+        if (context_.get() != alcGetThreadContext())
+            alcSetThreadContext(context_.get());
+    }
+
+    void deactivate_context()
+    {
+        if (context_.get() == alcGetThreadContext())
+            alcSetThreadContext(nullptr);
     }
 };
 
@@ -223,10 +231,13 @@ struct oal_consumer : public core::frame_consumer
         executor_.invoke([this] {
             if (source_) {
                 std::lock_guard guard{mutex_};
+                device_->activate_context();
 
                 alSourceStop(source_);
                 alDeleteSources(1, &source_);
                 alDeleteBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
+
+                device_->deactivate_context();
             }
         });
     }
@@ -261,6 +272,7 @@ struct oal_consumer : public core::frame_consumer
             CASPAR_LOG(info) << print() << " Latency: " << num_silence << " frames";
 
             std::lock_guard guard{mutex_};
+            device_->activate_context();
 
             buffers_.resize(num_silence + 2);
             alGenBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
@@ -304,6 +316,7 @@ struct oal_consumer : public core::frame_consumer
                 // submit to OAL queue
                 std::unique_lock lock{mutex_};
                 free_cv_.wait(lock, [this] { return !free_.empty() || stop_; });
+                device_->activate_context();
 
                 auto buf = free_.front();
                 free_.pop();
@@ -328,6 +341,8 @@ struct oal_consumer : public core::frame_consumer
                 ALint done = 0;
                 {
                     std::lock_guard guard{mutex_};
+                    device_->activate_context();
+
                     alGetSourcei(source_, AL_BUFFERS_PROCESSED, &done);
                     if (done) {
                         ALuint buf;

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -372,6 +372,8 @@ struct oal_consumer : public core::frame_consumer
     }
 };
 
+static constexpr auto old_config_path = L"configuration.system-audio.producer.default-device-name";
+
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,
                                                       const core::video_format_repository& format_repository,
                                                       const std::vector<spl::shared_ptr<core::video_channel>>& channels,
@@ -380,9 +382,11 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
     if (params.empty() || !(boost::iequals(params.at(0), L"AUDIO") || boost::iequals(params.at(0), L"SYSTEM-AUDIO")))
         return core::frame_consumer::empty();
 
-    auto device_name = u8(get_param(L"DEVICE_NAME", params, L""));
-    auto s = u8(get_param(L"DELAY", params, L"0"));
-    return spl::make_shared<oal_consumer>(device_name, timespan{s});
+    auto old_name = env::properties().get(old_config_path, L"");
+
+    auto device_name = u8(get_param(L"DEVICE_NAME", params, old_name));
+    auto delay = u8(get_param(L"DELAY", params, L"0"));
+    return spl::make_shared<oal_consumer>(device_name, timespan{delay});
 }
 
 spl::shared_ptr<core::frame_consumer>
@@ -391,9 +395,11 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
                               const std::vector<spl::shared_ptr<core::video_channel>>& channels,
                               const core::channel_info&                                channel_info)
 {
-    auto device_name = u8(ptree.get(L"device-name", L""));
-    auto s = u8(ptree.get(L"delay", L"0"));
-    return spl::make_shared<oal_consumer>(device_name, timespan{s});
+    auto old_name = env::properties().get(old_config_path, L"");
+
+    auto device_name = u8(ptree.get(L"device-name", old_name));
+    auto delay = u8(ptree.get(L"delay", L"0"));
+    return spl::make_shared<oal_consumer>(device_name, timespan{delay});
 }
 
 } // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -29,6 +29,7 @@
 #include <common/log.h>
 #include <common/param.h>
 #include <common/timer.h>
+#include <common/timespan.h>
 #include <common/utf.h>
 
 #include <core/consumer/channel_info.h>
@@ -57,7 +58,6 @@ extern "C" {
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
@@ -70,42 +70,6 @@ extern "C" {
 namespace caspar::oal {
 
 using namespace std::chrono_literals;
-
-struct delay_value
-{
-    int value;
-    enum { frames, msec } type;
-
-    int in_frames(const core::video_format_desc& desc) {
-        return (type == msec) ? value * desc.fps / 1000. + .5 : value;
-    }
-
-    static delay_value from_string(const std::string& s)
-    {
-        try {
-            std::istringstream ss{s};
-
-            int value;
-            if (!(ss >> value)) throw std::invalid_argument{"Invalid delay value"};
-
-            std::string suffix;
-            ss >> suffix;
-
-            if (suffix.size())
-            {
-                if (suffix != "ms") throw std::invalid_argument{"Invalid suffix - expected 'ms' or nothing"};
-                if (!(ss >> std::ws).eof()) throw std::invalid_argument{"Trailing garbage"};
-                return {value, msec};
-            }
-            else return {value, frames};
-
-        } catch (...) {
-            CASPAR_THROW_EXCEPTION(user_error() << msg_info("Failed to parse delay " + s)
-                << nested_exception(std::current_exception())
-            );
-        }
-    }
-};
 
 class device
 {
@@ -197,7 +161,7 @@ struct oal_consumer : public core::frame_consumer
     ALuint              source_ = 0;
     std::vector<ALuint> buffers_;
     std::queue<ALuint>  free_;
-    delay_value         delay_;
+    timespan            delay_;
 
     std::mutex          mutex_;
     std::condition_variable free_cv_;
@@ -209,7 +173,7 @@ struct oal_consumer : public core::frame_consumer
     executor executor_{L"oal_consumer"};
 
   public:
-    explicit oal_consumer(const std::string& device_name, const delay_value& delay) :
+    explicit oal_consumer(const std::string& device_name, const timespan& delay) :
         device_{ device::open(device_name) }, delay_{delay}
     {
         using diagnostics::color;
@@ -263,7 +227,7 @@ struct oal_consumer : public core::frame_consumer
             swr_.reset(raw);
             swr_init(raw);
 
-            auto num_silence = delay_.in_frames(format_desc_);
+            auto num_silence = delay_.in_frames(format_desc_.fps);
             num_silence = std::clamp<int>(num_silence, 1, format_desc_.fps);
 
             CASPAR_LOG(info) << print() << " Latency: " << num_silence << " frames";
@@ -395,7 +359,7 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
 
     auto device_name = u8(get_param(L"DEVICE_NAME", params, L""));
     auto s = u8(get_param(L"DELAY", params, L"0"));
-    return spl::make_shared<oal_consumer>(device_name, delay_value::from_string(s));
+    return spl::make_shared<oal_consumer>(device_name, timespan{s});
 }
 
 spl::shared_ptr<core::frame_consumer>
@@ -406,7 +370,7 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
 {
     auto device_name = u8(ptree.get(L"device-name", L""));
     auto s = u8(ptree.get(L"delay", L"0"));
-    return spl::make_shared<oal_consumer>(device_name, delay_value::from_string(s));
+    return spl::make_shared<oal_consumer>(device_name, timespan{s});
 }
 
 } // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -52,12 +52,14 @@ extern "C" {
 }
 
 #include <atomic>
+#include <cctype>
 #include <condition_variable>
 #include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <ranges>
 #include <string>
 #include <thread>
 #include <vector>
@@ -101,22 +103,39 @@ class device
             device_name = name;
             CASPAR_LOG(info) << "Using default OpenAL device: " << device_name;
         }
+        else if (enum_devices) {
+            auto clean = [](const std::string& s) {
+                auto v = s | std::views::filter(::isgraph) | std::views::transform(::tolower);
+                return std::string{v.begin(), v.end()};
+            };
 
-        device_.reset(alcOpenDevice(device_name.data()));
-        if (!device_) {
-            CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+            std::map<std::string, std::string> device_names;
 
             if (auto names = alcGetString(nullptr, enum_devices)) {
-                std::string name;
-                for (; *names; names += name.size() + 1) {
-                    name = names;
-                    CASPAR_LOG(info) << name;
+                while (*names) {
+                    std::string name = names;
+                    device_names[clean(name)] = name;
+
+                    names += name.size() + 1;
                 }
             }
-            CASPAR_LOG(info) << "-------- OpenAL Devices -------";
 
-            CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize device."));
+            auto it = device_names.find(clean(device_name));
+            if (it == device_names.end()) {
+                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+                for (auto&& [_, name] : device_names) CASPAR_LOG(info) << name;
+                CASPAR_LOG(info) << "-------- OpenAL Devices -------";
+
+                CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Invalid OpenAL device: " + device_name));
+            }
+            else {
+                device_name = it->second;
+                CASPAR_LOG(info) << "Using OpenAL device: " << device_name;
+            }
         }
+
+        device_.reset(alcOpenDevice(device_name.data()));
+        if (!device_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to initialize device."));
 
         context_.reset(alcCreateContext(device_.get(), nullptr));
         if (!context_) CASPAR_THROW_EXCEPTION(invalid_operation() << msg_info("Failed to create context."));

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -49,15 +49,23 @@ extern "C" {
 }
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
+#include <condition_variable>
+#include <cstdint>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <AL/al.h>
 #include <AL/alc.h>
 
-namespace caspar { namespace oal {
+namespace caspar::oal {
+
+using namespace std::chrono_literals;
 
 class device
 {
@@ -139,10 +147,14 @@ struct oal_consumer : public core::frame_consumer
     device              device_;
     ALuint              source_ = 0;
     std::vector<ALuint> buffers_;
-    bool                started_  = false;
-    int                 duration_ = 1920;
+    std::queue<ALuint>  free_;
 
-    std::shared_ptr<SwrContext> swr_;
+    std::mutex          mutex_;
+    std::condition_variable free_cv_;
+    std::atomic<bool>   stop_{false};
+
+    struct swr_deleter { void operator()(SwrContext* p) { swr_free(&p); } };
+    std::unique_ptr<SwrContext, swr_deleter> swr_;
 
     executor executor_{L"oal_consumer"};
 
@@ -157,15 +169,16 @@ struct oal_consumer : public core::frame_consumer
 
     ~oal_consumer() override
     {
+        stop_ = true;
+        free_cv_.notify_all();
+
         executor_.invoke([this] {
-            if (source_ != 0u) {
+            if (source_) {
+                std::lock_guard guard{mutex_};
+
                 alSourceStop(source_);
                 alDeleteSources(1, &source_);
-            }
-
-            for (auto& buffer : buffers_) {
-                if (buffer != 0u)
-                    alDeleteBuffers(1, &buffer);
+                alDeleteBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
             }
         });
     }
@@ -181,137 +194,96 @@ struct oal_consumer : public core::frame_consumer
         graph_->set_text(print());
 
         executor_.begin_invoke([this] {
-            duration_ = *std::min_element(format_desc_.audio_cadence.begin(), format_desc_.audio_cadence.end());
-            buffers_.resize(8);
+            AVChannelLayout from, to;
+            av_channel_layout_default(&from, format_desc_.audio_channels);
+            av_channel_layout_default(&to, 2); // stereo
+
+            SwrContext* raw;
+            swr_alloc_set_opts2(&raw,
+                &to,   AV_SAMPLE_FMT_S16, format_desc_.audio_sample_rate,
+                &from, AV_SAMPLE_FMT_S32, format_desc_.audio_sample_rate,
+                0, nullptr
+            );
+            swr_.reset(raw);
+            swr_init(raw);
+
+            std::lock_guard guard{mutex_};
+
+            buffers_.resize(16);
             alGenBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
+            for (auto buf : buffers_) free_.push(buf);
+
             alGenSources(1, &source_);
 
-            alSourcei(source_, AL_LOOPING, AL_FALSE);
+            // queue one frame worth of silence to ensure there is something
+            // in the OAL queue until we get the next frame
+            std::vector<int16_t> silence(format_desc_.audio_cadence[0] * 2, 0); // stereo
+            auto buf = free_.front();
+            free_.pop();
+            alBufferData(buf, AL_FORMAT_STEREO16, silence.data(),
+                static_cast<ALsizei>(silence.size() * sizeof(std::int16_t)),
+                format_desc_.audio_sample_rate
+            );
+            alSourceQueueBuffers(source_, 1, &buf);
         });
     }
 
     std::future<bool> send(core::video_field field, core::const_frame frame) override
     {
-        executor_.begin_invoke([=, this] {
-            auto dst         = std::shared_ptr<AVFrame>(av_frame_alloc(), [](AVFrame* ptr) { av_frame_free(&ptr); });
-            dst->format      = AV_SAMPLE_FMT_S16;
-            dst->sample_rate = format_desc_.audio_sample_rate;
-            av_channel_layout_default(&dst->ch_layout, 2);
-            dst->nb_samples = duration_;
-            if (av_frame_get_buffer(dst.get(), 32) < 0) {
-                // TODO FF error
-                CASPAR_THROW_EXCEPTION(invalid_argument());
-            }
-            std::memset(dst->extended_data[0], 0, dst->linesize[0]);
+        executor_.begin_invoke([this, frame = std::move(frame)] {
+            // resample and downmix
+            auto&& audio_in = frame.audio_data();
+            auto num_samples = static_cast<int>(audio_in.size() / format_desc_.audio_channels);
 
-            if (!started_) {
-                for (ALuint& buffer : buffers_) {
-                    alBufferData(buffer,
-                                 AL_FORMAT_STEREO16,
-                                 dst->extended_data[0],
-                                 static_cast<ALsizei>(dst->linesize[0]),
-                                 dst->sample_rate);
-                    alSourceQueueBuffers(source_, 1, &buffer);
-                }
+            std::vector<std::int16_t> audio_out(num_samples * 2); // stereo
 
-                alSourcePlay(source_);
-                started_ = true;
+            auto from = reinterpret_cast<const std::uint8_t*>(audio_in.data());
+            auto to = reinterpret_cast<std::uint8_t*>(audio_out.data());
+            swr_convert(swr_.get(), &to, num_samples, &from, num_samples);
 
-                return;
-            }
+            {
+                // submit to OAL queue
+                std::unique_lock lock{mutex_};
+                free_cv_.wait(lock, [this] { return !free_.empty() || stop_; });
 
-            auto src         = std::shared_ptr<AVFrame>(av_frame_alloc(), [](AVFrame* ptr) { av_frame_free(&ptr); });
-            src->format      = AV_SAMPLE_FMT_S32;
-            src->sample_rate = format_desc_.audio_sample_rate;
-            av_channel_layout_default(&src->ch_layout, format_desc_.audio_channels);
-            src->nb_samples       = static_cast<int>(frame.audio_data().size() / format_desc_.audio_channels);
-            src->extended_data[0] = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(frame.audio_data().data()));
-            src->linesize[0]      = static_cast<int>(frame.audio_data().size() * sizeof(int32_t));
+                auto buf = free_.front();
+                free_.pop();
+                alBufferData(buf, AL_FORMAT_STEREO16, audio_out.data(),
+                    static_cast<ALsizei>(audio_out.size() * sizeof(std::int16_t)),
+                    format_desc_.audio_sample_rate
+                );
+                alSourceQueueBuffers(source_, 1, &buf);
 
-            if (!swr_) {
-                swr_.reset(swr_alloc(), [](SwrContext* ptr) { swr_free(&ptr); });
-                if (!swr_) {
-                    CASPAR_THROW_EXCEPTION(bad_alloc());
-                }
-                if (swr_config_frame(swr_.get(), dst.get(), src.get()) < 0) {
-                    // TODO FF error
-                    CASPAR_THROW_EXCEPTION(invalid_argument());
-                }
-                if (swr_init(swr_.get()) < 0) {
-                    // TODO FF error
-                    CASPAR_THROW_EXCEPTION(invalid_argument());
-                }
-            }
-
-            if (swr_convert_frame(swr_.get(), nullptr, src.get()) < 0) {
-                // TODO FF error
-                CASPAR_THROW_EXCEPTION(invalid_argument());
-            }
-
-            ALint processed = 0;
-            alGetSourceiv(source_, AL_BUFFERS_PROCESSED, &processed);
-
-            auto in_duration  = swr_get_delay(swr_.get(), 48000);
-            auto out_duration = static_cast<int64_t>(processed) * duration_;
-            auto delta        = static_cast<int>(out_duration - in_duration);
-
-            ALenum state;
-            alGetSourcei(source_, AL_SOURCE_STATE, &state);
-            if (state != AL_PLAYING) {
-                while (delta > duration_) {
-                    ALuint buffer = 0;
-                    alSourceUnqueueBuffers(source_, 1, &buffer);
-                    if (buffer == 0u) {
-                        break;
-                    }
-                    alBufferData(buffer,
-                                 AL_FORMAT_STEREO16,
-                                 dst->extended_data[0],
-                                 static_cast<ALsizei>(dst->linesize[0]),
-                                 dst->sample_rate);
-                    alSourceQueueBuffers(source_, 1, &buffer);
-                    delta -= duration_;
-                }
-
-                alSourcePlay(source_);
-            }
-
-            // TODO (fix)
-            // if (std::abs(delta) > duration_ && swr_set_compensation(swr_.get(), delta, 2000) < 0) {
-            //    // TODO FF error
-            //    CASPAR_THROW_EXCEPTION(invalid_argument());
-            //}
-
-            for (auto n = 0; n < processed; ++n) {
-                if (swr_get_delay(swr_.get(), 48000) < dst->nb_samples) {
-                    break;
-                }
-
-                ALuint buffer = 0;
-                alSourceUnqueueBuffers(source_, 1, &buffer);
-                if (buffer == 0u) {
-                    // TODO error
-                    break;
-                }
-
-                if (swr_convert_frame(swr_.get(), dst.get(), nullptr) != 0) {
-                    // TODO FF error
-                    CASPAR_THROW_EXCEPTION(invalid_argument());
-                }
-
-                alBufferData(buffer,
-                             AL_FORMAT_STEREO16,
-                             dst->extended_data[0],
-                             static_cast<ALsizei>(dst->linesize[0]),
-                             dst->sample_rate);
-                alSourceQueueBuffers(source_, 1, &buffer);
+                ALenum state = 0;
+                alGetSourcei(source_, AL_SOURCE_STATE, &state);
+                if (state != AL_PLAYING) alSourcePlay(source_);
             }
 
             graph_->set_value("tick-time", perf_timer_.elapsed() * format_desc_.fps * 0.5);
             perf_timer_.restart();
         });
 
-        return make_ready_future(true);
+        return std::async(std::launch::deferred, [this] {
+            // wait until one buffer is done playing
+            while (!stop_) {
+                ALint done = 0;
+                {
+                    std::lock_guard guard{mutex_};
+                    alGetSourcei(source_, AL_BUFFERS_PROCESSED, &done);
+                    if (done) {
+                        ALuint buf;
+                        alSourceUnqueueBuffers(source_, 1, &buf);
+                        free_.push(buf);
+                    }
+                }
+                if (done) {
+                    free_cv_.notify_one();
+                    return true;
+                }
+                std::this_thread::sleep_for(100us);
+            }
+            return false;
+        });
     }
 
     std::wstring print() const override
@@ -321,7 +293,7 @@ struct oal_consumer : public core::frame_consumer
 
     std::wstring name() const override { return L"system-audio"; }
 
-    bool has_synchronization_clock() const override { return false; }
+    bool has_synchronization_clock() const override { return true; }
 
     int index() const override { return 500; }
 
@@ -352,4 +324,4 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
     return spl::make_shared<oal_consumer>(ptree.get(L"device-name", L""));
 }
 
-}} // namespace caspar::oal
+} // namespace caspar::oal

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -40,6 +40,8 @@
 
 #include <tbb/concurrent_queue.h>
 
+#pragma warning(disable : 4267)
+
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -76,8 +78,8 @@ struct delay_value
     int value;
     enum { frames, msec } type;
 
-    auto in_frames(const core::video_format_desc& desc) {
-        return (type == msec) ? static_cast<int>(value * desc.fps / 1000. + .5) : value;
+    int in_frames(const core::video_format_desc& desc) {
+        return (type == msec) ? value * desc.fps / 1000. + .5 : value;
     }
 
     static delay_value from_string(const std::string& s)
@@ -237,7 +239,7 @@ struct oal_consumer : public core::frame_consumer
 
                 alSourceStop(source_);
                 alDeleteSources(1, &source_);
-                alDeleteBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
+                alDeleteBuffers(buffers_.size(), buffers_.data());
 
                 device_->deactivate_context();
             }
@@ -269,7 +271,7 @@ struct oal_consumer : public core::frame_consumer
             swr_init(raw);
 
             auto num_silence = delay_.in_frames(format_desc_);
-            num_silence = std::clamp(num_silence, 1, static_cast<int>(format_desc_.fps));
+            num_silence = std::clamp<int>(num_silence, 1, format_desc_.fps);
 
             CASPAR_LOG(info) << print() << " Latency: " << num_silence << " frames";
 
@@ -277,7 +279,7 @@ struct oal_consumer : public core::frame_consumer
             device_->activate_context();
 
             buffers_.resize(num_silence + 2);
-            alGenBuffers(static_cast<ALsizei>(buffers_.size()), buffers_.data());
+            alGenBuffers(buffers_.size(), buffers_.data());
 
             alGenSources(1, &source_);
 
@@ -290,7 +292,7 @@ struct oal_consumer : public core::frame_consumer
                     silence.resize(cadence * 2); // stereo
 
                     alBufferData(buf, AL_FORMAT_STEREO16, silence.data(),
-                        static_cast<ALsizei>(silence.size() * sizeof(std::int16_t)),
+                        silence.size() * sizeof(std::int16_t),
                         format_desc_.audio_sample_rate
                     );
                     alSourceQueueBuffers(source_, 1, &buf);
@@ -306,7 +308,7 @@ struct oal_consumer : public core::frame_consumer
         executor_.begin_invoke([this, frame = std::move(frame)] {
             // resample and downmix
             auto&& audio_in = frame.audio_data();
-            auto num_samples = static_cast<int>(audio_in.size() / format_desc_.audio_channels);
+            int num_samples = audio_in.size() / format_desc_.audio_channels;
 
             std::vector<std::int16_t> audio_out(num_samples * 2); // stereo
 
@@ -325,7 +327,7 @@ struct oal_consumer : public core::frame_consumer
                 auto buf = free_.front();
                 free_.pop();
                 alBufferData(buf, AL_FORMAT_STEREO16, audio_out.data(),
-                    static_cast<ALsizei>(audio_out.size() * sizeof(std::int16_t)),
+                    audio_out.size() * sizeof(std::int16_t),
                     format_desc_.audio_sample_rate
                 );
                 alSourceQueueBuffers(source_, 1, &buf);

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -32,6 +32,7 @@
 #include <common/memory.h>
 #include <common/param.h>
 #include <common/timer.h>
+#include <common/timespan.h>
 #include <common/utf.h>
 
 #include <core/consumer/channel_info.h>
@@ -110,6 +111,8 @@ struct configuration
     colour_spaces   colour_space  = colour_spaces::RGB;
     bool            high_bitdepth = false;
     bool            gpu_texture   = false;
+
+    timespan        delay;
 };
 
 struct frame
@@ -194,7 +197,12 @@ struct screen_consumer
             }
         }
 
-        frame_buffer_.set_capacity(1);
+        auto delay_frames = config_.delay.in_frames(format_desc_.fps);
+        delay_frames = std::clamp<int>(delay_frames, 0, format_desc_.fps);
+        CASPAR_LOG(info) << print() << " Latency: " << delay_frames << " frames";
+
+        frame_buffer_.set_capacity(delay_frames + 1);
+        while (delay_frames--) frame_buffer_.push(core::const_frame{});
 
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
         graph_->set_color("frame-time", diagnostics::color(0.1f, 1.0f, 0.1f));
@@ -823,6 +831,10 @@ spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wst
         config.key_only = false;
     }
 
+    if (contains_param(L"DELAY", params)) {
+        config.delay = timespan{ u8(get_param(L"DELAY", params, L"")) };
+    }
+
     return spl::make_shared<screen_consumer_proxy>(config);
 }
 
@@ -892,6 +904,8 @@ create_preconfigured_consumer(const boost::property_tree::wptree&               
     } else if (aspect_str == L"4:3") {
         config.aspect = configuration::aspect_ratio::aspect_4_3;
     }
+
+    config.delay = timespan{ u8(ptree.get(L"delay", L"0")) };
 
     return spl::make_shared<screen_consumer_proxy>(config);
 }

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -135,6 +135,7 @@
             </bluefish>
             <system-audio>
                 <device-name>... (optional device name)</device-name>
+                <delay> [1..] (# of frames; clamped between 1 and 'fps' frames) | [0..]ms (converted to frames and clamped) </delay>
             </system-audio>
             <screen>
                 <device>1 [1..]</device>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -153,6 +153,7 @@
                 <height>0 (0=not set)</height>
                 <sbs-key>false [true|false]</sbs-key>
                 <colour-space>RGB [RGB|datavideo-full|datavideo-limited] (Enables colour space conversion for DataVideo TC-100 / TC-200)</colour-space>
+                <delay> [0..] (# of frames; clamped between 0 and 'fps' frames) | [0..]ms (converted to frames and clamped) </delay>
             </screen>
             <ndi>
                 <name>[custom name]</name>

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -58,11 +58,6 @@
 	<angle-backend>gl [|gl|d3d11|d3d9]</angle-backend>
     <cache-path>(CEF writes some caches next to the executable, which can fail depending on permissions. This changes it to use another path)</cache-path>
 </html>
-<system-audio>
-    <producer>
-        <default-device-name></default-device-name>
-    </producer>
-</system-audio>
 <ndi>
     <auto-load>false [true|false]</auto-load>
     <discovery-server>[hostname:port] (Global NDI Discovery Server URL applied to all consumers. Per-consumer discovery-server overrides this value.)</discovery-server>
@@ -139,6 +134,7 @@
                 <uhd-mode>0 [0|1|2|3] (0 = Disable BVC-Multi_Link,  1  = Auto ( ie. BVC-ML gets SQ, Native buffers get 2SI), 2 = Force 2SI output, 3 = Force SQ ie. Square Division output ) this setting only applies in UHD modes. </uhd-mode>
             </bluefish>
             <system-audio>
+                <device-name>... (optional device name)</device-name>
             </system-audio>
             <screen>
                 <device>1 [1..]</device>


### PR DESCRIPTION
- Fixes device enumeration bug in OAL
- Allows multiple devices to be used (different channels can output to different devices)
- Keeps the video stream synced with the OAL consumer
- Added configurable delay to the screen and OAL consumers 