### PR TITLE
chore: clean up pragma warnings

### DIFF
--- a/src/common/compiler/vs/disable_silly_warnings.h
+++ b/src/common/compiler/vs/disable_silly_warnings.h
@@ -19,28 +19,24 @@
 */
 #pragma once
 
-#if defined(_MSC_VER)
 #pragma warning(disable : 4100) // unreferenced formal parameter
 #pragma warning(disable : 4127) // conditional expression is constant
 #pragma warning(disable : 4180) // qualifier applied to function type has no meaning; ignored
+#pragma warning(disable : 4244) // conversion from 'type1' to 'type2', possible loss of data
+#pragma warning(disable : 4245) // conversion from 'type1' to 'type2', signed/unsigned mismatch
 #pragma warning(disable : 4324) // padding a structure for alignment
+#pragma warning(disable : 4334) // result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
 #pragma warning(disable : 4355) // 'this' : used in base member initializer list
+#pragma warning(disable : 4459) // declaration of 'query' hides global declaration
+#pragma warning(disable : 4481) // nonstandard extension used: override specifier 'override'
 #pragma warning(disable : 4482) // nonstandard extension used: enum 'enum' used in qualified name
 #pragma warning(disable : 4503) // decorated name length exceeded, name was truncated
+#pragma warning(disable : 4505) // unreferenced local function has been
 #pragma warning(disable : 4512) // assignment operator could not be generated
+#if (_MSC_VER > 1800 && _MSC_FULL_VER >= 190023506)
+#pragma warning(disable : 4592) // symbol will be dynamically initialized (implementation limitation)
+#endif
 #pragma warning(disable : 4702) // unreachable code
 #pragma warning(disable : 4714) // marked as __forceinline not inlined
-#pragma warning(disable : 4505) // unreferenced local function has been
-#pragma warning(disable : 4481) // nonstandard extension used: override specifier 'override'
 #pragma warning(disable : 4834) // discarding return value of function with 'nodiscard' attribute
 #pragma warning(disable : 4996) // function call with parameters that may be unsafe
-#pragma warning(disable : 4459) // declaration of 'query' hides global declaration
-#pragma warning(                                                                                                       \
-    disable : 4334) // '<<': result of 32 - bit shift implicitly converted to 64 bits(was 64 - bit shift intended ?)
-
-#if (_MSC_VER > 1800 && _MSC_FULL_VER >= 190023506)
-#pragma warning(disable : 4592) // symbol will be dynamically initialized (implementation limitation). Bug in
-                                // VS2015 14.0.24720.00 Update 1
-#endif
-
-#endif

--- a/src/core/diagnostics/osd_graph.cpp
+++ b/src/core/diagnostics/osd_graph.cpp
@@ -23,8 +23,6 @@
 
 #include "osd_graph.h"
 
-#pragma warning(disable : 4244)
-
 #include "call_context.h"
 
 #include <common/executor.h>

--- a/src/modules/bluefish/producer/bluefish_producer.cpp
+++ b/src/modules/bluefish/producer/bluefish_producer.cpp
@@ -55,19 +55,12 @@
 
 #include <mutex>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>
 #include <libavutil/timecode.h>
 }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 using namespace caspar::ffmpeg;
 

--- a/src/modules/decklink/StdAfx.h
+++ b/src/modules/decklink/StdAfx.h
@@ -52,21 +52,11 @@
 #include <tbb/concurrent_queue.h>
 #include <vector>
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
 #include <libavcodec/avcodec.h>
 }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-
-#pragma warning(push)
-#pragma warning(disable : 4996)
 
 #if defined(_MSC_VER)
 #include <atlbase.h>
@@ -74,8 +64,6 @@ extern "C" {
 #include <atlcom.h>
 #include <atlhost.h>
 #endif
-
-#pragma warning(pop)
 
 #include <functional>
 

--- a/src/modules/decklink/decklink_api.h
+++ b/src/modules/decklink/decklink_api.h
@@ -29,12 +29,7 @@
 
 #include "interop/DeckLinkAPI.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4996)
-
 #include <atlbase.h>
-
-#pragma warning(pop)
 
 namespace caspar { namespace decklink {
 

--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -45,10 +45,6 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
@@ -61,9 +57,6 @@ extern "C" {
 #include <libavutil/samplefmt.h>
 #include <libavutil/timecode.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <boost/format.hpp>
 
@@ -223,22 +216,11 @@ struct Filter
             FF(avfilter_graph_create_filter(
                 &sink, avfilter_get_by_name("buffersink"), "out", nullptr, nullptr, graph.get()));
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
             AVPixelFormat pix_fmts[] = {pix_fmt, AV_PIX_FMT_NONE};
             FF(av_opt_set_int_list(sink, "pix_fmts", pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         } else if (type == AVMEDIA_TYPE_AUDIO) {
             FF(avfilter_graph_create_filter(
                 &sink, avfilter_get_by_name("abuffersink"), "out", nullptr, nullptr, graph.get()));
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
 
             AVSampleFormat sample_fmts[]  = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
             int            sample_rates[] = {format_desc.audio_sample_rate, 0};
@@ -256,9 +238,6 @@ struct Filter
             av_channel_layout_uninit(&channel_layout);
              */
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
                                    << boost::errinfo_errno(EINVAL) << msg_info_t("invalid output media type"));

--- a/src/modules/ffmpeg/StdAfx.h
+++ b/src/modules/ffmpeg/StdAfx.h
@@ -61,8 +61,6 @@
 #include <thread>
 #include <vector>
 
-#pragma warning(push, 1)
-
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -80,5 +78,3 @@ extern "C" {
 #include <libavutil/timecode.h>
 #include <libswscale/swscale.h>
 }
-
-#pragma warning(pop)

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -44,16 +44,10 @@
 #include <boost/regex.hpp>
 
 #pragma warning(push)
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4245)
 #pragma warning(disable : 4701)
 #include <boost/crc.hpp>
 #pragma warning(pop)
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
@@ -65,9 +59,6 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <tbb/concurrent_queue.h>
 #include <tbb/parallel_for.h>
@@ -209,10 +200,6 @@ struct Stream
         if (codec->type == AVMEDIA_TYPE_VIDEO) {
             sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("buffersink"), "out"));
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
             // TODO codec->profiles
             // TODO FF(av_opt_set_int_list(sink, "framerates", codec->supported_framerates, { 0, 0 },
             // AV_OPT_SEARCH_CHILDREN));
@@ -228,15 +215,8 @@ struct Stream
             FF(av_opt_set_int_list(sink, "pix_fmts", codec->pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         } else if (codec->type == AVMEDIA_TYPE_AUDIO) {
             sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
             // TODO codec->profiles
 
 #if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
@@ -263,9 +243,6 @@ struct Stream
             // TODO: need to translate codec->ch_layouts into something that can be passed via av_opt_set_*
             // FF(av_opt_set_chlayout(sink, "ch_layouts", codec->ch_layouts, AV_OPT_SEARCH_CHILDREN));
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
                                    << boost::errinfo_errno(EINVAL) << msg_info_t("invalid output media type"));

--- a/src/modules/ffmpeg/ffmpeg.cpp
+++ b/src/modules/ffmpeg/ffmpeg.cpp
@@ -32,11 +32,7 @@
 
 #include <mutex>
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 4244)
 #pragma warning(disable : 4603)
-#pragma warning(disable : 4996)
-#endif
 
 extern "C" {
 #include <libavdevice/avdevice.h>

--- a/src/modules/ffmpeg/producer/av_input.cpp
+++ b/src/modules/ffmpeg/producer/av_input.cpp
@@ -13,16 +13,9 @@
 
 #include <set>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavformat/avformat.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 namespace caspar { namespace ffmpeg {
 

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -26,10 +26,6 @@
 #include <core/frame/frame_factory.h>
 #include <core/monitor/monitor.h>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
@@ -43,9 +39,6 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include <algorithm>
 #include <atomic>
@@ -559,10 +552,6 @@ struct Filter
         if (media_type == AVMEDIA_TYPE_VIDEO) {
             sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("buffersink"), "out"));
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
             const AVPixelFormat pix_fmts[] = {AV_PIX_FMT_RGB24,
                                               AV_PIX_FMT_BGR24,
                                               AV_PIX_FMT_BGRA,
@@ -598,16 +587,9 @@ struct Filter
 #else
             FF(av_opt_set_int_list(sink, "pix_fmts", pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
 #endif
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
         } else if (media_type == AVMEDIA_TYPE_AUDIO) {
             sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4245)
-#endif
             const AVSampleFormat sample_fmts[] = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
             const int sample_rates[] = {format_desc.audio_sample_rate, -1};
 
@@ -623,9 +605,6 @@ struct Filter
 #else
             FF(av_opt_set_int_list(sink, "sample_fmts", sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
             FF(av_opt_set_int_list(sink, "sample_rates", sample_rates, -1, AV_OPT_SEARCH_CHILDREN));
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
 #endif
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -43,15 +43,11 @@
 
 #include <chrono>
 
-#pragma warning(push, 1)
-
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
 #include <libavformat/avformat.h>
 }
-
-#pragma warning(pop)
 
 namespace caspar { namespace ffmpeg {
 

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -3,10 +3,6 @@
 
 #include <common/bit_depth.h>
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavfilter/avfilter.h>
@@ -15,9 +11,6 @@ extern "C" {
 #include <libavutil/imgutils.h>
 #include <libavutil/pixfmt.h>
 }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 #include <array>
 #include <tbb/parallel_for.h>

--- a/src/modules/flash/producer/FlashAxContainer.cpp
+++ b/src/modules/flash/producer/FlashAxContainer.cpp
@@ -26,9 +26,7 @@
 
 #include <common/log.h>
 
-#if defined(_MSC_VER)
 #pragma warning(push, 2) // TODO
-#endif
 
 using namespace ATL;
 

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -25,10 +25,7 @@
 #include "shlwapi.h"
 #include "winerror.h"
 
-#if defined(_MSC_VER)
 #pragma warning(disable : 4146)
-#pragma warning(disable : 4244)
-#endif
 
 #include "FlashAxContainer.h"
 #include "flash_producer.h"

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -44,10 +44,6 @@
 #include "../util/image_converter.h"
 #include "../util/image_view.h"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -56,9 +52,6 @@ extern "C" {
 #include <libavutil/imgutils.h>
 #include <libavutil/pixfmt.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 namespace caspar::image {
 

--- a/src/modules/image/producer/image_scroll_producer.cpp
+++ b/src/modules/image/producer/image_scroll_producer.cpp
@@ -46,18 +46,11 @@
 #include <optional>
 #include <utility>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
 #include <libavutil/frame.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 namespace caspar { namespace image {
 

--- a/src/modules/image/util/image_converter.cpp
+++ b/src/modules/image/util/image_converter.cpp
@@ -23,10 +23,6 @@
 
 #include <common/except.h>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -34,9 +30,6 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 #include <libswscale/swscale.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 namespace caspar::image {
 

--- a/src/modules/image/util/image_loader.cpp
+++ b/src/modules/image/util/image_loader.cpp
@@ -24,11 +24,6 @@
 #include "image_algorithms.h"
 
 #include <common/except.h>
-
-#if defined(_MSC_VER)
-#pragma warning(disable : 4714) // marked as __forceinline not inlined
-#endif
-
 #include "common/scope_exit.h"
 
 #include <ffmpeg/util/av_assert.h>
@@ -39,10 +34,6 @@
 
 #include <set>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -52,9 +43,6 @@ extern "C" {
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 namespace caspar { namespace image {
 

--- a/src/modules/newtek/producer/newtek_ndi_producer.cpp
+++ b/src/modules/newtek/producer/newtek_ndi_producer.cpp
@@ -52,16 +52,9 @@
 
 #include <ffmpeg/util/av_util.h>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #include <libavformat/avformat.h>
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "../util/ndi.h"
 

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -42,10 +42,6 @@
 
 #include <tbb/concurrent_queue.h>
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
 extern "C" {
 #define __STDC_CONSTANT_MACROS
 #define __STDC_LIMIT_MACROS
@@ -53,9 +49,6 @@ extern "C" {
 #include <libavutil/samplefmt.h>
 #include <libswresample/swresample.h>
 }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 #include <memory>
 #include <vector>

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -53,9 +53,6 @@
 
 #if defined(_MSC_VER)
 #include <windows.h>
-
-#pragma warning(push)
-#pragma warning(disable : 4244)
 #else
 #include "../util/x11_util.h"
 #endif

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -21,9 +21,7 @@
 
 #include "../StdAfx.h"
 
-#if defined(_MSC_VER)
 #pragma warning(push, 1) // TODO: Legacy code, just disable warnings
-#endif
 
 #include "AMCPCommandsImpl.h"
 

--- a/src/protocol/amcp/AMCPProtocolStrategy.cpp
+++ b/src/protocol/amcp/AMCPProtocolStrategy.cpp
@@ -39,9 +39,7 @@
 
 #include <common/diagnostics/graph.h>
 
-#if defined(_MSC_VER)
 #pragma warning(push, 1) // TODO: Legacy code, just disable warnings
-#endif
 
 namespace caspar { namespace protocol { namespace amcp {
 


### PR DESCRIPTION
* Consolidate C4244 and C4245
* Remove unnecessary #ifdef/endif
* Sort warnings in disable_silly_warnings.h