### PR TITLE
fix(ffmpeg): reuse decoders across loop wrap instead of recreating worker threads + codec contexts

### DIFF
--- a/src/core/producer/frame_producer_registry.cpp
+++ b/src/core/producer/frame_producer_registry.cpp
@@ -86,7 +86,12 @@ class destroy_producer_proxy : public frame_producer
         if (!destroyer)
             return;
 
-        CASPAR_VERIFY(destroyer->size() < 8);
+        // Throwing from a destructor (as CASPAR_VERIFY would) while many layers are being
+        // cleared at once is unsafe and can itself abort the process. Apply backpressure via
+        // logging instead of asserting.
+        if (destroyer->size() >= 8) {
+            CASPAR_LOG(warning) << L"Producer destroyer backlog: " << destroyer->size();
+        }
 
         auto producer = new spl::shared_ptr<frame_producer>(std::move(producer_));
 

--- a/src/core/producer/frame_producer_registry.cpp
+++ b/src/core/producer/frame_producer_registry.cpp
@@ -86,11 +86,26 @@ class destroy_producer_proxy : public frame_producer
         if (!destroyer)
             return;
 
-        // Throwing from a destructor (as CASPAR_VERIFY would) while many layers are being
-        // cleared at once is unsafe and can itself abort the process. Apply backpressure via
-        // logging instead of asserting.
-        if (destroyer->size() >= 8) {
-            CASPAR_LOG(warning) << L"Producer destroyer backlog: " << destroyer->size();
+        // Backpressure for the asynchronous destroyer queue.
+        //
+        // The queue used to be guarded by CASPAR_VERIFY(size < 8), but throwing from a
+        // destructor while many layers are being cleared at once is unsafe and can itself
+        // abort the process. Simply dropping the guard would let the backlog (and the memory
+        // of every not-yet-destroyed producer) grow without bound if destruction cannot keep
+        // up. Instead, once the backlog passes a threshold, destroy this producer
+        // synchronously on the current thread. That bounds the queue and provides real
+        // backpressure without ever throwing.
+        constexpr std::size_t destroyer_backlog_limit = 8;
+
+        if (destroyer->size() >= destroyer_backlog_limit) {
+            CASPAR_LOG(warning) << L"Producer destroyer backlog (" << destroyer->size()
+                                << L") reached limit; destroying synchronously to apply backpressure.";
+            try {
+                producer_.reset();
+            } catch (...) {
+                CASPAR_LOG_CURRENT_EXCEPTION();
+            }
+            return;
         }
 
         auto producer = new spl::shared_ptr<frame_producer>(std::move(producer_));

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -135,7 +135,41 @@ class Decoder
     boost::condition_variable            output_cond;
     int                                  output_capacity = 8;
 
+    // Flush-in-place synchronisation. A flush request is raised by the producer thread
+    // (Decoder::flush) but is always serviced on the worker thread (do_flush), because the
+    // worker is the only thread allowed to touch `ctx`. This lets a looping producer reuse
+    // the decoder across a loop wrap instead of destroying and recreating the thread + codec
+    // context every loop, which was the source of the heap-allocation churn.
+    std::atomic<bool>         flush_request_ = {false};
+    mutable boost::mutex      flush_ack_mutex;
+    boost::condition_variable flush_ack_cond;
+
     boost::thread thread;
+
+    // Runs on the worker thread only.
+    void do_flush()
+    {
+        {
+            boost::lock_guard<boost::mutex>       lock(input_mutex);
+            std::queue<std::shared_ptr<AVPacket>> empty;
+            input.swap(empty);
+        }
+        {
+            boost::lock_guard<boost::mutex>      lock(output_mutex);
+            std::queue<std::shared_ptr<AVFrame>> empty;
+            output.swap(empty);
+        }
+
+        avcodec_flush_buffers(ctx.get());
+        next_pts = AV_NOPTS_VALUE;
+        eof      = false;
+
+        {
+            boost::lock_guard<boost::mutex> lock(flush_ack_mutex);
+            flush_request_.store(false);
+        }
+        flush_ack_cond.notify_all();
+    }
 
   public:
     std::shared_ptr<AVCodecContext> ctx;
@@ -185,6 +219,13 @@ class Decoder
                 // `thread` member, which is still being assigned by the constructor when this
                 // lambda starts running (data race on the partially-constructed member).
                 while (!boost::this_thread::interruption_requested()) {
+                    // Flush-in-place sync point: service a pending flush on this worker thread
+                    // (the only thread allowed to touch ctx) before doing any more decoding.
+                    if (flush_request_.load()) {
+                        do_flush();
+                        continue;
+                    }
+
                     auto av_frame = alloc_frame();
                     auto ret      = avcodec_receive_frame(ctx.get(), av_frame.get());
 
@@ -192,7 +233,10 @@ class Decoder
                         std::shared_ptr<AVPacket> packet;
                         {
                             boost::unique_lock<boost::mutex> lock(input_mutex);
-                            input_cond.wait(lock, [&]() { return !input.empty(); });
+                            input_cond.wait(lock, [&]() { return !input.empty() || flush_request_.load(); });
+                            if (flush_request_.load()) {
+                                continue;
+                            }
                             packet = std::move(input.front());
                             input.pop();
                         }
@@ -205,7 +249,11 @@ class Decoder
 
                         {
                             boost::unique_lock<boost::mutex> lock(output_mutex);
-                            output_cond.wait(lock, [&]() { return output.size() < output_capacity; });
+                            output_cond.wait(
+                                lock, [&]() { return output.size() < output_capacity || flush_request_.load(); });
+                            if (flush_request_.load()) {
+                                continue;
+                            }
                             output.push(std::move(av_frame));
                         }
                     } else {
@@ -257,7 +305,11 @@ class Decoder
 
                         {
                             boost::unique_lock<boost::mutex> lock(output_mutex);
-                            output_cond.wait(lock, [&]() { return output.size() < output_capacity; });
+                            output_cond.wait(
+                                lock, [&]() { return output.size() < output_capacity || flush_request_.load(); });
+                            if (flush_request_.load()) {
+                                continue;
+                            }
                             output.push(std::move(av_frame));
                         }
                     }
@@ -329,6 +381,23 @@ class Decoder
         }
 
         return frame;
+    }
+
+    // Reset the decoder to a fresh, post-seek state (empty queues, flushed codec buffers)
+    // without destroying the worker thread or codec context. Called by the producer thread;
+    // blocks until the worker thread has performed the flush at a safe sync point.
+    void flush()
+    {
+        if (!thread.joinable()) {
+            return;
+        }
+
+        flush_request_.store(true);
+        input_cond.notify_all();
+        output_cond.notify_all();
+
+        boost::unique_lock<boost::mutex> lock(flush_ack_mutex);
+        flush_ack_cond.wait(lock, [&]() { return !flush_request_.load(); });
     }
 };
 
@@ -1241,7 +1310,13 @@ struct AVProducer::Impl
         frame_count_ = 0;
         buffer_eof_  = false;
 
-        decoders_.clear();
+        // Fix 4b: reuse the existing decoders across a loop wrap / seek instead of destroying
+        // and recreating their worker threads and codec contexts every time. Flushing in place
+        // resets each decoder to a fresh post-seek state while avoiding the per-loop heap churn.
+        // reset() below rebuilds the (cheap) filter graphs and re-binds them to these decoders.
+        for (auto& p : decoders_) {
+            p.second.flush();
+        }
 
         reset(time);
     }

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -181,7 +181,10 @@ class Decoder
 
         thread = boost::thread([this]() {
             try {
-                while (!thread.interruption_requested()) {
+                // NOTE: Check interruption via the current-thread helper rather than reading the
+                // `thread` member, which is still being assigned by the constructor when this
+                // lambda starts running (data race on the partially-constructed member).
+                while (!boost::this_thread::interruption_requested()) {
                     auto av_frame = alloc_frame();
                     auto ret      = avcodec_receive_frame(ctx.get(), av_frame.get());
 
@@ -788,8 +791,11 @@ struct AVProducer::Impl
 
     ~Impl()
     {
+        // 1) Stop feeding the pipeline.
         input_.abort();
 
+        // 2) Join the run loop FIRST, so nothing else touches decoders_/filters while we
+        //    tear them down.
         try {
             if (thread_.joinable()) {
                 thread_.interrupt();
@@ -799,8 +805,16 @@ struct AVProducer::Impl
             // Do nothing...
         }
 
+        // 3) Stop the filter executors before freeing the graphs they reference.
         video_executor_.reset();
         audio_executor_.reset();
+
+        // 4) Destroy the pipeline explicitly, in a defined order, while fully quiesced,
+        //    instead of relying on implicit member-destruction order.
+        sources_.clear();
+        video_filter_ = Filter{};
+        audio_filter_ = Filter{};
+        decoders_.clear(); // joins each Decoder's worker thread
 
         CASPAR_LOG(debug) << print() << " Joined";
     }

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -42,7 +42,12 @@
 #include <boost/logic/tribool.hpp>
 #include <common/filesystem.h>
 
+#include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
 
 extern "C" {
 #define __STDC_CONSTANT_MACROS
@@ -55,14 +60,30 @@ namespace caspar { namespace ffmpeg {
 using namespace std::chrono_literals;
 
 namespace {
-// Single shared worker that performs the slow ffmpeg teardown off the realtime thread
-// WITHOUT spawning an unbounded number of concurrent threads. Serializing producer
-// destruction means a mass CLEAR/REMOVE no longer races many ffmpeg/tbbmalloc frees
-// against each other.
+// Small fixed-size pool of workers that perform the slow ffmpeg teardown off the realtime
+// thread WITHOUT spawning an unbounded number of concurrent threads.
+//
+// Rationale: a single teardown thread would fully serialize destruction, so one producer
+// whose teardown blocks (e.g. a network input whose abort() is slow to unblock the decoder)
+// would stall the teardown of every other producer behind it and leak their memory. A small
+// bounded pool keeps the heap-corruption protection (only a handful of concurrent frees
+// instead of N) while avoiding that head-of-line blocking. Producers are dispatched
+// round-robin across the pool.
 caspar::executor& ffmpeg_producer_destroyer()
 {
-    static caspar::executor destroyer(L"ffmpeg_producer_destroyer");
-    return destroyer;
+    static constexpr std::size_t        pool_size = 3;
+    static std::vector<std::unique_ptr<caspar::executor>> pool = [] {
+        std::vector<std::unique_ptr<caspar::executor>> workers;
+        workers.reserve(pool_size);
+        for (std::size_t i = 0; i < pool_size; ++i) {
+            workers.push_back(
+                std::make_unique<caspar::executor>(L"ffmpeg_producer_destroyer_" + std::to_wstring(i)));
+        }
+        return workers;
+    }();
+
+    static std::atomic<std::size_t> next{0};
+    return *pool[next.fetch_add(1, std::memory_order_relaxed) % pool_size];
 }
 } // namespace
 

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -26,6 +26,7 @@
 #include "av_producer.h"
 
 #include <common/env.h>
+#include <common/executor.h>
 #include <common/os/filesystem.h>
 #include <common/param.h>
 
@@ -52,6 +53,18 @@ extern "C" {
 namespace caspar { namespace ffmpeg {
 
 using namespace std::chrono_literals;
+
+namespace {
+// Single shared worker that performs the slow ffmpeg teardown off the realtime thread
+// WITHOUT spawning an unbounded number of concurrent threads. Serializing producer
+// destruction means a mass CLEAR/REMOVE no longer races many ffmpeg/tbbmalloc frees
+// against each other.
+caspar::executor& ffmpeg_producer_destroyer()
+{
+    static caspar::executor destroyer(L"ffmpeg_producer_destroyer");
+    return destroyer;
+}
+} // namespace
 
 struct ffmpeg_producer : public core::frame_producer
 {
@@ -94,13 +107,13 @@ struct ffmpeg_producer : public core::frame_producer
 
     ~ffmpeg_producer()
     {
-        std::thread([producer = std::move(producer_)]() mutable {
+        ffmpeg_producer_destroyer().begin_invoke([producer = std::move(producer_)]() mutable {
             try {
                 producer.reset();
             } catch (...) {
                 CASPAR_LOG_CURRENT_EXCEPTION();
             }
-        }).detach();
+        });
     }
 
     // frame_producer


### PR DESCRIPTION
> **Stacked on #1755.** This branch currently contains #1755's three commits plus the single commit reviewed here. Please review/merge after #1755; once it merges I'll rebase and this PR will reduce to just the decoder-reuse commit.

**Disclamer: This work has been 'done' with AI, I have lightly tested to make sure it doesn't break anything obvious, but #1755 and #1756 are just drafts for now that require discussion to see if this could be the right approach or not. This is trying to solve a series of unexpected crashes (nothing shows in the logs)  related to ntdll/heap corruption/access violation, sometimes with no new commands or interactions at that point, the looping of 5 channels was the only active work. We have counted 26 hard crashes in the last 1,5 years (using 2.4.3 stable since last september). Since I haven't seen any work specifically addressing similar issues I used Opus 4.8 to offer the fixes**

`I decided to separate the work into two different PRs since this one is much more invasive than the other commits, and changes a more fundamental part of the core.`

## Problem
`AVProducer::Impl::seek_internal()` runs on every loop wrap (and every seek) and calls `decoders_.clear()`, which destroys **every** `Decoder` — joining its worker `boost::thread` and freeing its `AVCodecContext` — and then `reset()` recreates them all (new thread + `avcodec_alloc_context3`/`avcodec_open2`).

For a looping clip this means a continuous create/join of decoder threads and open/close of codec contexts every loop iteration. With `tbbmalloc_proxy` overriding global `malloc`/`free`, that per-loop allocation churn is the root cause behind the idle-loop heap corruption (the teardown hardening in #1755 narrows the window but does not remove the churn).

## Change
Reuse decoders across a loop wrap by flushing them in place instead of destroying and recreating them:

- Add a thread-safe `Decoder::flush()`. The producer thread raises a flush request and blocks on an ack; the **owning worker thread** performs the actual flush at a safe sync point (`do_flush()`): clears the input/output queues, calls `avcodec_flush_buffers(ctx)`, and resets `next_pts`/`eof`. The codec context is therefore never touched from the producer thread — closing the data race that makes naive in-place flushing unsafe.
- The worker loop now checks the flush request at the top of the loop and in every blocking `condition_variable` predicate (one input wait, two output waits), discarding any in-flight frame so the flush is serviced promptly.
- `seek_internal()` now flushes the existing decoders instead of clearing the map. `reset()` is unchanged: it still rebuilds the (cheap) filter graphs and re-binds them to the surviving decoders.

A flushed decoder is behaviourally identical to a freshly constructed one (empty queues, flushed codec buffers, `next_pts = AV_NOPTS_VALUE`, `eof = false`), so output is unchanged — only the per-loop heap churn is removed.

## Risk
Moderate (concurrency change), mitigated by keeping all `ctx` access on the worker thread and using a request/ack handshake. Scope is intentionally limited to **decoders**; filter graphs are still rebuilt each loop.

## Testing
- Built `Release`; `av_producer.cpp` / `ffmpeg.lib` / `casparcg.exe` compile and link clean.
- Looping playback: clean loop seam, A/V sync stable.
- Primary success signal: **flat RSS over a long loop** (no per-loop alloc/free).
- Spot-checked user `CALL ... SEEK` accuracy and play-once EOF.