### PR TITLE
chore: work around a bug in GCC 14

### DIFF
--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -37,11 +37,18 @@
 #include <core/frame/frame.h>
 #include <core/video_format.h>
 
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/regex.hpp>
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic pop
+#endif
 
 #pragma warning(push)
 #pragma warning(disable : 4244)

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -39,11 +39,18 @@
 #include <common/os/filesystem.h>
 #include <common/timer.h>
 
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/regex.hpp>
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic pop
+#endif
 
 #include <tbb/concurrent_queue.h>
 #include <tbb/parallel_for.h>

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -63,6 +63,10 @@
 #include <future>
 #include <memory>
 
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/regex.hpp>
 #include <boost/archive/iterators/base64_from_binary.hpp>
@@ -77,6 +81,9 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/regex.hpp>
+#if defined(__GNUC__) && __GNUC__ == 14
+#pragma GCC diagnostic pop
+#endif
 
 #include <tbb/concurrent_unordered_map.h>
 


### PR DESCRIPTION
GCC 14 on Debian Trixie fails with the following error caused by a false positive:

```
In constructor ‘constexpr std::pair<_T1, _T2>::pair(const _T1&, const _T2&) requires  _S_constructible<const _T1&, const _T2&>() [with _T1 = char; _T2 = char]’,
    inlined from ‘boost::re_detail_500::digraph<charT>::digraph(const boost::re_detail_500::digraph<charT>&) [with charT = char]’ at /usr/include/boost/regex/v5/basic_regex_creator.hpp:44:80,
    inlined from ‘constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = boost::re_detail_500::digraph<char>; _Args = {const boost::re_detail_500::digraph<char>&}]’ at /usr/include/c++/14/bits/stl_construct.h:97:14,
    inlined from ‘static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = boost::re_detail_500::digraph<char>; _Args = {const boost::re_detail_500::digraph<char>&}; _Tp = boost::re_detail_500::digraph<char>]’ at /usr/include/c++/14/bits/alloc_traits.h:577:21,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...) [with _Args = {const boost::re_detail_500::digraph<char>&}; _Tp = boost::re_detail_500::digraph<char>; _Alloc = std::allocator<boost::re_detail_500::digraph<char> >]’ at /usr/include/c++/14/bits/vector.tcc:634:26,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = boost::re_detail_500::digraph<char>; _Alloc = std::allocator<boost::re_detail_500::digraph<char> >]’ at /usr/include/c++/14/bits/stl_vector.h:1294:21,
    inlined from ‘void boost::re_detail_500::basic_char_set<charT, traits>::add_range(const digraph_type&, const digraph_type&) [with charT = char; traits = boost::regex_traits<char>]’ at /usr/include/boost/regex/v5/basic_regex_creator.hpp:82:25,
    inlined from ‘void boost::re_detail_500::basic_regex_parser<charT, traits>::parse_set_literal(boost::re_detail_500::basic_char_set<charT, traits>&) [with charT = char; traits = boost::regex_traits<char>]’ at /usr/include/boost/regex/v5/basic_regex_parser.hpp:1609:28:
/usr/include/c++/14/bits/stl_pair.h:431:9: error: writing 2 bytes into a region of size 0 [-Werror=stringop-overflow=]
  431 |       : first(__x), second(__y)
      |         ^~~~~~~~~~
...
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = boost::re_detail_500::digraph<char>]’,
    inlined from ‘constexpr _Tp* std::allocator< <template-parameter-1-1> >::allocate(std::size_t) [with _Tp = boost::re_detail_500::digraph<char>]’ at /usr/include/c++/14/bits/allocator.h:196:40,
    inlined from ‘static constexpr _Tp* std::allocator_traits<std::allocator<_Up> >::allocate(allocator_type&, size_type) [with _Tp = boost::re_detail_500::digraph<char>]’ at /usr/include/c++/14/bits/alloc_traits.h:515:28,
    inlined from ‘constexpr std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = boost::re_detail_500::digraph<char>; _Alloc = std::allocator<boost::re_detail_500::digraph<char> >]’ at /usr/include/c++/14/bits/stl_vector.h:380:33,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...) [with _Args = {const boost::re_detail_500::digraph<char>&}; _Tp = boost::re_detail_500::digraph<char>; _Alloc = std::allocator<boost::re_detail_500::digraph<char> >]’ at /usr/include/c++/14/bits/vector.tcc:596:44,
    inlined from ‘constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = boost::re_detail_500::digraph<char>; _Alloc = std::allocator<boost::re_detail_500::digraph<char> >]’ at /usr/include/c++/14/bits/stl_vector.h:1294:21,
    inlined from ‘void boost::re_detail_500::basic_char_set<charT, traits>::add_range(const digraph_type&, const digraph_type&) [with charT = char; traits = boost::regex_traits<char>]’ at /usr/include/boost/regex/v5/basic_regex_creator.hpp:82:25,
    inlined from ‘void boost::re_detail_500::basic_regex_parser<charT, traits>::parse_set_literal(boost::re_detail_500::basic_char_set<charT, traits>&) [with charT = char; traits = boost::regex_traits<char>]’ at /usr/include/boost/regex/v5/basic_regex_parser.hpp:1609:28:
/usr/include/c++/14/bits/new_allocator.h:151:55: note: at offset -2 into destination object of size 9223372036854775806 allocated by ‘operator new’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```