### PR TITLE
fix: escape backslashes and control chars in html cg update payload

### DIFF
--- a/src/modules/html/producer/html_cg_proxy.cpp
+++ b/src/modules/html/producer/html_cg_proxy.cpp
@@ -60,8 +60,12 @@ void html_cg_proxy::next(int layer) { producer_->call({L"next()"}); }
 
 void html_cg_proxy::update(int layer, const std::wstring& data)
 {
-    auto escaped =
-        boost::algorithm::replace_all_copy(boost::algorithm::trim_copy_if(data, boost::is_any_of(" \"")), "\"", "\\\"");
+    auto escaped = boost::algorithm::trim_copy_if(data, boost::is_any_of(L" \""));
+    boost::algorithm::replace_all(escaped, L"\\", L"\\\\");
+    boost::algorithm::replace_all(escaped, L"\"", L"\\\"");
+    boost::algorithm::replace_all(escaped, L"\n", L"\\n");
+    boost::algorithm::replace_all(escaped, L"\r", L"\\r");
+    boost::algorithm::replace_all(escaped, L"\t", L"\\t");
     producer_->call({L"update(\"" + escaped + L"\")"});
 }
 


### PR DESCRIPTION
update() builds a JS update("\<data\>") call but only escaped ", not \. So any backslash in the payload (like the \" in JSON) broke the JS string and threw SyntaxError: missing ) after argument list.