### PR TITLE
add consumer id in config.xml and for ADD and REMOVE commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ CasparCG 2.5.0 Stable
 
 ### Consumers
 ##### Improvements
+* All: Support optional consumer ID via AMCP ADD/REMOVE commands and config.xml. Allows multiple consumers of the same type per channel and removal by ID.
+  - AMCP: `ADD 1 NDI ID "my-id" NAME "Test"` / `REMOVE 1 ID "my-id"`
+  - Config: `<ndi><id>my-id</id><name>Test</name></ndi>`
 * Screen: Set size and position from AMCP
 * Screen: Improve performance
 * Image: Propagate AMCP parameters from PRINT command

--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -44,6 +44,8 @@ class frame_consumer
     frame_consumer(const frame_consumer&);
     frame_consumer& operator=(const frame_consumer&);
 
+    std::wstring consumer_id_;
+
   public:
     static const spl::shared_ptr<frame_consumer>& empty();
 
@@ -61,6 +63,9 @@ class frame_consumer
     virtual std::wstring name() const  = 0;
     virtual bool         has_synchronization_clock() const { return false; }
     virtual int          index() const = 0;
+
+    const std::wstring&  consumer_id() const { return consumer_id_; }
+    virtual void         set_consumer_id(const std::wstring& id) { consumer_id_ = id; }
 };
 
 }} // namespace caspar::core

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -101,6 +101,11 @@ class destroy_consumer_proxy : public frame_consumer
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }
     int                  index() const override { return consumer_->index(); }
     core::monitor::state state() const override { return consumer_->state(); }
+    void set_consumer_id(const std::wstring& id) override
+    {
+        frame_consumer::set_consumer_id(id);
+        consumer_->set_consumer_id(id);
+    }
 };
 
 class print_consumer_proxy : public frame_consumer
@@ -137,6 +142,11 @@ class print_consumer_proxy : public frame_consumer
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }
     int                  index() const override { return consumer_->index(); }
     core::monitor::state state() const override { return consumer_->state(); }
+    void set_consumer_id(const std::wstring& id) override
+    {
+        frame_consumer::set_consumer_id(id);
+        consumer_->set_consumer_id(id);
+    }
 };
 
 frame_consumer_registry::frame_consumer_registry() {}

--- a/src/core/consumer/output.cpp
+++ b/src/core/consumer/output.cpp
@@ -84,6 +84,18 @@ struct output::impl
 
     bool remove(const spl::shared_ptr<frame_consumer>& consumer) { return remove(consumer->index()); }
 
+    bool remove_by_id(const std::wstring& consumer_id)
+    {
+        std::lock_guard<std::mutex> lock(consumers_mutex_);
+        for (auto it = consumers_.begin(); it != consumers_.end(); ++it) {
+            if (it->second->consumer_id() == consumer_id) {
+                consumers_.erase(it);
+                return true;
+            }
+        }
+        return false;
+    }
+
     std::future<bool> call(int index, const std::vector<std::wstring>& params)
     {
         std::lock_guard<std::mutex> lock(consumers_mutex_);
@@ -209,6 +221,9 @@ struct output::impl
         for (auto& p : consumers) {
             state["port"][p.first]             = p.second->state();
             state["port"][p.first]["consumer"] = p.second->name();
+            if (!p.second->consumer_id().empty()) {
+                state["port"][p.first]["consumer_id"] = p.second->consumer_id();
+            }
         }
         state_ = std::move(state);
 
@@ -241,6 +256,7 @@ void output::add(int index, const spl::shared_ptr<frame_consumer>& consumer) { i
 void output::add(const spl::shared_ptr<frame_consumer>& consumer) { impl_->add(consumer); }
 bool output::remove(int index) { return impl_->remove(index); }
 bool output::remove(const spl::shared_ptr<frame_consumer>& consumer) { return impl_->remove(consumer); }
+bool output::remove_by_id(const std::wstring& consumer_id) { return impl_->remove_by_id(consumer_id); }
 std::future<bool> output::call(int index, const std::vector<std::wstring>& params)
 {
     return impl_->call(index, params);

--- a/src/core/consumer/output.h
+++ b/src/core/consumer/output.h
@@ -28,6 +28,7 @@
 #include <core/video_format.h>
 
 #include <memory>
+#include <string>
 
 namespace caspar::diagnostics {
 class graph;
@@ -53,6 +54,7 @@ class output final
     void add(int index, const spl::shared_ptr<frame_consumer>& consumer);
     bool remove(const spl::shared_ptr<frame_consumer>& consumer);
     bool remove(int index);
+    bool remove_by_id(const std::wstring& consumer_id);
 
     std::future<bool> call(int index, const std::vector<std::wstring>& params);
 

--- a/src/modules/artnet/consumer/artnet_consumer.cpp
+++ b/src/modules/artnet/consumer/artnet_consumer.cpp
@@ -152,7 +152,11 @@ struct artnet_consumer : public core::frame_consumer
         return make_ready_future(true);
     }
 
-    std::wstring print() const override { return L"artnet[]"; }
+    std::wstring print() const override
+    {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return L"artnet[" + id_str + L"]";
+    }
 
     std::wstring name() const override { return L"artnet"; }
 
@@ -167,6 +171,8 @@ struct artnet_consumer : public core::frame_consumer
         state["artnet/host"]              = config.host;
         state["artnet/port"]              = config.port;
         state["artnet/refresh-rate"]      = config.refreshRate;
+        if (!consumer_id().empty())
+            state["artnet/consumer_id"] = consumer_id();
 
         return state;
     }

--- a/src/modules/bluefish/consumer/bluefish_consumer.cpp
+++ b/src/modules/bluefish/consumer/bluefish_consumer.cpp
@@ -866,7 +866,11 @@ struct bluefish_consumer_proxy : public core::frame_consumer
         return executor_.begin_invoke([=, this] { return consumer_->send(field, frame); });
     }
 
-    std::wstring print() const override { return consumer_ ? consumer_->print() : L"[bluefish_consumer]"; }
+    std::wstring print() const override
+    {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return consumer_ ? consumer_->print() + id_str : L"[bluefish_consumer" + id_str + L"]";
+    }
 
     std::wstring name() const override { return L"bluefish"; }
 
@@ -880,6 +884,8 @@ struct bluefish_consumer_proxy : public core::frame_consumer
         state["bluefish/index"]          = config_.device_index;
         state["bluefish/stream"]         = static_cast<unsigned int>(config_.device_stream);
         state["bluefish/embedded_audio"] = config_.embedded_audio;
+        if (!consumer_id().empty())
+            state["bluefish/consumer_id"] = consumer_id();
         return state;
     }
 };

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -1179,7 +1179,8 @@ struct decklink_consumer_proxy : public core::frame_consumer
 
     [[nodiscard]] std::wstring print() const override
     {
-        return consumer_ ? consumer_->print() : L"[decklink_consumer]";
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return consumer_ ? consumer_->print() + id_str : L"[decklink_consumer" + id_str + L"]";
     }
 
     [[nodiscard]] std::wstring name() const override { return L"decklink"; }
@@ -1188,7 +1189,13 @@ struct decklink_consumer_proxy : public core::frame_consumer
 
     [[nodiscard]] bool has_synchronization_clock() const override { return true; }
 
-    [[nodiscard]] core::monitor::state state() const override { return get_state_for_config(config_, format_desc_); }
+    [[nodiscard]] core::monitor::state state() const override
+    {
+        auto state = get_state_for_config(config_, format_desc_);
+        if (!consumer_id().empty())
+            state["decklink/consumer_id"] = consumer_id();
+        return state;
+    }
 };
 
 spl::shared_ptr<core::frame_consumer> create_consumer(const std::vector<std::wstring>&     params,

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -681,7 +681,11 @@ struct ffmpeg_consumer : public core::frame_consumer
         return make_ready_future(true);
     }
 
-    std::wstring print() const override { return L"ffmpeg[" + u16(path_) + L"]"; }
+    std::wstring print() const override
+    {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return L"ffmpeg[" + u16(path_) + id_str + L"]";
+    }
 
     std::wstring name() const override { return L"ffmpeg"; }
 
@@ -692,7 +696,10 @@ struct ffmpeg_consumer : public core::frame_consumer
     core::monitor::state state() const override
     {
         std::lock_guard<std::mutex> lock(state_mutex_);
-        return state_;
+        auto                        s = state_;
+        if (!consumer_id().empty())
+            s["file/consumer_id"] = consumer_id();
+        return s;
     }
 };
 

--- a/src/modules/image/consumer/image_consumer.cpp
+++ b/src/modules/image/consumer/image_consumer.cpp
@@ -153,7 +153,11 @@ struct image_consumer : public core::frame_consumer
         return make_ready_future(false);
     }
 
-    std::wstring print() const override { return L"image[]"; }
+    std::wstring print() const override
+    {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return L"image[" + id_str + L"]";
+    }
 
     std::wstring name() const override { return L"image"; }
 
@@ -163,6 +167,8 @@ struct image_consumer : public core::frame_consumer
     {
         core::monitor::state state;
         state["image/filename"] = u8(filename_);
+        if (!consumer_id().empty())
+            state["image/consumer_id"] = consumer_id();
         return state;
     }
 };

--- a/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
+++ b/src/modules/newtek/consumer/newtek_ndi_consumer.cpp
@@ -288,10 +288,11 @@ struct newtek_ndi_consumer : public core::frame_consumer
 
     std::wstring print() const override
     {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
         if (channel_index_) {
-            return L"ndi_consumer[" + boost::lexical_cast<std::wstring>(channel_index_) + L"|" + name_ + L"]";
+            return L"ndi_consumer[" + boost::lexical_cast<std::wstring>(channel_index_) + L"|" + name_ + id_str + L"]";
         } else {
-            return L"[ndi_consumer]";
+            return L"[ndi_consumer" + id_str + L"]";
         }
     }
 
@@ -314,6 +315,8 @@ struct newtek_ndi_consumer : public core::frame_consumer
         state["ndi/use_advertiser"]       = use_advertiser_;
         state["ndi/allow_monitoring"]     = allow_monitoring_;
         state["ndi/discovery_server_url"] = discovery_server_url_;
+        if (!consumer_id().empty())
+            state["ndi/consumer_id"] = consumer_id();
         return state;
     }
 };

--- a/src/modules/oal/consumer/oal_consumer.cpp
+++ b/src/modules/oal/consumer/oal_consumer.cpp
@@ -372,7 +372,8 @@ struct oal_consumer : public core::frame_consumer
 
     std::wstring print() const override
     {
-        return L"oal[" + std::to_wstring(channel_index_) + L"|" + format_desc_.name + L"]";
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return L"oal[" + std::to_wstring(channel_index_) + L"|" + format_desc_.name + id_str + L"]";
     }
 
     std::wstring name() const override { return L"system-audio"; }
@@ -383,8 +384,10 @@ struct oal_consumer : public core::frame_consumer
 
     core::monitor::state state() const override
     {
-        static const core::monitor::state empty;
-        return empty;
+        core::monitor::state state;
+        if (!consumer_id().empty())
+            state["system-audio/consumer_id"] = consumer_id();
+        return state;
     }
 };
 

--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -758,7 +758,11 @@ struct screen_consumer_proxy : public core::frame_consumer
         return consumer_->send(field, frame);
     }
 
-    std::wstring print() const override { return consumer_ ? consumer_->print() : L"[screen_consumer]"; }
+    std::wstring print() const override
+    {
+        auto id_str = consumer_id().empty() ? L"" : L"|id=" + consumer_id();
+        return consumer_ ? consumer_->print() + id_str : L"[screen_consumer" + id_str + L"]";
+    }
 
     std::wstring name() const override { return L"screen"; }
 
@@ -773,6 +777,8 @@ struct screen_consumer_proxy : public core::frame_consumer
         state["screen/index"]         = config_.screen_index;
         state["screen/key_only"]      = config_.key_only;
         state["screen/always_on_top"] = config_.always_on_top;
+        if (!consumer_id().empty())
+            state["screen/consumer_id"] = consumer_id();
         return state;
     }
 };

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -60,6 +60,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <memory>
 
@@ -492,6 +493,12 @@ std::future<std::wstring> apply_command(command_context& ctx)
     });
 }
 
+static int consumer_index_from_id(const std::wstring& id)
+{
+    auto hash = std::hash<std::wstring>{}(id);
+    return 10000000 + static_cast<int>(hash % 10000000);
+}
+
 std::wstring add_command(command_context& ctx)
 {
     replace_placeholders(L"<CLIENT_IP_ADDRESS>", ctx.client->address(), ctx.parameters);
@@ -499,18 +506,42 @@ std::wstring add_command(command_context& ctx)
     core::diagnostics::scoped_call_context save;
     core::diagnostics::call_context::for_thread().video_channel = ctx.channel_index + 1;
 
+    auto consumer_id = get_param(L"ID", ctx.parameters, L"");
+
     auto consumer =
         ctx.static_context->consumer_registry->create_consumer(ctx.parameters,
                                                                ctx.static_context->format_repository,
                                                                get_channels(ctx),
                                                                ctx.channel.raw_channel->get_consumer_channel_info());
-    ctx.channel.raw_channel->output().add(ctx.layer_index(consumer->index()), consumer);
+
+    if (!consumer_id.empty()) {
+        consumer->set_consumer_id(consumer_id);
+    }
+
+    int index;
+    if (ctx.layer_id != -1) {
+        index = ctx.layer_id;
+    } else if (!consumer_id.empty()) {
+        index = consumer_index_from_id(consumer_id);
+    } else {
+        index = consumer->index();
+    }
+
+    ctx.channel.raw_channel->output().add(index, consumer);
 
     return L"202 ADD OK\r\n";
 }
 
 std::wstring remove_command(command_context& ctx)
 {
+    auto consumer_id = get_param(L"ID", ctx.parameters, L"");
+    if (!consumer_id.empty()) {
+        if (!ctx.channel.raw_channel->output().remove_by_id(consumer_id)) {
+            return L"404 REMOVE FAILED\r\n";
+        }
+        return L"202 REMOVE OK\r\n";
+    }
+
     auto index = ctx.layer_index(std::numeric_limits<int>::min());
 
     if (index == std::numeric_limits<int>::min()) {

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -58,6 +58,7 @@
 #include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <functional>
 #include <thread>
 #include <utility>
 
@@ -363,13 +364,24 @@ struct server::impl
                     auto name = xml_consumer.first;
 
                     try {
-                        if (name != L"<xmlcomment>")
-                            channel.raw_channel->output().add(
+                        if (name != L"<xmlcomment>") {
+                            auto consumer =
                                 consumer_registry_->create_consumer(name,
                                                                     xml_consumer.second,
                                                                     video_format_repository_,
                                                                     channels_vec,
-                                                                    channel.raw_channel->get_consumer_channel_info()));
+                                                                    channel.raw_channel->get_consumer_channel_info());
+
+                            auto id = xml_consumer.second.get(L"id", L"");
+                            if (!id.empty()) {
+                                consumer->set_consumer_id(id);
+                                auto hash = std::hash<std::wstring>{}(id);
+                                int  index = 10000000 + static_cast<int>(hash % 10000000);
+                                channel.raw_channel->output().add(index, consumer);
+                            } else {
+                                channel.raw_channel->output().add(consumer);
+                            }
+                        }
                     } catch (...) {
                         CASPAR_LOG_CURRENT_EXCEPTION();
                     }


### PR DESCRIPTION
Hello,

I needed a way to add and remove consumers dynamically and consistently. The way consumer indices are managed is obscur and notre reliable. So I added an optionnal ID to each consumer to be able to identify them. 

We can add the id in the xml config and along the ADD command like this : 
`ADD 1 NDI ID "myId" NAME "myName"`

Then we can remove it like this : 
`REMOVE 1 ID "myId"`

