### PR TITLE
fix: av_input does not destroy graph_ object before joining worker thread

### DIFF
--- a/src/modules/ffmpeg/producer/av_input.cpp
+++ b/src/modules/ffmpeg/producer/av_input.cpp
@@ -99,7 +99,6 @@ Input::Input(const std::string& filename, std::shared_ptr<diagnostics::graph> gr
 
 Input::~Input()
 {
-    graph_         = spl::shared_ptr<diagnostics::graph>();
     abort_request_ = true;
     ic_cond_.notify_all();
 


### PR DESCRIPTION
Fixes a race condition in the destruction of ffmpeg::Input instances.

The graph: object was reset before the worker-thread had time to exit. Potentially leading to nullptr dereference

fix:
remove the line resetting graph_ from the desctructor, since graph_ will be destroyed automatically anyway.