### PR TITLE
fix(common): stop per-exception stacktrace symbolization to fix Win32 thread-handle leak

### DIFF
--- a/src/common/except.h
+++ b/src/common/except.h
@@ -45,7 +45,6 @@ using msg_info_t        = boost::error_info<struct tag_msg_info, std::string>;
 using error_info_t      = boost::error_info<struct tag_error_info, std::string>;
 using source_info_t     = boost::error_info<struct tag_source_info, std::string>;
 using file_name_info_t  = boost::error_info<struct tag_file_name_info, std::string>;
-using stacktrace_info_t = boost::error_info<struct tag_stacktrace_info, boost::stacktrace::stacktrace>;
 
 template <typename T>
 arg_name_info_t arg_name_info(const T& str)
@@ -77,8 +76,6 @@ file_name_info_t file_name_info(const T& str)
 {
     return file_name_info_t(u8(str));
 }
-
-inline stacktrace_info_t stacktrace_info() { return stacktrace_info_t(boost::stacktrace::stacktrace()); }
 
 using line_info        = boost::error_info<struct tag_line_info, size_t>;
 using nested_exception = boost::error_info<struct tag_nested_exception_, std::exception_ptr>;
@@ -150,6 +147,6 @@ struct not_supported : virtual user_error
 #define CASPAR_THROW_EXCEPTION(x)                                                                                      \
     ::boost::throw_exception(::boost::enable_error_info(x)                                                             \
                              << ::boost::throw_function(BOOST_CURRENT_FUNCTION) << ::boost::throw_file(__FILE__)       \
-                             << ::boost::throw_line((int)__LINE__) << stacktrace_info())
+                             << ::boost::throw_line((int)__LINE__))
 
 } // namespace caspar

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -74,6 +74,12 @@ bool          set_log_level(const std::wstring& lvl);
 std::wstring& get_log_level();
 void          set_log_column_alignment(bool align_columns);
 
+// Symbolizes the current call stack via boost::stacktrace. On MSVC this drives the dbgeng debug engine,
+// which attaches to the process and opens a handle to every thread; doing this on every logged exception
+// leaks Win32 thread handles under high exception churn (e.g. HLS reconnect storms). It is therefore NOT
+// called on the exception-logging hot path below. Real crashes still get a full backtrace via the
+// signal/terminate handler in main.cpp (safe_dump_to + from_dump). Keep this helper for explicit, manual
+// diagnostic use only.
 inline std::wstring get_stack_trace()
 {
     auto bt = boost::stacktrace::stacktrace();
@@ -85,9 +91,8 @@ inline std::wstring get_stack_trace()
 
 #define CASPAR_LOG_CURRENT_EXCEPTION()                                                                                 \
     try {                                                                                                              \
-        CASPAR_LOG(error) << L"Exception: " << caspar::u16(::caspar::log::current_exception_diagnostic_information())  \
-                          << L"\r\n"                                                                                   \
-                          << caspar::log::get_stack_trace();                                                           \
+        CASPAR_LOG(error) << L"Exception: "                                                                            \
+                          << caspar::u16(::caspar::log::current_exception_diagnostic_information());                   \
     } catch (...) {                                                                                                    \
     }
 


### PR DESCRIPTION
**Disclamer: AI powered PR and code fixes. I stumbled upon this leak by accident trying to find the cause of another crash, but this fix is mainly important (even critical) for long-term streaming operations. The test that found it was a flaky (on purpose) http server, and Caspar was receiving HLS streams. Since there were constant reconnections and 'exceptions' logged, the thread handles were getting duplicated constantly and didn't belong to an actual thread. In this synthetic test at some point the machine ran out of resources and hard crashed the whole system.**

## Summary

Under sustained exception churn on Windows, the server leaks **Win32 thread handles** until it eventually runs out and becomes unstable. The leak is most visible with reconnect-prone network sources (e.g. an HLS/HTTP input that keeps dropping and reconnecting), but it is **source-agnostic** — it is driven by how often exceptions are *thrown and logged*, not by any particular producer.

This PR removes the per-exception stack-trace capture and symbolization that causes the leak. The change is two files in `src/common`.

## Root cause

Two pieces work together:

- `CASPAR_THROW_EXCEPTION` (`common/except.h`) attaches a `boost::stacktrace::stacktrace()` to **every** thrown exception.
- `CASPAR_LOG_CURRENT_EXCEPTION` (`common/log.h`) then **symbolizes** that trace on every logged exception.

On MSVC, `boost::stacktrace` symbolization uses the **dbgeng/dbghelp** backend. Each symbolization call attaches the debug engine to the process and, as part of walking it, **opens a handle to every thread in the process** — and those per-thread handles are never released. So every logged exception leaks roughly *one handle per live thread*. A source that faults and reconnects in a tight loop turns that into thousands of leaked handles.

## How it was diagnosed (so others can reproduce the method)

1. **Reproduce the leak.** Point an `ffmpeg`/HLS producer at an unreliable source (we used a small local HTTP server that randomly truncates segments, returns 5xx, or stalls) and let it churn. Sample the process handle count over time with any of: Process Explorer, `Get-Process <pid> | Select-Object Handles`, or `NtQuerySystemInformation(SystemExtendedHandleInformation)`. You should see the handle count climb monotonically while the source keeps faulting.
2. **Tie growth to exceptions.** Stop the faulting source (or `CLEAR` the channels) so no more exceptions are thrown/logged → handle growth stops immediately. This points at the exception path rather than the producer/decoder itself.
3. **Confirm the backend.** Check the loaded modules; `dbgeng.dll` + `dbghelp.dll` are present, loaded by `boost::stacktrace`. A quick A/B is to rebuild once with `BOOST_STACKTRACE_USE_NOOP` defined: dbgeng no longer loads and the handle count stays flat under the same fault load — confirming the symbolization path is the leak.

## The fix and why this approach

- `except.h`: stop attaching a `stacktrace` to every thrown exception.
- `log.h`: `CASPAR_LOG_CURRENT_EXCEPTION` now logs the exception **type, message and throw location** (function/file/line via boost error info) but no longer symbolizes a stack on the hot path.

We deliberately kept this minimal rather than switching the `boost::stacktrace` backend or globally disabling it:

- **Crash diagnostics are unaffected.** Real crashes still produce a full backtrace via the existing signal/terminate handler in `shell/main.cpp` (`safe_dump_to` writes addresses signal-safely at crash time; `from_dump` symbolizes once at the next startup). That path is separate from the per-exception logging path and does not leak.
- **No behavioural/ABI surprises** from changing how stacks are captured globally; the only thing removed is the expensive per-exception symbolization that was leaking handles.
- The `get_stack_trace()` helper is **kept** (with an explanatory comment) for explicit, manual diagnostic use.

### Restoring the per-exception stack trace (if you want it locally)

The information isn't gone from the codebase — it's just no longer emitted on every logged exception. To get the old behaviour back for local debugging, re-add the symbolized trace to the log line in `common/log.h`:

```cpp
#define CASPAR_LOG_CURRENT_EXCEPTION()                                          \
    try {                                                                       \
        CASPAR_LOG(error) << L"Exception: "                                     \
                          << caspar::u16(::caspar::log::current_exception_diagnostic_information()) \
                          << L"\r\n" << caspar::log::get_stack_trace();         \
    } catch (...) {                                                             \
    }
```

Just be aware that doing so reintroduces the dbgeng symbolization (and therefore the handle leak) under heavy exception churn on Windows.

## Verification

With the fix applied, the same faulting-source soak (8 minutes, multi-channel, full multi-threaded decode) holds the process handle count **flat/oscillating around its baseline** instead of climbing. Stopping the leak required no change to decoder/producer threading, so decode performance is unchanged.

## Files changed

- `src/common/except.h` — drop per-throw `stacktrace_info`.
- `src/common/log.h` — drop per-exception symbolization on the log hot path; keep `get_stack_trace()` for manual use.

## Platform scope

The handle-exhaustion failure mode is **Windows-specific**: it comes from `boost::stacktrace`'s MSVC **dbgeng/dbghelp** backend, which opens a never-released handle to every thread on each symbolization. Linux has no dbgeng and no equivalent per-thread `HANDLE`, so it does not hit this leak. However, the per-exception symbolization is **wasteful on every platform** (on Linux the backtrace backend still does CPU-heavy DWARF/`addr2line` work per logged exception), so removing it is a small win for Linux too.