### PR TITLE
Add image effects: MIXER BLUR, SHARPEN and GRAIN

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -258,6 +258,18 @@ struct image_kernel::impl
             shader_->set("blur_enable", false);
         }
 
+        // Sharpen
+        if (std::abs(transforms.image_transform.sharpen_amount) > epsilon) {
+            shader_->set("sharpen_enable", true);
+            shader_->set("sharpen_amount", static_cast<float>(transforms.image_transform.sharpen_amount));
+            shader_->set("sharpen_radius", static_cast<float>(transforms.image_transform.sharpen_radius));
+            shader_->set("target_size",
+                         static_cast<float>(params.target_width),
+                         static_cast<float>(params.target_height));
+        } else {
+            shader_->set("sharpen_enable", false);
+        }
+
         // Setup blend_func
 
         if (transforms.image_transform.is_key) {

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -86,6 +86,7 @@ struct image_kernel::impl
     spl::shared_ptr<shader> shader_;
     GLuint                  vao_;
     GLuint                  vbo_;
+    int                     frame_counter_ = 0;
 
     explicit impl(const spl::shared_ptr<device>& ogl)
         : ogl_(ogl)
@@ -268,6 +269,19 @@ struct image_kernel::impl
                          static_cast<float>(params.target_height));
         } else {
             shader_->set("sharpen_enable", false);
+        }
+
+        // Film grain
+        if (std::abs(transforms.image_transform.grain_intensity) > epsilon) {
+            shader_->set("grain_enable", true);
+            shader_->set("grain_intensity", static_cast<float>(transforms.image_transform.grain_intensity));
+            shader_->set("grain_size", static_cast<float>(transforms.image_transform.grain_size));
+            shader_->set("grain_frame", frame_counter_++);
+            shader_->set("target_size",
+                         static_cast<float>(params.target_width),
+                         static_cast<float>(params.target_height));
+        } else {
+            shader_->set("grain_enable", false);
         }
 
         // Setup blend_func

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -239,6 +239,25 @@ struct image_kernel::impl
             shader_->set("chroma", false);
         }
 
+        // Blur
+        if (transforms.image_transform.blur.enable) {
+            shader_->set("blur_enable", true);
+            shader_->set("blur_radius", static_cast<float>(transforms.image_transform.blur.radius));
+            shader_->set("blur_type", static_cast<int>(transforms.image_transform.blur.type));
+            shader_->set("blur_angle", static_cast<float>(transforms.image_transform.blur.angle));
+            shader_->set("blur_center",
+                         static_cast<float>(transforms.image_transform.blur.center[0]),
+                         static_cast<float>(transforms.image_transform.blur.center[1]));
+            shader_->set("blur_tilt",
+                         static_cast<float>(transforms.image_transform.blur.tilt_y),
+                         static_cast<float>(transforms.image_transform.blur.tilt_h));
+            shader_->set("target_size",
+                         static_cast<float>(params.target_width),
+                         static_cast<float>(params.target_height));
+        } else {
+            shader_->set("blur_enable", false);
+        }
+
         // Setup blend_func
 
         if (transforms.image_transform.is_key) {

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,6 +43,14 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
+uniform bool		blur_enable;
+uniform float		blur_radius;
+uniform int			blur_type; // 0=gaussian, 1=box, 2=directional, 3=zoom, 4=tilt_shift, 5=lens
+uniform float		blur_angle;
+uniform vec2		blur_center;
+uniform vec2		blur_tilt;
+uniform vec2		target_size;
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -519,9 +527,117 @@ vec4 get_rgba_color(vec2 uv)
     return vec4(0.0, 0.0, 0.0, 0.0);
 }
 
+vec4 get_blurred_color(vec2 uv)
+{
+    if (!blur_enable || blur_radius < 0.5)
+        return get_rgba_color(uv);
+
+    vec2  texelSize   = 1.0 / target_size;
+    vec4  totalColor  = vec4(0.0);
+    float totalWeight = 0.0;
+
+    // GAUSSIAN BLUR (2D spiral with Gaussian weights)
+    if (blur_type == 0)
+    {
+        int   iSamples = int(clamp(blur_radius * 3.0, 16.0, 120.0));
+        float sigma    = blur_radius / 2.0;
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blur_radius;
+            float theta  = float(i) * 2.39996323; // golden angle
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            float weight = exp(-(radius * radius) / (2.0 * sigma * sigma));
+            totalColor  += get_rgba_color(uv + offset) * weight;
+            totalWeight += weight;
+        }
+    }
+    // BOX BLUR
+    else if (blur_type == 1)
+    {
+        int   steps    = min(int(blur_radius), 6);
+        float stepSize = blur_radius / max(float(steps), 1.0);
+        for (int y = -steps; y <= steps; y++) {
+            for (int x = -steps; x <= steps; x++) {
+                vec2 offset = vec2(float(x), float(y)) * stepSize * texelSize;
+                totalColor  += get_rgba_color(uv + offset);
+                totalWeight += 1.0;
+            }
+        }
+    }
+    // DIRECTIONAL BLUR (motion blur)
+    else if (blur_type == 2)
+    {
+        float angleRad = radians(blur_angle);
+        vec2  dir      = vec2(cos(angleRad), sin(angleRad));
+        int   iSamples = int(clamp(blur_radius * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = (float(i) / max(float(iSamples - 1), 1.0)) - 0.5;
+            vec2  offset = dir * (t * blur_radius * 2.0 * texelSize);
+            totalColor  += get_rgba_color(uv + offset);
+            totalWeight += 1.0;
+        }
+    }
+    // ZOOM BLUR
+    else if (blur_type == 3)
+    {
+        vec2  center   = blur_center;
+        vec2  toPixel  = uv - center;
+        float strength = blur_radius * 0.01;
+        int   iSamples = int(clamp(blur_radius * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float scale  = 1.0 - strength * (float(i) / max(float(iSamples - 1), 1.0));
+            totalColor  += get_rgba_color(center + toPixel * scale);
+            totalWeight += 1.0;
+        }
+    }
+    // TILT-SHIFT
+    else if (blur_type == 4)
+    {
+        float angleRad    = radians(blur_angle);
+        vec2  normal      = vec2(sin(angleRad), cos(angleRad));
+        float dist        = abs(dot(uv - blur_center, normal) - (blur_tilt.x - 0.5));
+        float focus_width = blur_tilt.y;
+        float blurAmount  = smoothstep(focus_width * 0.5, focus_width * 0.5 + 0.2, dist) * blur_radius;
+        if (blurAmount < 0.5)
+            return get_rgba_color(uv);
+        int iSamples = int(clamp(blurAmount * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blurAmount;
+            float theta  = float(i) * 2.39996323;
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            totalColor  += get_rgba_color(uv + offset);
+            totalWeight += 1.0;
+        }
+    }
+    // LENS (cinematic bokeh)
+    else if (blur_type == 5)
+    {
+        float noise        = fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+        float dither_theta = noise * 6.2831853;
+        int   iSamples     = int(clamp(blur_radius * 8.0, 32.0, 400.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blur_radius;
+            float theta  = dither_theta + float(i) * 2.39996323;
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            vec4  col    = get_rgba_color(uv + offset);
+            float lum    = dot(col.rgb, vec3(0.299, 0.587, 0.114));
+            float weight = 1.0 + pow(max(lum - 0.3, 0.0), 3.0) * 15.0;
+            weight      *= mix(0.3, 1.0, t);
+            totalColor  += col * weight;
+            totalWeight += weight;
+        }
+    }
+
+    if (totalWeight > 0.0)
+        return totalColor / totalWeight;
+    return get_rgba_color(uv);
+}
+
 void main()
 {
-    vec4 color = get_rgba_color(TexCoord.st / TexCoord.q);
+    vec4 color = get_blurred_color(TexCoord.st / TexCoord.q);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -455,64 +455,64 @@ vec4 get_sample(sampler2D sampler, vec2 coords)
     return texture(sampler, coords);
 }
 
-vec4 get_rgba_color()
+vec4 get_rgba_color(vec2 uv)
 {
     switch(pixel_format)
     {
     case 0:		//gray
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rrr * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).rrr * precision_factor[0], 1.0);
     case 1:		//bgra,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).bgra * precision_factor[0];
+        return get_sample(plane[0], uv).bgra * precision_factor[0];
     case 2:		//rgba,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).rgba * precision_factor[0];
+        return get_sample(plane[0], uv).rgba * precision_factor[0];
     case 3:		//argb,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).argb * precision_factor[0];
+        return get_sample(plane[0], uv).argb * precision_factor[0];
     case 4:		//abgr,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).gbar * precision_factor[0];
+        return get_sample(plane[0], uv).gbar * precision_factor[0];
     case 5:		//ycbcr,
         {
-            float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float y  = get_sample(plane[0], uv).r * precision_factor[0];
+            float cb = get_sample(plane[1], uv).r * precision_factor[1];
+            float cr = get_sample(plane[2], uv).r * precision_factor[2];
             return ycbcra_to_rgba(y, cb, cr, 1.0);
         }
     case 6:		//ycbcra
         {
-            float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
-            float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r * precision_factor[3];
+            float y  = get_sample(plane[0], uv).r * precision_factor[0];
+            float cb = get_sample(plane[1], uv).r * precision_factor[1];
+            float cr = get_sample(plane[2], uv).r * precision_factor[2];
+            float a  = get_sample(plane[3], uv).r * precision_factor[3];
             return ycbcra_to_rgba(y, cb, cr, a);
         }
     case 7:		//luma
         {
-            vec3 y3 = get_sample(plane[0], TexCoord.st / TexCoord.q).rrr * precision_factor[0];
+            vec3 y3 = get_sample(plane[0], uv).rrr * precision_factor[0];
             return vec4((y3-0.065)/0.859, 1.0);
         }
     case 8:		//bgr,
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).bgr * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).bgr * precision_factor[0], 1.0);
     case 9:		//rgb,
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rgb * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).rgb * precision_factor[0], 1.0);
 	case 10:	// uyvy
 		{
-			float y = get_sample(plane[0], TexCoord.st / TexCoord.q).g * precision_factor[0];
-			float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).b * precision_factor[1];
-			float cr = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
+			float y = get_sample(plane[0], uv).g * precision_factor[0];
+			float cb = get_sample(plane[1], uv).b * precision_factor[1];
+			float cr = get_sample(plane[1], uv).r * precision_factor[1];
 			return ycbcra_to_rgba(y, cb, cr, 1.0);
 		}
     case 11:    // gbrp
         {
-            float g  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float b = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float r = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float g  = get_sample(plane[0], uv).r * precision_factor[0];
+            float b = get_sample(plane[1], uv).r * precision_factor[1];
+            float r = get_sample(plane[2], uv).r * precision_factor[2];
 			return vec4(b, g, r, 1.0);
         }
     case 12:    // gbrap
         {
-            float g  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float b = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float r = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
-            float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r * precision_factor[3];
+            float g  = get_sample(plane[0], uv).r * precision_factor[0];
+            float b = get_sample(plane[1], uv).r * precision_factor[1];
+            float r = get_sample(plane[2], uv).r * precision_factor[2];
+            float a  = get_sample(plane[3], uv).r * precision_factor[3];
 			return vec4(b, g, r, a);
         }
     }
@@ -521,7 +521,7 @@ vec4 get_rgba_color()
 
 void main()
 {
-    vec4 color = get_rgba_color();
+    vec4 color = get_rgba_color(TexCoord.st / TexCoord.q);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -55,6 +55,11 @@ uniform bool		sharpen_enable;
 uniform float		sharpen_amount;
 uniform float		sharpen_radius;
 
+uniform bool		grain_enable;
+uniform float		grain_intensity;
+uniform float		grain_size;
+uniform int			grain_frame; // animated per frame for temporal variation
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -650,6 +655,23 @@ vec3 apply_sharpen(vec2 uv, vec3 center_col, float amount, float rad)
     return center_col + (center_col - blur_avg) * amount;
 }
 
+float grain_hash(vec2 p, int frame_seed)
+{
+    vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + float(frame_seed) * 0.00137);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+vec3 apply_film_grain(vec3 c, vec2 uv, float intensity, float size_val, int frame_seed)
+{
+    vec2  grain_uv = uv * target_size / max(size_val, 0.5);
+    float noise    = grain_hash(grain_uv, frame_seed) * 2.0 - 1.0; // -1..+1
+    float lum      = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float response = smoothstep(0.0, 0.15, lum) * (1.0 - smoothstep(0.8, 1.0, lum));
+    c += vec3(noise * intensity * response);
+    return c;
+}
+
 void main()
 {
     vec2 uv    = TexCoord.st / TexCoord.q;
@@ -673,5 +695,7 @@ void main()
         color = 1.0 - color;
     if (blend_mode >= 0)
         color = blend(color);
+    if (grain_enable)
+        color.rgb = apply_film_grain(color.rgb, uv, grain_intensity, grain_size, grain_frame);
     fragColor = color.bgra;
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -51,6 +51,10 @@ uniform vec2		blur_center;
 uniform vec2		blur_tilt;
 uniform vec2		target_size;
 
+uniform bool		sharpen_enable;
+uniform float		sharpen_amount;
+uniform float		sharpen_radius;
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -635,9 +639,23 @@ vec4 get_blurred_color(vec2 uv)
     return get_rgba_color(uv);
 }
 
+vec3 apply_sharpen(vec2 uv, vec3 center_col, float amount, float rad)
+{
+    vec2 ts = 1.0 / target_size * rad;
+    vec3 n  = get_rgba_color(uv + vec2( 0.0, -ts.y)).rgb;
+    vec3 s  = get_rgba_color(uv + vec2( 0.0,  ts.y)).rgb;
+    vec3 e  = get_rgba_color(uv + vec2( ts.x,  0.0)).rgb;
+    vec3 w  = get_rgba_color(uv + vec2(-ts.x,  0.0)).rgb;
+    vec3 blur_avg = (n + s + e + w) * 0.25;
+    return center_col + (center_col - blur_avg) * amount;
+}
+
 void main()
 {
-    vec4 color = get_blurred_color(TexCoord.st / TexCoord.q);
+    vec2 uv    = TexCoord.st / TexCoord.q;
+    vec4 color = get_blurred_color(uv);
+    if (sharpen_enable)
+        color.rgb = apply_sharpen(uv, color.rgb, sharpen_amount, sharpen_radius);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -490,64 +490,64 @@ vec4 get_sample(sampler2D sampler, vec2 coords)
     return texture(sampler, coords);
 }
 
-vec4 get_rgba_color()
+vec4 get_rgba_color(vec2 uv)
 {
     switch(pixel_format)
     {
     case 0:		//gray
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rrr * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).rrr * precision_factor[0], 1.0);
     case 1:		//bgra,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).bgra * precision_factor[0];
+        return get_sample(plane[0], uv).bgra * precision_factor[0];
     case 2:		//rgba,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).rgba * precision_factor[0];
+        return get_sample(plane[0], uv).rgba * precision_factor[0];
     case 3:		//argb,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).argb * precision_factor[0];
+        return get_sample(plane[0], uv).argb * precision_factor[0];
     case 4:		//abgr,
-        return get_sample(plane[0], TexCoord.st / TexCoord.q).gbar * precision_factor[0];
+        return get_sample(plane[0], uv).gbar * precision_factor[0];
     case 5:		//ycbcr,
         {
-            float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float y  = get_sample(plane[0], uv).r * precision_factor[0];
+            float cb = get_sample(plane[1], uv).r * precision_factor[1];
+            float cr = get_sample(plane[2], uv).r * precision_factor[2];
             return ycbcra_to_rgba(y, cb, cr, 1.0);
         }
     case 6:		//ycbcra
         {
-            float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
-            float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r * precision_factor[3];
+            float y  = get_sample(plane[0], uv).r * precision_factor[0];
+            float cb = get_sample(plane[1], uv).r * precision_factor[1];
+            float cr = get_sample(plane[2], uv).r * precision_factor[2];
+            float a  = get_sample(plane[3], uv).r * precision_factor[3];
             return ycbcra_to_rgba(y, cb, cr, a);
         }
     case 7:		//luma
         {
-            vec3 y3 = get_sample(plane[0], TexCoord.st / TexCoord.q).rrr * precision_factor[0];
+            vec3 y3 = get_sample(plane[0], uv).rrr * precision_factor[0];
             return vec4((y3-0.065)/0.859, 1.0);
         }
     case 8:		//bgr,
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).bgr * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).bgr * precision_factor[0], 1.0);
     case 9:		//rgb,
-        return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rgb * precision_factor[0], 1.0);
+        return vec4(get_sample(plane[0], uv).rgb * precision_factor[0], 1.0);
 	case 10:	// uyvy
 		{
-			float y = get_sample(plane[0], TexCoord.st / TexCoord.q).g * precision_factor[0];
-			float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).b * precision_factor[1];
-			float cr = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
+			float y = get_sample(plane[0], uv).g * precision_factor[0];
+			float cb = get_sample(plane[1], uv).b * precision_factor[1];
+			float cr = get_sample(plane[1], uv).r * precision_factor[1];
 			return ycbcra_to_rgba(y, cb, cr, 1.0);
 		}
     case 11:    // gbrp
         {
-            float g  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float b = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float r = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float g  = get_sample(plane[0], uv).r * precision_factor[0];
+            float b = get_sample(plane[1], uv).r * precision_factor[1];
+            float r = get_sample(plane[2], uv).r * precision_factor[2];
 			return vec4(b, g, r, 1.0);
         }
     case 12:    // gbrap
         {
-            float g  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float b = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float r = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
-            float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r * precision_factor[3];
+            float g  = get_sample(plane[0], uv).r * precision_factor[0];
+            float b = get_sample(plane[1], uv).r * precision_factor[1];
+            float r = get_sample(plane[2], uv).r * precision_factor[2];
+            float a  = get_sample(plane[3], uv).r * precision_factor[3];
 			return vec4(b, g, r, a);
         }
     }
@@ -666,7 +666,7 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
 
 void main()
 {
-    vec4 color = get_rgba_color();
+    vec4 color = get_rgba_color(TexCoord.st / TexCoord.q);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,13 +43,6 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
-uniform bool		blur_enable;
-uniform float		blur_radius;
-uniform int			blur_type; // 0=gaussian, 1=box, 2=directional, 3=zoom, 4=tilt_shift, 5=lens
-uniform float		blur_angle;
-uniform vec2		blur_center;
-uniform vec2		blur_tilt;
-uniform vec2		target_size;
 // White balance (temperature / tint)
 uniform bool		white_balance;
 uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
@@ -84,6 +77,13 @@ uniform vec3		cdl_slope;
 uniform vec3		cdl_offset;
 uniform vec3		cdl_power;
 uniform float		cdl_saturation;
+uniform bool		blur_enable;
+uniform float		blur_radius;
+uniform int			blur_type; // 0=gaussian, 1=box, 2=directional, 3=zoom, 4=tilt_shift, 5=lens
+uniform float		blur_angle;
+uniform vec2		blur_center;
+uniform vec2		blur_tilt;
+uniform vec2		target_size;
 
 uniform bool		sharpen_enable;
 uniform float		sharpen_amount;
@@ -775,7 +775,7 @@ vec4 get_blurred_color(vec2 uv)
             float theta  = dither_theta + float(i) * 2.39996323;
             vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
             vec4  col    = get_rgba_color(uv + offset);
-            float lum    = dot(col.rgb, vec3(0.299, 0.587, 0.114));
+            float lum    = working_luma(col.rgb);
             float weight = 1.0 + pow(max(lum - 0.3, 0.0), 3.0) * 15.0;
             weight      *= mix(0.3, 1.0, t);
             totalColor  += col * weight;
@@ -810,13 +810,7 @@ vec3 apply_film_grain(vec3 c, vec2 uv, float intensity, float size_val, int fram
 {
     vec2  grain_uv = uv * target_size / max(size_val, 0.5);
     float noise    = grain_hash(grain_uv, frame_seed) * 2.0 - 1.0; // -1..+1
-    // dot(c.bgr, ...) -- c is BGR here, since this backend carries the pixel through
-    // the chain in the mixer's native BGR channel order (ContrastSaturationBrightness
-    // above already takes luma_coeff.bgr for the same reason). Unswizzled, the
-    // photographic response curve is driven by a luminance with red's Rec.709
-    // coefficient applied to blue, so grain lands in the wrong tonal range on
-    // saturated colour. Greys are unaffected by the exchange.
-    float lum      = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722));
+    float lum      = working_luma(c);
     float response = smoothstep(0.0, 0.15, lum) * (1.0 - smoothstep(0.8, 1.0, lum));
     c += vec3(noise * intensity * response);
     return c;

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -89,6 +89,11 @@ uniform bool		sharpen_enable;
 uniform float		sharpen_amount;
 uniform float		sharpen_radius;
 
+uniform bool		grain_enable;
+uniform float		grain_intensity;
+uniform float		grain_size;
+uniform int			grain_frame; // animated per frame for temporal variation
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -794,6 +799,23 @@ vec3 apply_sharpen(vec2 uv, vec3 center_col, float amount, float rad)
     return center_col + (center_col - blur_avg) * amount;
 }
 
+float grain_hash(vec2 p, int frame_seed)
+{
+    vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + float(frame_seed) * 0.00137);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+vec3 apply_film_grain(vec3 c, vec2 uv, float intensity, float size_val, int frame_seed)
+{
+    vec2  grain_uv = uv * target_size / max(size_val, 0.5);
+    float noise    = grain_hash(grain_uv, frame_seed) * 2.0 - 1.0; // -1..+1
+    float lum      = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float response = smoothstep(0.0, 0.15, lum) * (1.0 - smoothstep(0.8, 1.0, lum));
+    c += vec3(noise * intensity * response);
+    return c;
+}
+
 void main()
 {
     vec2 uv    = TexCoord.st / TexCoord.q;
@@ -832,5 +854,7 @@ void main()
         color = 1.0 - color;
     if (blend_mode >= 0)
         color = blend(color);
+    if (grain_enable)
+        color.rgb = apply_film_grain(color.rgb, uv, grain_intensity, grain_size, grain_frame);
     fragColor = color.bgra;
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -85,6 +85,10 @@ uniform vec3		cdl_offset;
 uniform vec3		cdl_power;
 uniform float		cdl_saturation;
 
+uniform bool		sharpen_enable;
+uniform float		sharpen_amount;
+uniform float		sharpen_radius;
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -779,9 +783,23 @@ vec4 get_blurred_color(vec2 uv)
     return get_rgba_color(uv);
 }
 
+vec3 apply_sharpen(vec2 uv, vec3 center_col, float amount, float rad)
+{
+    vec2 ts = 1.0 / target_size * rad;
+    vec3 n  = get_rgba_color(uv + vec2( 0.0, -ts.y)).rgb;
+    vec3 s  = get_rgba_color(uv + vec2( 0.0,  ts.y)).rgb;
+    vec3 e  = get_rgba_color(uv + vec2( ts.x,  0.0)).rgb;
+    vec3 w  = get_rgba_color(uv + vec2(-ts.x,  0.0)).rgb;
+    vec3 blur_avg = (n + s + e + w) * 0.25;
+    return center_col + (center_col - blur_avg) * amount;
+}
+
 void main()
 {
-    vec4 color = get_blurred_color(TexCoord.st / TexCoord.q);
+    vec2 uv    = TexCoord.st / TexCoord.q;
+    vec4 color = get_blurred_color(uv);
+    if (sharpen_enable)
+        color.rgb = apply_sharpen(uv, color.rgb, sharpen_amount, sharpen_radius);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,6 +43,13 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
+uniform bool		blur_enable;
+uniform float		blur_radius;
+uniform int			blur_type; // 0=gaussian, 1=box, 2=directional, 3=zoom, 4=tilt_shift, 5=lens
+uniform float		blur_angle;
+uniform vec2		blur_center;
+uniform vec2		blur_tilt;
+uniform vec2		target_size;
 // White balance (temperature / tint)
 uniform bool		white_balance;
 uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
@@ -664,9 +671,117 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
     return c;
 }
 
+vec4 get_blurred_color(vec2 uv)
+{
+    if (!blur_enable || blur_radius < 0.5)
+        return get_rgba_color(uv);
+
+    vec2  texelSize   = 1.0 / target_size;
+    vec4  totalColor  = vec4(0.0);
+    float totalWeight = 0.0;
+
+    // GAUSSIAN BLUR (2D spiral with Gaussian weights)
+    if (blur_type == 0)
+    {
+        int   iSamples = int(clamp(blur_radius * 3.0, 16.0, 120.0));
+        float sigma    = blur_radius / 2.0;
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blur_radius;
+            float theta  = float(i) * 2.39996323; // golden angle
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            float weight = exp(-(radius * radius) / (2.0 * sigma * sigma));
+            totalColor  += get_rgba_color(uv + offset) * weight;
+            totalWeight += weight;
+        }
+    }
+    // BOX BLUR
+    else if (blur_type == 1)
+    {
+        int   steps    = min(int(blur_radius), 6);
+        float stepSize = blur_radius / max(float(steps), 1.0);
+        for (int y = -steps; y <= steps; y++) {
+            for (int x = -steps; x <= steps; x++) {
+                vec2 offset = vec2(float(x), float(y)) * stepSize * texelSize;
+                totalColor  += get_rgba_color(uv + offset);
+                totalWeight += 1.0;
+            }
+        }
+    }
+    // DIRECTIONAL BLUR (motion blur)
+    else if (blur_type == 2)
+    {
+        float angleRad = radians(blur_angle);
+        vec2  dir      = vec2(cos(angleRad), sin(angleRad));
+        int   iSamples = int(clamp(blur_radius * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = (float(i) / max(float(iSamples - 1), 1.0)) - 0.5;
+            vec2  offset = dir * (t * blur_radius * 2.0 * texelSize);
+            totalColor  += get_rgba_color(uv + offset);
+            totalWeight += 1.0;
+        }
+    }
+    // ZOOM BLUR
+    else if (blur_type == 3)
+    {
+        vec2  center   = blur_center;
+        vec2  toPixel  = uv - center;
+        float strength = blur_radius * 0.01;
+        int   iSamples = int(clamp(blur_radius * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float scale  = 1.0 - strength * (float(i) / max(float(iSamples - 1), 1.0));
+            totalColor  += get_rgba_color(center + toPixel * scale);
+            totalWeight += 1.0;
+        }
+    }
+    // TILT-SHIFT
+    else if (blur_type == 4)
+    {
+        float angleRad    = radians(blur_angle);
+        vec2  normal      = vec2(sin(angleRad), cos(angleRad));
+        float dist        = abs(dot(uv - blur_center, normal) - (blur_tilt.x - 0.5));
+        float focus_width = blur_tilt.y;
+        float blurAmount  = smoothstep(focus_width * 0.5, focus_width * 0.5 + 0.2, dist) * blur_radius;
+        if (blurAmount < 0.5)
+            return get_rgba_color(uv);
+        int iSamples = int(clamp(blurAmount * 2.0, 16.0, 100.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blurAmount;
+            float theta  = float(i) * 2.39996323;
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            totalColor  += get_rgba_color(uv + offset);
+            totalWeight += 1.0;
+        }
+    }
+    // LENS (cinematic bokeh)
+    else if (blur_type == 5)
+    {
+        float noise        = fract(sin(dot(uv, vec2(12.9898, 78.233))) * 43758.5453);
+        float dither_theta = noise * 6.2831853;
+        int   iSamples     = int(clamp(blur_radius * 8.0, 32.0, 400.0));
+        for (int i = 0; i < iSamples; i++) {
+            float t      = float(i) / max(float(iSamples - 1), 1.0);
+            float radius = sqrt(t) * blur_radius;
+            float theta  = dither_theta + float(i) * 2.39996323;
+            vec2  offset = vec2(cos(theta), sin(theta)) * radius * texelSize;
+            vec4  col    = get_rgba_color(uv + offset);
+            float lum    = dot(col.rgb, vec3(0.299, 0.587, 0.114));
+            float weight = 1.0 + pow(max(lum - 0.3, 0.0), 3.0) * 15.0;
+            weight      *= mix(0.3, 1.0, t);
+            totalColor  += col * weight;
+            totalWeight += weight;
+        }
+    }
+
+    if (totalWeight > 0.0)
+        return totalColor / totalWeight;
+    return get_rgba_color(uv);
+}
+
 void main()
 {
-    vec4 color = get_rgba_color(TexCoord.st / TexCoord.q);
+    vec4 color = get_blurred_color(TexCoord.st / TexCoord.q);
     if (is_straight_alpha)
         color.rgb *= color.a;
     if (chroma)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -810,7 +810,13 @@ vec3 apply_film_grain(vec3 c, vec2 uv, float intensity, float size_val, int fram
 {
     vec2  grain_uv = uv * target_size / max(size_val, 0.5);
     float noise    = grain_hash(grain_uv, frame_seed) * 2.0 - 1.0; // -1..+1
-    float lum      = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    // dot(c.bgr, ...) -- c is BGR here, since this backend carries the pixel through
+    // the chain in the mixer's native BGR channel order (ContrastSaturationBrightness
+    // above already takes luma_coeff.bgr for the same reason). Unswizzled, the
+    // photographic response curve is driven by a luminance with red's Rec.709
+    // coefficient applied to blue, so grain lands in the wrong tonal range on
+    // saturated colour. Greys are unaffected by the exchange.
+    float lum      = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722));
     float response = smoothstep(0.0, 0.15, lum) * (1.0 - smoothstep(0.8, 1.0, lum));
     c += vec3(noise * intensity * response);
     return c;

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -70,6 +70,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.is_mix |= other.is_mix;
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
+    if (other.blur.enable) {
+        self.blur = other.blur;
+    }
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -76,6 +76,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.sharpen_amount += other.sharpen_amount;
     if (other.sharpen_radius != 1.0)
         self.sharpen_radius = other.sharpen_radius;
+    self.grain_intensity += other.grain_intensity;
+    if (other.grain_size != 1.0)
+        self.grain_size = other.grain_size;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -73,6 +73,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     if (other.blur.enable) {
         self.blur = other.blur;
     }
+    self.sharpen_amount += other.sharpen_amount;
+    if (other.sharpen_radius != 1.0)
+        self.sharpen_radius = other.sharpen_radius;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -74,6 +74,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     if (other.blur.enable) {
         self.blur = other.blur;
     }
+    self.sharpen_amount += other.sharpen_amount;
+    if (other.sharpen_radius != 1.0)
+        self.sharpen_radius = other.sharpen_radius;
 
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -71,15 +71,6 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.is_mix |= other.is_mix;
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
-    if (other.blur.enable) {
-        self.blur = other.blur;
-    }
-    self.sharpen_amount += other.sharpen_amount;
-    if (other.sharpen_radius != 1.0)
-        self.sharpen_radius = other.sharpen_radius;
-    self.grain_intensity += other.grain_intensity;
-    if (other.grain_size != 1.0)
-        self.grain_size = other.grain_size;
 
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
@@ -149,6 +140,20 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.cdl_power[i]  = lim::cdl_power.clamp(self.cdl_power[i] * other.cdl_power[i]);
     }
     self.cdl_saturation = lim::cdl_saturation.clamp(self.cdl_saturation * other.cdl_saturation);
+
+    if (other.blur.enable) {
+        self.blur = other.blur;
+    }
+
+    // Shape parameters come from whichever transform has the effect on, not from a
+    // float comparison against their default.
+    self.sharpen_amount = lim::sharpen_amount.clamp(self.sharpen_amount + other.sharpen_amount);
+    if (other.sharpen_amount != 0.0)
+        self.sharpen_radius = lim::sharpen_radius.clamp(other.sharpen_radius);
+
+    self.grain_intensity = lim::grain_intensity.clamp(self.grain_intensity + other.grain_intensity);
+    if (other.grain_intensity != 0.0)
+        self.grain_size = lim::grain_size.clamp(other.grain_size);
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -71,6 +71,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.is_mix |= other.is_mix;
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
+    if (other.blur.enable) {
+        self.blur = other.blur;
+    }
 
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -77,6 +77,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.sharpen_amount += other.sharpen_amount;
     if (other.sharpen_radius != 1.0)
         self.sharpen_radius = other.sharpen_radius;
+    self.grain_intensity += other.grain_intensity;
+    if (other.grain_size != 1.0)
+        self.grain_size = other.grain_size;
 
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -113,6 +113,9 @@ image_transform image_transform::tween(double                 time,
     result.blur.tilt_y    = do_tween(time, source.blur.tilt_y, dest.blur.tilt_y, duration, tween);
     result.blur.tilt_h    = do_tween(time, source.blur.tilt_h, dest.blur.tilt_h, duration, tween);
 
+    result.sharpen_amount = do_tween(time, source.sharpen_amount, dest.sharpen_amount, duration, tween);
+    result.sharpen_radius = do_tween(time, source.sharpen_radius, dest.sharpen_radius, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -158,7 +161,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                lhs.perspective == rhs.perspective && lhs.blur.enable == rhs.blur.enable &&
                eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
                eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
-               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
+               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
+               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -116,6 +116,9 @@ image_transform image_transform::tween(double                 time,
     result.sharpen_amount = do_tween(time, source.sharpen_amount, dest.sharpen_amount, duration, tween);
     result.sharpen_radius = do_tween(time, source.sharpen_radius, dest.sharpen_radius, duration, tween);
 
+    result.grain_intensity = do_tween(time, source.grain_intensity, dest.grain_intensity, duration, tween);
+    result.grain_size      = do_tween(time, source.grain_size, dest.grain_size, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -162,7 +165,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
                eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
                eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
-               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) ||
+               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) &&
+               eq(lhs.grain_intensity, rhs.grain_intensity) && eq(lhs.grain_size, rhs.grain_size) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -103,6 +103,16 @@ image_transform image_transform::tween(double                 time,
         do_tween(time, source.chroma.spill_suppress_saturation, dest.chroma.spill_suppress_saturation, duration, tween);
     result.chroma.enable    = dest.chroma.enable;
     result.chroma.show_mask = dest.chroma.show_mask;
+
+    result.blur.enable    = source.blur.enable || dest.blur.enable;
+    result.blur.type      = dest.blur.type;
+    result.blur.radius    = do_tween(time, source.blur.radius, dest.blur.radius, duration, tween);
+    result.blur.angle     = do_tween(time, source.blur.angle, dest.blur.angle, duration, tween);
+    result.blur.center[0] = do_tween(time, source.blur.center[0], dest.blur.center[0], duration, tween);
+    result.blur.center[1] = do_tween(time, source.blur.center[1], dest.blur.center[1], duration, tween);
+    result.blur.tilt_y    = do_tween(time, source.blur.tilt_y, dest.blur.tilt_y, duration, tween);
+    result.blur.tilt_h    = do_tween(time, source.blur.tilt_h, dest.blur.tilt_h, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -145,7 +155,10 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-               lhs.perspective == rhs.perspective ||
+               lhs.perspective == rhs.perspective && lhs.blur.enable == rhs.blur.enable &&
+               eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
+               eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
+               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -113,6 +113,9 @@ image_transform image_transform::tween(double                 time,
     result.blur.tilt_y    = do_tween(time, source.blur.tilt_y, dest.blur.tilt_y, duration, tween);
     result.blur.tilt_h    = do_tween(time, source.blur.tilt_h, dest.blur.tilt_h, duration, tween);
 
+    result.sharpen_amount = do_tween(time, source.sharpen_amount, dest.sharpen_amount, duration, tween);
+    result.sharpen_radius = do_tween(time, source.sharpen_radius, dest.sharpen_radius, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -182,6 +185,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                lhs.perspective == rhs.perspective && lhs.blur.enable == rhs.blur.enable &&
                eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
                eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
+               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
+               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) ||
                eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -116,6 +116,9 @@ image_transform image_transform::tween(double                 time,
     result.sharpen_amount = do_tween(time, source.sharpen_amount, dest.sharpen_amount, duration, tween);
     result.sharpen_radius = do_tween(time, source.sharpen_radius, dest.sharpen_radius, duration, tween);
 
+    result.grain_intensity = do_tween(time, source.grain_intensity, dest.grain_intensity, duration, tween);
+    result.grain_size      = do_tween(time, source.grain_size, dest.grain_size, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -186,6 +189,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
                eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
                eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
+               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) &&
+               eq(lhs.grain_intensity, rhs.grain_intensity) && eq(lhs.grain_size, rhs.grain_size) ||
                eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) ||
                eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -103,6 +103,16 @@ image_transform image_transform::tween(double                 time,
         do_tween(time, source.chroma.spill_suppress_saturation, dest.chroma.spill_suppress_saturation, duration, tween);
     result.chroma.enable    = dest.chroma.enable;
     result.chroma.show_mask = dest.chroma.show_mask;
+
+    result.blur.enable    = source.blur.enable || dest.blur.enable;
+    result.blur.type      = dest.blur.type;
+    result.blur.radius    = do_tween(time, source.blur.radius, dest.blur.radius, duration, tween);
+    result.blur.angle     = do_tween(time, source.blur.angle, dest.blur.angle, duration, tween);
+    result.blur.center[0] = do_tween(time, source.blur.center[0], dest.blur.center[0], duration, tween);
+    result.blur.center[1] = do_tween(time, source.blur.center[1], dest.blur.center[1], duration, tween);
+    result.blur.tilt_y    = do_tween(time, source.blur.tilt_y, dest.blur.tilt_y, duration, tween);
+    result.blur.tilt_h    = do_tween(time, source.blur.tilt_h, dest.blur.tilt_h, duration, tween);
+
     result.is_key           = source.is_key || dest.is_key;
     result.invert           = source.invert || dest.invert;
     result.is_mix           = source.is_mix || dest.is_mix;
@@ -169,6 +179,10 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
+               lhs.perspective == rhs.perspective && lhs.blur.enable == rhs.blur.enable &&
+               eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
+               eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
+               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -185,14 +185,6 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-               lhs.perspective == rhs.perspective && lhs.blur.enable == rhs.blur.enable &&
-               eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
-               eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
-               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
-               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) &&
-               eq(lhs.grain_intensity, rhs.grain_intensity) && eq(lhs.grain_size, rhs.grain_size) ||
-               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) ||
-               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
@@ -204,7 +196,13 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
                boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
                boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
-               eq(lhs.cdl_saturation, rhs.cdl_saturation) ||
+               eq(lhs.cdl_saturation, rhs.cdl_saturation) &&
+               lhs.blur.enable == rhs.blur.enable &&
+               eq(lhs.blur.radius, rhs.blur.radius) && lhs.blur.type == rhs.blur.type &&
+               eq(lhs.blur.angle, rhs.blur.angle) && boost::range::equal(lhs.blur.center, rhs.blur.center, eq) &&
+               eq(lhs.blur.tilt_y, rhs.blur.tilt_y) && eq(lhs.blur.tilt_h, rhs.blur.tilt_h) &&
+               eq(lhs.sharpen_amount, rhs.sharpen_amount) && eq(lhs.sharpen_radius, rhs.sharpen_radius) &&
+               eq(lhs.grain_intensity, rhs.grain_intensity) && eq(lhs.grain_size, rhs.grain_size) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -118,6 +118,8 @@ struct image_transform final
     core::levels          levels;
     core::chroma          chroma;
     core::blur_config     blur;
+    double                sharpen_amount = 0.0;
+    double                sharpen_radius = 1.0;
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -120,6 +120,8 @@ struct image_transform final
     core::blur_config     blur;
     double                sharpen_amount = 0.0;
     double                sharpen_radius = 1.0;
+    double                grain_intensity = 0.0;
+    double                grain_size      = 1.0;
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -73,6 +73,27 @@ struct rectangle final
     std::array<double, 2> lr = {1.0, 1.0};
 };
 
+enum class blur_type : int
+{
+    gaussian    = 0,
+    box         = 1,
+    directional = 2,
+    zoom        = 3,
+    tilt_shift  = 4,
+    lens        = 5
+};
+
+struct blur_config final
+{
+    bool                  enable = false;
+    double                radius = 0.0;
+    blur_type             type   = blur_type::gaussian;
+    double                angle  = 0.0;
+    std::array<double, 2> center = {0.5, 0.5};
+    double                tilt_y = 0.5;
+    double                tilt_h = 0.2;
+};
+
 struct image_transform final
 {
     double opacity    = 1.0;
@@ -96,6 +117,7 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    core::blur_config     blur;
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -73,6 +73,26 @@ struct rectangle final
     std::array<double, 2> lr = {1.0, 1.0};
 };
 
+enum class blur_type : int
+{
+    gaussian    = 0,
+    box         = 1,
+    directional = 2,
+    zoom        = 3,
+    tilt_shift  = 4,
+    lens        = 5
+};
+
+struct blur_config final
+{
+    bool                  enable = false;
+    double                radius = 0.0;
+    blur_type             type   = blur_type::gaussian;
+    double                angle  = 0.0;
+    std::array<double, 2> center = {0.5, 0.5};
+    double                tilt_y = 0.5;
+    double                tilt_h = 0.2;
+};
 /// An inclusive range for a grading parameter, and the clamp that enforces it.
 struct grade_range final
 {
@@ -150,6 +170,7 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    core::blur_config     blur;
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -73,26 +73,6 @@ struct rectangle final
     std::array<double, 2> lr = {1.0, 1.0};
 };
 
-enum class blur_type : int
-{
-    gaussian    = 0,
-    box         = 1,
-    directional = 2,
-    zoom        = 3,
-    tilt_shift  = 4,
-    lens        = 5
-};
-
-struct blur_config final
-{
-    bool                  enable = false;
-    double                radius = 0.0;
-    blur_type             type   = blur_type::gaussian;
-    double                angle  = 0.0;
-    std::array<double, 2> center = {0.5, 0.5};
-    double                tilt_y = 0.5;
-    double                tilt_h = 0.2;
-};
 /// An inclusive range for a grading parameter, and the clamp that enforces it.
 struct grade_range final
 {
@@ -145,7 +125,39 @@ inline constexpr grade_range cdl_offset{-1.0, 1.0};
 inline constexpr grade_range cdl_power{0.01, 10.0};
 inline constexpr grade_range cdl_saturation{0.0, 10.0};
 
+/// Blur radius is in output pixels; the bound stops a typo stalling a layer.
+/// Normalised position or fraction of the frame.
+inline constexpr grade_range unit{0.0, 1.0};
+inline constexpr grade_range blur_radius{0.0, 200.0};
+inline constexpr grade_range blur_angle{-360.0, 360.0};
+inline constexpr grade_range sharpen_amount{0.0, 5.0};
+/// Multiplier on the texel step; 0 would sample the centre four times.
+inline constexpr grade_range sharpen_radius{0.1, 10.0};
+inline constexpr grade_range grain_intensity{0.0, 1.0};
+/// The shader floors this at 0.5 when dividing by it.
+inline constexpr grade_range grain_size{0.5, 10.0};
+
 } // namespace grade_limits
+enum class blur_type : int
+{
+    gaussian    = 0,
+    box         = 1,
+    directional = 2,
+    zoom        = 3,
+    tilt_shift  = 4,
+    lens        = 5
+};
+
+struct blur_config final
+{
+    bool                  enable = false;
+    double                radius = 0.0;
+    blur_type             type   = blur_type::gaussian;
+    double                angle  = 0.0;
+    std::array<double, 2> center = {0.5, 0.5};
+    double                tilt_y = 0.5;
+    double                tilt_h = 0.2;
+};
 
 struct image_transform final
 {
@@ -170,11 +182,6 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
-    core::blur_config     blur;
-    double                sharpen_amount = 0.0;
-    double                sharpen_radius = 1.0;
-    double                grain_intensity = 0.0;
-    double                grain_size      = 1.0;
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel
@@ -190,6 +197,11 @@ struct image_transform final
     std::array<double, 3> cdl_offset     = {0.0, 0.0, 0.0}; // ASC CDL offset
     std::array<double, 3> cdl_power      = {1.0, 1.0, 1.0}; // ASC CDL power
     double                cdl_saturation = 1.0;             // ASC CDL saturation
+    core::blur_config     blur;
+    double                sharpen_amount = 0.0;
+    double                sharpen_radius = 1.0;
+    double                grain_intensity = 0.0;
+    double                grain_size      = 1.0;
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -171,6 +171,8 @@ struct image_transform final
     core::levels          levels;
     core::chroma          chroma;
     core::blur_config     blur;
+    double                sharpen_amount = 0.0;
+    double                sharpen_radius = 1.0;
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -173,6 +173,8 @@ struct image_transform final
     core::blur_config     blur;
     double                sharpen_amount = 0.0;
     double                sharpen_radius = 1.0;
+    double                grain_intensity = 0.0;
+    double                grain_size      = 1.0;
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1237,6 +1237,37 @@ std::future<std::wstring> mixer_sharpen_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER GRAIN intensity [size] [duration tween]
+std::future<std::wstring> mixer_grain_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.grain_intensity) + L" " +
+                   std::to_wstring(t.grain_size) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       intensity = std::stod(ctx.parameters.at(0));
+    double       size      = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    int          duration  = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween     = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.grain_intensity = intensity;
+            transform.image_transform.grain_size      = size;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1889,6 +1920,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER LEVELS", mixer_levels_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER SHARPEN", mixer_sharpen_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER GRAIN", mixer_grain_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1130,6 +1130,82 @@ std::future<std::wstring> mixer_levels_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+core::blur_type get_blur_type(const std::wstring& str)
+{
+    if (boost::iequals(str, L"box"))
+        return core::blur_type::box;
+    if (boost::iequals(str, L"directional"))
+        return core::blur_type::directional;
+    if (boost::iequals(str, L"zoom"))
+        return core::blur_type::zoom;
+    if (boost::iequals(str, L"tilt_shift") || boost::iequals(str, L"tilt-shift"))
+        return core::blur_type::tilt_shift;
+    if (boost::iequals(str, L"lens"))
+        return core::blur_type::lens;
+    return core::blur_type::gaussian;
+}
+
+std::wstring get_blur_type_string(core::blur_type type)
+{
+    switch (type) {
+        case core::blur_type::box:
+            return L"box";
+        case core::blur_type::directional:
+            return L"directional";
+        case core::blur_type::zoom:
+            return L"zoom";
+        case core::blur_type::tilt_shift:
+            return L"tilt_shift";
+        case core::blur_type::lens:
+            return L"lens";
+        case core::blur_type::gaussian:
+        default:
+            return L"gaussian";
+    }
+}
+
+std::future<std::wstring> mixer_blur_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto blur = transform2.get().image_transform.blur;
+            return L"201 MIXER OK\r\n" + std::to_wstring(blur.radius) + L" " + get_blur_type_string(blur.type) + L" " +
+                   std::to_wstring(blur.angle) + L" " + std::to_wstring(blur.center[0]) + L" " +
+                   std::to_wstring(blur.center[1]) + L" " + std::to_wstring(blur.tilt_y) + L" " +
+                   std::to_wstring(blur.tilt_h) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    core::blur_config  blur;
+
+    // Format: MIXER 1-10 BLUR <radius> [type] [angle] [center_x] [center_y] [tilt_y] [tilt_h] [duration] [tween]
+    blur.enable = std::stod(ctx.parameters.at(0)) > 0.001; // Enable if radius > 0
+    blur.radius = std::stod(ctx.parameters.at(0));
+    blur.type   = ctx.parameters.size() > 1 ? get_blur_type(ctx.parameters[1]) : core::blur_type::gaussian;
+    blur.angle  = ctx.parameters.size() > 2 ? std::stod(ctx.parameters[2]) : 0.0;
+    blur.center = {ctx.parameters.size() > 3 ? std::stod(ctx.parameters[3]) : 0.5,
+                   ctx.parameters.size() > 4 ? std::stod(ctx.parameters[4]) : 0.5};
+    blur.tilt_y = ctx.parameters.size() > 5 ? std::stod(ctx.parameters[5]) : 0.5;
+    blur.tilt_h = ctx.parameters.size() > 6 ? std::stod(ctx.parameters[6]) : 0.2;
+
+    int          duration = ctx.parameters.size() > 7 ? std::stoi(ctx.parameters[7]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 8 ? ctx.parameters[8] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.blur = blur;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1780,6 +1856,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER SATURATION", mixer_saturation_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CONTRAST", mixer_contrast_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LEVELS", mixer_levels_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1206,6 +1206,37 @@ std::future<std::wstring> mixer_blur_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER SHARPEN amount [radius] [duration tween]
+std::future<std::wstring> mixer_sharpen_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.sharpen_amount) + L" " +
+                   std::to_wstring(t.sharpen_radius) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       amount   = std::stod(ctx.parameters.at(0));
+    double       radius   = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    int          duration = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.sharpen_amount = amount;
+            transform.image_transform.sharpen_radius = radius;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1857,6 +1888,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER CONTRAST", mixer_contrast_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LEVELS", mixer_levels_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER SHARPEN", mixer_sharpen_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1470,21 +1470,6 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
-core::blur_type get_blur_type(const std::wstring& str)
-{
-    if (boost::iequals(str, L"box"))
-        return core::blur_type::box;
-    if (boost::iequals(str, L"directional"))
-        return core::blur_type::directional;
-    if (boost::iequals(str, L"zoom"))
-        return core::blur_type::zoom;
-    if (boost::iequals(str, L"tilt_shift") || boost::iequals(str, L"tilt-shift"))
-        return core::blur_type::tilt_shift;
-    if (boost::iequals(str, L"lens"))
-        return core::blur_type::lens;
-    return core::blur_type::gaussian;
-}
-
 std::wstring get_blur_type_string(core::blur_type type)
 {
     switch (type) {
@@ -1504,6 +1489,21 @@ std::wstring get_blur_type_string(core::blur_type type)
     }
 }
 
+core::blur_type get_blur_type(const std::wstring& str)
+{
+    if (boost::iequals(str, L"box"))
+        return core::blur_type::box;
+    if (boost::iequals(str, L"directional"))
+        return core::blur_type::directional;
+    if (boost::iequals(str, L"zoom"))
+        return core::blur_type::zoom;
+    if (boost::iequals(str, L"tilt_shift") || boost::iequals(str, L"tilt-shift"))
+        return core::blur_type::tilt_shift;
+    if (boost::iequals(str, L"lens"))
+        return core::blur_type::lens;
+    return core::blur_type::gaussian;
+}
+
 std::future<std::wstring> mixer_blur_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1521,14 +1521,25 @@ std::future<std::wstring> mixer_blur_command(command_context& ctx)
     core::blur_config  blur;
 
     // Format: MIXER 1-10 BLUR <radius> [type] [angle] [center_x] [center_y] [tilt_y] [tilt_h] [duration] [tween]
-    blur.enable = std::stod(ctx.parameters.at(0)) > 0.001; // Enable if radius > 0
-    blur.radius = std::stod(ctx.parameters.at(0));
+    grade_require(ctx, 1, L"MIXER BLUR radius [type] [angle] [centerX] [centerY] [tiltY] [tiltH] [duration] [tween]");
+    blur.radius = grade_param(ctx.parameters.at(0), core::grade_limits::blur_radius, L"blur radius");
+    blur.enable = blur.radius > 0.001; // a zero radius is the effect being off
     blur.type   = ctx.parameters.size() > 1 ? get_blur_type(ctx.parameters[1]) : core::blur_type::gaussian;
-    blur.angle  = ctx.parameters.size() > 2 ? std::stod(ctx.parameters[2]) : 0.0;
-    blur.center = {ctx.parameters.size() > 3 ? std::stod(ctx.parameters[3]) : 0.5,
-                   ctx.parameters.size() > 4 ? std::stod(ctx.parameters[4]) : 0.5};
-    blur.tilt_y = ctx.parameters.size() > 5 ? std::stod(ctx.parameters[5]) : 0.5;
-    blur.tilt_h = ctx.parameters.size() > 6 ? std::stod(ctx.parameters[6]) : 0.2;
+    blur.angle  = ctx.parameters.size() > 2
+                      ? grade_param(ctx.parameters[2], core::grade_limits::blur_angle, L"blur angle")
+                      : 0.0;
+    blur.center = {ctx.parameters.size() > 3
+                       ? grade_param(ctx.parameters[3], core::grade_limits::unit, L"blur centre X")
+                       : 0.5,
+                   ctx.parameters.size() > 4
+                       ? grade_param(ctx.parameters[4], core::grade_limits::unit, L"blur centre Y")
+                       : 0.5};
+    blur.tilt_y = ctx.parameters.size() > 5
+                      ? grade_param(ctx.parameters[5], core::grade_limits::unit, L"tilt centre")
+                      : 0.5;
+    blur.tilt_h = ctx.parameters.size() > 6
+                      ? grade_param(ctx.parameters[6], core::grade_limits::unit, L"tilt height")
+                      : 0.2;
 
     int          duration = ctx.parameters.size() > 7 ? std::stoi(ctx.parameters[7]) : 0;
     std::wstring tween    = ctx.parameters.size() > 8 ? ctx.parameters[8] : L"linear";
@@ -1558,8 +1569,11 @@ std::future<std::wstring> mixer_sharpen_command(command_context& ctx)
     }
 
     transforms_applier transforms(ctx);
-    double       amount   = std::stod(ctx.parameters.at(0));
-    double       radius   = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    grade_require(ctx, 1, L"MIXER SHARPEN amount [radius] [duration] [tween]");
+    double amount = grade_param(ctx.parameters.at(0), core::grade_limits::sharpen_amount, L"sharpen amount");
+    double radius = ctx.parameters.size() > 1
+                        ? grade_param(ctx.parameters[1], core::grade_limits::sharpen_radius, L"sharpen radius")
+                        : 1.0;
     int          duration = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
     std::wstring tween    = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
 
@@ -1588,8 +1602,11 @@ std::future<std::wstring> mixer_grain_command(command_context& ctx)
     }
 
     transforms_applier transforms(ctx);
-    double       intensity = std::stod(ctx.parameters.at(0));
-    double       size      = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    grade_require(ctx, 1, L"MIXER GRAIN intensity [size] [duration] [tween]");
+    double intensity = grade_param(ctx.parameters.at(0), core::grade_limits::grain_intensity, L"grain intensity");
+    double size      = ctx.parameters.size() > 1
+                           ? grade_param(ctx.parameters[1], core::grade_limits::grain_size, L"grain size")
+                           : 1.0;
     int          duration  = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
     std::wstring tween     = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1470,6 +1470,82 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+core::blur_type get_blur_type(const std::wstring& str)
+{
+    if (boost::iequals(str, L"box"))
+        return core::blur_type::box;
+    if (boost::iequals(str, L"directional"))
+        return core::blur_type::directional;
+    if (boost::iequals(str, L"zoom"))
+        return core::blur_type::zoom;
+    if (boost::iequals(str, L"tilt_shift") || boost::iequals(str, L"tilt-shift"))
+        return core::blur_type::tilt_shift;
+    if (boost::iequals(str, L"lens"))
+        return core::blur_type::lens;
+    return core::blur_type::gaussian;
+}
+
+std::wstring get_blur_type_string(core::blur_type type)
+{
+    switch (type) {
+        case core::blur_type::box:
+            return L"box";
+        case core::blur_type::directional:
+            return L"directional";
+        case core::blur_type::zoom:
+            return L"zoom";
+        case core::blur_type::tilt_shift:
+            return L"tilt_shift";
+        case core::blur_type::lens:
+            return L"lens";
+        case core::blur_type::gaussian:
+        default:
+            return L"gaussian";
+    }
+}
+
+std::future<std::wstring> mixer_blur_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto blur = transform2.get().image_transform.blur;
+            return L"201 MIXER OK\r\n" + std::to_wstring(blur.radius) + L" " + get_blur_type_string(blur.type) + L" " +
+                   std::to_wstring(blur.angle) + L" " + std::to_wstring(blur.center[0]) + L" " +
+                   std::to_wstring(blur.center[1]) + L" " + std::to_wstring(blur.tilt_y) + L" " +
+                   std::to_wstring(blur.tilt_h) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    core::blur_config  blur;
+
+    // Format: MIXER 1-10 BLUR <radius> [type] [angle] [center_x] [center_y] [tilt_y] [tilt_h] [duration] [tween]
+    blur.enable = std::stod(ctx.parameters.at(0)) > 0.001; // Enable if radius > 0
+    blur.radius = std::stod(ctx.parameters.at(0));
+    blur.type   = ctx.parameters.size() > 1 ? get_blur_type(ctx.parameters[1]) : core::blur_type::gaussian;
+    blur.angle  = ctx.parameters.size() > 2 ? std::stod(ctx.parameters[2]) : 0.0;
+    blur.center = {ctx.parameters.size() > 3 ? std::stod(ctx.parameters[3]) : 0.5,
+                   ctx.parameters.size() > 4 ? std::stod(ctx.parameters[4]) : 0.5};
+    blur.tilt_y = ctx.parameters.size() > 5 ? std::stod(ctx.parameters[5]) : 0.5;
+    blur.tilt_h = ctx.parameters.size() > 6 ? std::stod(ctx.parameters[6]) : 0.2;
+
+    int          duration = ctx.parameters.size() > 7 ? std::stoi(ctx.parameters[7]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 8 ? ctx.parameters[8] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.blur = blur;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2139,6 +2215,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER GRID", mixer_grid_command, 1);
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1576,6 +1576,36 @@ std::future<std::wstring> mixer_sharpen_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_grain_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.grain_intensity) + L" " +
+                   std::to_wstring(t.grain_size) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       intensity = std::stod(ctx.parameters.at(0));
+    double       size      = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    int          duration  = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween     = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.grain_intensity = intensity;
+            transform.image_transform.grain_size      = size;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2247,6 +2277,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER SHARPEN", mixer_sharpen_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER GRAIN", mixer_grain_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1546,6 +1546,36 @@ std::future<std::wstring> mixer_blur_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_sharpen_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.sharpen_amount) + L" " +
+                   std::to_wstring(t.sharpen_radius) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       amount   = std::stod(ctx.parameters.at(0));
+    double       radius   = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.0;
+    int          duration = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.sharpen_amount = amount;
+            transform.image_transform.sharpen_radius = radius;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2216,6 +2246,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER BLUR", mixer_blur_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER SHARPEN", mixer_sharpen_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);


### PR DESCRIPTION
Disclamer: AI powered PR and code, but the functionalities have been tested since late last year.

## Summary

Adds three new per-layer image effects to the OpenGL mixer, controllable via AMCP `MIXER` commands and fully tweenable:

- **`MIXER BLUR`** — 6 blur styles: gaussian, box, directional (motion), zoom, tilt-shift, and lens (cinematic bokeh).
- **`MIXER SHARPEN`** — unsharp-mask sharpening.
- **`MIXER GRAIN`** — luminance-weighted film grain, animated per frame for temporal variation.

Each effect is off by default and has zero cost when unused (the shader early-outs and the kernel only sets a single `*_enable = false` uniform).

## Commits

The change is split into reviewable commits:

1. **`ogl: parameterize get_rgba_color() with a UV coordinate`** — Refactor with no behavior change. Lets the fragment shader sample the source at an arbitrary UV (previously it always used the current fragment's `TexCoord`). This is the enabler for neighbor-sampling effects. `main()` passes `TexCoord.st / TexCoord.q`, so output is identical.
2. **`mixer: add MIXER BLUR command with 6 blur types`**
3. **`mixer: add MIXER SHARPEN command`**
4. **`mixer: add MIXER GRAIN command`**

## AMCP syntax

```
MIXER <ch-layer> BLUR <radius> [type] [angle] [cx] [cy] [tilt_y] [tilt_h] [duration] [tween]
MIXER <ch-layer> SHARPEN <amount> [radius] [duration] [tween]
MIXER <ch-layer> GRAIN <intensity> [size] [duration] [tween]
```

`type` is one of `gaussian` (default), `box`, `directional`, `zoom`, `tilt_shift`, `lens`. A radius/amount/intensity of `0` disables the effect. Sending a command with no parameters queries the current value.

### Examples

```
MIXER 1-10 BLUR 5                        # gaussian, radius 5
MIXER 1-10 BLUR 3 directional 45         # motion blur, 45°
MIXER 1-10 BLUR 10 zoom 0.5 0.5          # zoom blur about center
MIXER 1-10 BLUR 8 tilt_shift 0 0.5 0.5 0.4 0.3
MIXER 1-10 BLUR 12 lens                  # cinematic bokeh
MIXER 1-10 BLUR 0                         # disable
MIXER 1-10 SHARPEN 0.5                    # sharpen, amount 0.5
MIXER 1-10 GRAIN 0.1                      # subtle film grain
MIXER 1-10 BLUR 8 gaussian 0 0.5 0.5 0.5 0.2 25 easeinoutsine   # tween in over 25 frames
```

## Implementation notes

- Effects live entirely in the existing OGL image pipeline (`shader.frag`, `image_kernel.cpp`) plus the transform plumbing (`frame_transform`, `transforms.cpp`) and AMCP command layer.
- Blur/sharpen sample neighbors via the parameterized `get_rgba_color(vec2 uv)`.
- Film grain uses a `frame_counter_` in the kernel so grain animates over time.
- All parameters participate in `image_transform::tween`, so effects animate with `duration`/`tween` like other mixer values.
- Independent of #1758 (ACES color management) — builds on clean `master`.

## Testing

Builds clean on Windows (VS2026, Release). Documentation for the wiki can follow separately.