### PR TITLE
fix: C++20 compatibility and monitor type safety

### DIFF
--- a/src/common/memory.h
+++ b/src/common/memory.h
@@ -402,7 +402,7 @@ class shared_ptr
 
     T* get() const { return p_.get(); }
 
-    bool unique() const { return p_.unique(); }
+    bool unique() const { return p_.use_count() == 1; }
 
     long use_count() const { return p_.use_count(); }
 

--- a/src/common/scope_exit.h
+++ b/src/common/scope_exit.h
@@ -16,20 +16,23 @@ class scope_exit
     explicit scope_exit(T2&& func)
         : func_(std::forward<T2>(func))
         , valid_(true)
+        , exception_count_(std::uncaught_exceptions())
     {
     }
 
     scope_exit(scope_exit&& other)
         : func_(std::move(other.func_))
         , valid_(std::move(other.valid_))
+        , exception_count_(other.exception_count_)
     {
         other.valid_ = false;
     }
 
     scope_exit& operator=(scope_exit&& other)
     {
-        func_  = std::move(other.func_);
-        valid_ = std::move(other.valid_);
+        func_            = std::move(other.func_);
+        valid_           = std::move(other.valid_);
+        exception_count_ = other.exception_count_;
 
         other.valid_ = false;
 
@@ -42,7 +45,7 @@ class scope_exit
             if (valid_)
                 func_();
         } catch (...) {
-            if (!std::uncaught_exception())
+            if (std::uncaught_exceptions() == exception_count_)
 #pragma warning(push)
 #pragma warning(disable : 4297)
                 throw;
@@ -55,6 +58,7 @@ class scope_exit
   private:
     T    func_;
     bool valid_;
+    int  exception_count_;
 };
 
 class scope_exit_helper

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -73,7 +73,7 @@ class destroy_consumer_proxy : public frame_consumer
             auto                                             str = (*consumer)->print();
 
             try {
-                if (!consumer->unique())
+                if (consumer->use_count() != 1)
                     CASPAR_LOG(debug) << str << L" Not destroyed on asynchronous destruction thread: "
                                       << consumer->use_count();
                 else

--- a/src/core/monitor/monitor.h
+++ b/src/core/monitor/monitor.h
@@ -23,8 +23,10 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/variant.hpp>
 
+#include <concepts>
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <boost/container/flat_map.hpp>
@@ -36,6 +38,23 @@ using data_t = boost::
     variant<bool, std::int32_t, std::int64_t, std::uint32_t, std::uint64_t, float, double, std::string, std::wstring>;
 using vector_t   = boost::container::small_vector<data_t, 2>;
 using data_map_t = boost::container::flat_map<std::string, vector_t>;
+
+// Constrains T to exactly the types held by data_t, stripping cv-ref qualifiers.
+template <typename T>
+concept data_type =
+    std::same_as<std::remove_cvref_t<T>, bool> || std::same_as<std::remove_cvref_t<T>, std::int32_t> ||
+    std::same_as<std::remove_cvref_t<T>, std::int64_t> || std::same_as<std::remove_cvref_t<T>, std::uint32_t> ||
+    std::same_as<std::remove_cvref_t<T>, std::uint64_t> || std::same_as<std::remove_cvref_t<T>, float> ||
+    std::same_as<std::remove_cvref_t<T>, double> || std::same_as<std::remove_cvref_t<T>, std::string> ||
+    std::same_as<std::remove_cvref_t<T>, std::wstring>;
+
+// Constructs a vector_t from any number of data_t-compatible values.
+template <typename... Ts>
+    requires(data_type<Ts> && ...)
+vector_t values(Ts&&... args)
+{
+    return vector_t{data_t(std::forward<Ts>(args))...};
+}
 
 class state
 {
@@ -55,8 +74,14 @@ class state
 
         state_proxy& operator=(data_t data)
         {
-            data_[key_] = {std::move(data)};
+            data_[key_] = vector_t{std::move(data)};
             return *this;
+        }
+
+        template <data_type T>
+        state_proxy& operator=(T data)
+        {
+            return *this = data_t(std::move(data));
         }
 
         state_proxy& operator=(vector_t data)

--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -202,7 +202,7 @@ class sting_producer : public frame_producer
             state_["transition/type"] = is_cut_mode_ ? std::string("cut") : std::string("sting");
 
             if (duration)
-                state_["transition/frame"] = {static_cast<int>(current_frame_), static_cast<int>(*duration)};
+                state_["transition/frame"] = monitor::values(current_frame_, *duration);
         };
 
         if (duration && current_frame_ >= *duration) {

--- a/src/core/producer/transition/transition_producer.cpp
+++ b/src/core/producer/transition/transition_producer.cpp
@@ -132,8 +132,9 @@ class transition_producer : public frame_producer
     {
         state_                        = dst_producer_->state();
         state_["transition/producer"] = dst_producer_->name();
-        state_["transition/frame"]    = {current_frame_, info_.duration};
-        state_["transition/type"]     = [&]() -> std::string {
+        state_["transition/frame"] =
+            monitor::values(static_cast<std::int32_t>(current_frame_), static_cast<std::int32_t>(info_.duration));
+        state_["transition/type"] = [&]() -> std::string {
             switch (info_.type) {
                 case transition_type::mix:
                     return "mix";

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -179,11 +179,12 @@ struct video_channel::impl final
                     state["stage"]       = stage_->state();
                     state["mixer"]       = mixer_.state();
                     state["output"]      = output_.state();
-                    state["framerate"]   = {stage_frames.format_desc.framerate.numerator() *
-                                                stage_frames.format_desc.field_count,
-                                            stage_frames.format_desc.framerate.denominator()};
-                    state["format"]      = stage_frames.format_desc.name;
-                    state_               = state;
+                    state["framerate"] =
+                        monitor::values(static_cast<std::int32_t>(stage_frames.format_desc.framerate.numerator() *
+                                                                  stage_frames.format_desc.field_count),
+                                        static_cast<std::int32_t>(stage_frames.format_desc.framerate.denominator()));
+                    state["format"] = stage_frames.format_desc.name;
+                    state_          = state;
 
                     caspar::timer osc_timer;
                     tick_(state_);

--- a/src/modules/bluefish/producer/bluefish_producer.cpp
+++ b/src/modules/bluefish/producer/bluefish_producer.cpp
@@ -423,13 +423,14 @@ struct bluefish_producer
                 std::lock_guard<std::mutex> lock(state_mutex_);
                 state_["file/name"]              = model_name_;
                 state_["file/path"]              = device_index_;
-                state_["file/video/width"]       = static_cast<long>(width);
-                state_["file/video/height"]      = static_cast<long>(height);
+                state_["file/video/width"]       = static_cast<std::int32_t>(width);
+                state_["file/video/height"]      = static_cast<std::int32_t>(height);
                 state_["file/audio/sample-rate"] = format_desc_.audio_sample_rate;
                 state_["file/audio/channels"]    = format_desc_.audio_channels;
                 state_["file/fps"]               = static_cast<double>(fps);
-                state_["profiler/time"]          = {frame_timer.elapsed(), fps};
-                state_["buffer"]                 = {frame_buffer_.size(), frame_buffer_.capacity()};
+                state_["profiler/time"]          = core::monitor::values(frame_timer.elapsed(), fps);
+                state_["buffer"] = core::monitor::values(static_cast<std::int32_t>(frame_buffer_.size()),
+                                                         static_cast<std::int32_t>(frame_buffer_.capacity()));
             }
 
             graph_->set_value("frame-time", frame_timer.elapsed() * fps / format_desc_.field_count * 0.5);

--- a/src/modules/decklink/decklink_api.h
+++ b/src/modules/decklink/decklink_api.h
@@ -43,7 +43,7 @@ using UINT32 = unsigned int;
 
 static std::wstring to_string(String bstr_string)
 {
-    std::wstring result = bstr_t(bstr_string, false);
+    std::wstring result = static_cast<const wchar_t*>(bstr_t(bstr_string, false));
     return result;
 }
 
@@ -94,7 +94,7 @@ static com_ptr<IDeckLinkVideoFrameAncillaryPackets> create_ancillary_packets()
 template <typename I, typename T>
 static com_iface_ptr<I> iface_cast(const com_ptr<T>& ptr, bool optional = false)
 {
-    com_iface_ptr<I> result = ptr;
+    com_iface_ptr<I> result(ptr);
 
     if (!optional && !result)
         CASPAR_THROW_EXCEPTION(not_supported()

--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -660,13 +660,13 @@ class decklink_producer : public IDeckLinkInputCallback
                 state_["file/audio/sample-rate"] = format_desc_.audio_sample_rate;
                 state_["file/audio/channels"]    = format_desc_.audio_channels;
                 state_["file/fps"]               = format_desc_.fps;
-                state_["profiler/time"]          = {frame_timer.elapsed(), format_desc_.fps};
-                state_["buffer"]                 = {static_cast<int>(buffer_size), buffer_capacity_};
-                state_["has_signal"]             = has_signal_;
+                state_["profiler/time"]          = core::monitor::values(frame_timer.elapsed(), format_desc_.fps);
+                state_["buffer"]     = core::monitor::values(static_cast<std::int32_t>(buffer_size), buffer_capacity_);
+                state_["has_signal"] = has_signal_;
 
                 if (video) {
-                    state_["file/video/width"]  = static_cast<int>(video->GetWidth());
-                    state_["file/video/height"] = static_cast<int>(video->GetHeight());
+                    state_["file/video/width"]  = static_cast<std::int32_t>(video->GetWidth());
+                    state_["file/video/height"] = static_cast<std::int32_t>(video->GetHeight());
                 }
             }
 

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -1007,9 +1007,11 @@ struct AVProducer::Impl
     {
         graph_->set_text(u16(print()));
         boost::lock_guard<boost::mutex> lock(state_mutex_);
-        state_["file/clip"] = {start().value_or(0) / format_desc_.fps, duration().value_or(0) / format_desc_.fps};
-        state_["file/time"] = {time() / format_desc_.fps, file_duration().value_or(0) / format_desc_.fps};
-        state_["loop"]      = loop_;
+        state_["file/clip"] =
+            core::monitor::values(start().value_or(0) / format_desc_.fps, duration().value_or(0) / format_desc_.fps);
+        state_["file/time"] =
+            core::monitor::values(time() / format_desc_.fps, file_duration().value_or(0) / format_desc_.fps);
+        state_["loop"] = loop_.load();
     }
 
     core::draw_frame prev_frame(const core::video_field field)

--- a/src/modules/flash/producer/flash_producer.cpp
+++ b/src/modules/flash/producer/flash_producer.cpp
@@ -427,7 +427,7 @@ struct flash_producer : public core::frame_producer
         state_["host/path"]   = filename_;
         state_["host/width"]  = width_;
         state_["host/height"] = height_;
-        state_["host/fps"]    = fps_;
+        state_["host/fps"]    = fps_.load();
         state_["buffer"]      = output_buffer_.size() % buffer_size_;
 
         return frame;


### PR DESCRIPTION
Replace deprecated std::uncaught_exception() with proper exception_count capture-at-construction pattern, and shared_ptr::unique() with use_count()==1. Fix implicit COM conversions that became errors under C++20.

Add data_type concept and values() helper to monitor.h to resolve boost::variant initializer_list ambiguity, and use a concept-constrained template for scalar state_proxy assignment. Update all multi-value monitor assignments to use values() with explicit fixed-width integer casts.