### PR TITLE
fix(decklink): wait for playback to stop before destroying consumer (teardown-race use-after-free)

### DIFF
--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -475,6 +475,10 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
     int                                       device_sync_group_;
     std::optional<core::const_frame>          first_field_;
 
+    std::mutex              playback_stopped_mutex_;
+    std::condition_variable playback_stopped_cond_;
+    bool                    playback_stopped_ = true;
+
     const std::wstring model_name_ = get_model_name(decklink_);
 
     // long long video_scheduled_ = 0;
@@ -533,8 +537,17 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
         if (output_) {
             if (device_sync_group_ == 0) {
                 output_->StopScheduledPlayback(0, nullptr, 0);
+
+                // Wait for the driver to confirm playback has fully stopped before tearing down, so
+                // no completion callback is in flight. (Sync-group ports are stopped via the primary
+                // port, which already waits before it destroys these secondary ports.)
+                std::unique_lock<std::mutex> lock(playback_stopped_mutex_);
+                playback_stopped_cond_.wait_for(lock, std::chrono::seconds(2), [&] { return playback_stopped_; });
             }
 
+            // Unregister the completion callback so the driver cannot call back into this object
+            // while/after it is destroyed.
+            output_->SetScheduledFrameCompletionCallback(nullptr);
             output_->DisableVideoOutput();
         }
     }
@@ -559,6 +572,10 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
     void start_playback(const Print& print)
     {
         if (device_sync_group_ == 0) {
+            {
+                std::lock_guard<std::mutex> lock(playback_stopped_mutex_);
+                playback_stopped_ = false;
+            }
             if (FAILED(output_->StartScheduledPlayback(0, decklink_format_desc_.time_scale, 1.0))) {
                 CASPAR_THROW_EXCEPTION(caspar_exception()
                                        << msg_info(print() + L" Failed to schedule secondary playback."));
@@ -618,7 +635,15 @@ struct decklink_secondary_port final : public IDeckLinkVideoOutputCallback
     ULONG STDMETHODCALLTYPE   AddRef() override { return 1; }
     ULONG STDMETHODCALLTYPE   Release() override { return 1; }
 
-    HRESULT STDMETHODCALLTYPE ScheduledPlaybackHasStopped() override { return S_OK; }
+    HRESULT STDMETHODCALLTYPE ScheduledPlaybackHasStopped() override
+    {
+        {
+            std::lock_guard<std::mutex> lock(playback_stopped_mutex_);
+            playback_stopped_ = true;
+        }
+        playback_stopped_cond_.notify_all();
+        return S_OK;
+    }
 
     HRESULT STDMETHODCALLTYPE ScheduledFrameCompleted(IDeckLinkVideoFrame*           completed_frame,
                                                       BMDOutputFrameCompletionResult result) override
@@ -674,6 +699,10 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
     std::atomic<bool>              abort_request_{false};
     std::shared_ptr<decklink_vanc> vanc_;
+
+    std::mutex              playback_stopped_mutex_;
+    std::condition_variable playback_stopped_cond_;
+    bool                    playback_stopped_ = true;
 
   public:
     decklink_consumer(const configuration& config, core::video_format_desc channel_format_desc, int channel_index)
@@ -797,6 +826,25 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
         if (output_ != nullptr) {
             output_->StopScheduledPlayback(0, nullptr, 0);
+
+            // Wait for the driver to confirm scheduled playback has fully stopped before tearing
+            // anything down. StopScheduledPlayback is asynchronous: the driver may still deliver
+            // ScheduledFrameCompleted callbacks (which dereference members of this object and the
+            // secondary ports) until it fires ScheduledPlaybackHasStopped. Destroying while such a
+            // callback is in flight is a use-after-free. This mirrors the Blackmagic DeckLink SDK
+            // SynchronizedPlayback example teardown sequence.
+            {
+                std::unique_lock<std::mutex> lock(playback_stopped_mutex_);
+                if (!playback_stopped_cond_.wait_for(
+                        lock, std::chrono::seconds(2), [&] { return playback_stopped_; })) {
+                    CASPAR_LOG(warning) << print() << L" Timed out waiting for scheduled playback to stop.";
+                }
+            }
+
+            // Unregister the completion callback so the driver cannot call back into this object
+            // (or the secondary ports) while/after they are destroyed.
+            output_->SetScheduledFrameCompletionCallback(nullptr);
+
             if (config_.embedded_audio) {
                 output_->DisableAudioOutput();
             }
@@ -888,6 +936,10 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
     void start_playback()
     {
+        {
+            std::lock_guard<std::mutex> lock(playback_stopped_mutex_);
+            playback_stopped_ = false;
+        }
         if (FAILED(output_->StartScheduledPlayback(0, decklink_format_desc_.time_scale, 1.0))) {
             CASPAR_THROW_EXCEPTION(caspar_exception() << msg_info(print() + L" Failed to schedule primary playback."));
         }
@@ -903,6 +955,11 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
 
     HRESULT STDMETHODCALLTYPE ScheduledPlaybackHasStopped() override
     {
+        {
+            std::lock_guard<std::mutex> lock(playback_stopped_mutex_);
+            playback_stopped_ = true;
+        }
+        playback_stopped_cond_.notify_all();
         CASPAR_LOG(info) << print() << L" Scheduled playback has stopped.";
         return S_OK;
     }


### PR DESCRIPTION
## Summary

The DeckLink consumer can crash the server during teardown with heap corruption (`STATUS_HEAP_CORRUPTION` / `0xC0000374`) or an access violation, because it destroys itself while a frame-completion callback may still be running on the DeckLink driver's thread. This PR makes teardown wait for the driver to confirm playback has stopped, and unregisters the completion callback before destruction — following the sequence in Blackmagic's own `SynchronizedPlayback` SDK example.

## The bug

`decklink_consumer` (and each `decklink_secondary_port`) registers itself as the `IDeckLinkVideoOutputCallback` via `SetScheduledFrameCompletionCallback(this)`. The primary consumer's `ScheduledFrameCompleted()` runs on the driver's thread and dereferences many members (`graph_`, `mode_`, `buffer_`, `secondary_port_contexts_`, …).

On destruction the code did:

```cpp
output_->StopScheduledPlayback(0, nullptr, 0);
output_->DisableVideoOutput();
secondary_port_contexts_.clear();   // members then destroyed
```

`StopScheduledPlayback` is **asynchronous** — the driver can keep delivering `ScheduledFrameCompleted` callbacks until it fires `ScheduledPlaybackHasStopped`. The destructor never waited for that, and never unregistered the callback. So if a completion callback is in flight while the consumer is being torn down, it touches members that are being destroyed → use-after-free.

This is timing-dependent (the callback must be in flight at the exact moment of teardown), so it manifests as a rare, log-silent crash — most often at end-of-broadcast teardown (`REMOVE` / consumer uninitialize) or on channel reconfiguration/restart.

## Why the async behaviour is expected

The Blackmagic DeckLink SDK `SynchronizedPlayback` example maintains a dedicated `std::mutex` + `std::condition_variable` + `bool m_stopped` for exactly this: it calls `StopScheduledPlayback`, then `waitForPlaybackStop()` (`m_stopCondition.wait`), and only proceeds to `DisableVideoOutput()` + `SetScheduledFrameCompletionCallback(nullptr)` + release once `ScheduledPlaybackHasStopped()` has fired. The existence of that wait in the reference code is the confirmation that `StopScheduledPlayback` does not synchronously fence callbacks.

## The fix

Mirror the SDK teardown sequence in both `decklink_consumer` and `decklink_secondary_port`:

1. `StopScheduledPlayback(...)`
2. Block until `ScheduledPlaybackHasStopped()` signals a condition variable (with a 2s timeout as a safety net against a missing callback).
3. `SetScheduledFrameCompletionCallback(nullptr)` — unregister so the driver cannot call back into the object.
4. `DisableVideoOutput()` and destroy members.

`ScheduledPlaybackHasStopped()` now sets the flag and notifies; `start_playback()` resets it before `StartScheduledPlayback`. For sync-group secondary ports (which are stopped via the primary), the primary already waits before it destroys them, so they only unregister their callback and disable output.

## Scope / risk

- One file, `+58/-1`; no behavioural change to the running (non-teardown) path.
- Adds a bounded (≤2s) wait on consumer destruction; the timeout logs a warning and proceeds if the driver never confirms.
- Builds cleanly on Windows (MSVC).

## Validation

Verified by code/SDK analysis and a clean build. Because the underlying crash is rare and timing-dependent, this has not been reproduced on a bench; it is offered as a correctness fix that closes a real use-after-free window and matches the vendor's documented teardown sequence. Production soak (absence of `0xC0000374` at teardown) is the intended real-world validation.