### PR TITLE
Add primary color grading: WHITEBALANCE, LIFT/MIDTONE/GAIN, HUESHIFT, TONEBALANCE, SPLITTONE, CDL

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -302,10 +302,9 @@ struct image_kernel::impl
                 std::abs(gain[1] - 1.0) > epsilon || std::abs(gain[2] - 1.0) > epsilon;
             if (lmg_active) {
                 shader_->set("lmg_enable", true);
-                // Upload swapped to BGR order so .r affects displayed Blue, .b affects displayed Red.
-                shader_->set("lmg_lift", lift[2], lift[1], lift[0]);
-                shader_->set("lmg_midtone", midtone[2], midtone[1], midtone[0]);
-                shader_->set("lmg_gain", gain[2], gain[1], gain[0]);
+                shader_->set("lmg_lift", lift[0], lift[1], lift[2]);
+                shader_->set("lmg_midtone", midtone[0], midtone[1], midtone[2]);
+                shader_->set("lmg_gain", gain[0], gain[1], gain[2]);
             } else {
                 shader_->set("lmg_enable", false);
             }
@@ -338,9 +337,8 @@ struct image_kernel::impl
                 std::abs(hc[0]) > epsilon || std::abs(hc[1]) > epsilon || std::abs(hc[2]) > epsilon;
             if (split_active) {
                 shader_->set("split_tone_enable", true);
-                // Upload swapped to BGR order so .r affects displayed Blue, .b affects displayed Red.
-                shader_->set("split_shadow_color", sc[2], sc[1], sc[0]);
-                shader_->set("split_highlight_color", hc[2], hc[1], hc[0]);
+                shader_->set("split_shadow_color", sc[0], sc[1], sc[2]);
+                shader_->set("split_highlight_color", hc[0], hc[1], hc[2]);
                 shader_->set("split_balance", static_cast<float>(transforms.image_transform.split_balance));
             } else {
                 shader_->set("split_tone_enable", false);
@@ -360,10 +358,9 @@ struct image_kernel::impl
                 std::abs(cs - 1.0) > epsilon;
             if (cdl_active) {
                 shader_->set("cdl_enable", true);
-                // Upload swapped to BGR working order (.r=Blue, .b=Red).
-                shader_->set("cdl_slope", s[2], s[1], s[0]);
-                shader_->set("cdl_offset", o[2], o[1], o[0]);
-                shader_->set("cdl_power", p[2], p[1], p[0]);
+                shader_->set("cdl_slope", s[0], s[1], s[2]);
+                shader_->set("cdl_offset", o[0], o[1], o[2]);
+                shader_->set("cdl_power", p[0], p[1], p[2]);
                 shader_->set("cdl_saturation", static_cast<float>(cs));
             } else {
                 shader_->set("cdl_enable", false);

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -290,6 +290,27 @@ struct image_kernel::impl
             shader_->set("white_balance", false);
         }
 
+        // Lift / Midtone / Gain (per-channel 3-way colour corrector)
+        {
+            const auto& lift    = transforms.image_transform.lift;
+            const auto& midtone = transforms.image_transform.midtone;
+            const auto& gain    = transforms.image_transform.gain;
+            bool        lmg_active =
+                std::abs(lift[0]) > epsilon || std::abs(lift[1]) > epsilon || std::abs(lift[2]) > epsilon ||
+                std::abs(midtone[0] - 1.0) > epsilon || std::abs(midtone[1] - 1.0) > epsilon ||
+                std::abs(midtone[2] - 1.0) > epsilon || std::abs(gain[0] - 1.0) > epsilon ||
+                std::abs(gain[1] - 1.0) > epsilon || std::abs(gain[2] - 1.0) > epsilon;
+            if (lmg_active) {
+                shader_->set("lmg_enable", true);
+                // Upload swapped to BGR order so .r affects displayed Blue, .b affects displayed Red.
+                shader_->set("lmg_lift", lift[2], lift[1], lift[0]);
+                shader_->set("lmg_midtone", midtone[2], midtone[1], midtone[0]);
+                shader_->set("lmg_gain", gain[2], gain[1], gain[0]);
+            } else {
+                shader_->set("lmg_enable", false);
+            }
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -347,6 +347,29 @@ struct image_kernel::impl
             }
         }
 
+        // ASC CDL (Slope/Offset/Power)
+        {
+            const auto& s  = transforms.image_transform.cdl_slope;
+            const auto& o  = transforms.image_transform.cdl_offset;
+            const auto& p  = transforms.image_transform.cdl_power;
+            double      cs = transforms.image_transform.cdl_saturation;
+            bool        cdl_active =
+                std::abs(s[0] - 1.0) > epsilon || std::abs(s[1] - 1.0) > epsilon || std::abs(s[2] - 1.0) > epsilon ||
+                std::abs(o[0]) > epsilon || std::abs(o[1]) > epsilon || std::abs(o[2]) > epsilon ||
+                std::abs(p[0] - 1.0) > epsilon || std::abs(p[1] - 1.0) > epsilon || std::abs(p[2] - 1.0) > epsilon ||
+                std::abs(cs - 1.0) > epsilon;
+            if (cdl_active) {
+                shader_->set("cdl_enable", true);
+                // Upload swapped to BGR working order (.r=Blue, .b=Red).
+                shader_->set("cdl_slope", s[2], s[1], s[0]);
+                shader_->set("cdl_offset", o[2], o[1], o[0]);
+                shader_->set("cdl_power", p[2], p[1], p[0]);
+                shader_->set("cdl_saturation", static_cast<float>(cs));
+            } else {
+                shader_->set("cdl_enable", false);
+            }
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -319,6 +319,16 @@ struct image_kernel::impl
             shader_->set("hue_shift_enable", false);
         }
 
+        // Tonal balance (shadows / highlights)
+        if (std::abs(transforms.image_transform.shadows) > epsilon ||
+            std::abs(transforms.image_transform.highlights) > epsilon) {
+            shader_->set("tonebalance_enable", true);
+            shader_->set("tb_shadows", static_cast<float>(transforms.image_transform.shadows));
+            shader_->set("tb_highlights", static_cast<float>(transforms.image_transform.highlights));
+        } else {
+            shader_->set("tonebalance_enable", false);
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -280,6 +280,16 @@ struct image_kernel::impl
             shader_->set("csb", false);
         }
 
+        // White balance (temperature / tint)
+        if (std::abs(transforms.image_transform.temperature) > epsilon ||
+            std::abs(transforms.image_transform.tint) > epsilon) {
+            shader_->set("white_balance", true);
+            shader_->set("wb_temperature", static_cast<float>(transforms.image_transform.temperature));
+            shader_->set("wb_tint", static_cast<float>(transforms.image_transform.tint));
+        } else {
+            shader_->set("white_balance", false);
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -329,6 +329,24 @@ struct image_kernel::impl
             shader_->set("tonebalance_enable", false);
         }
 
+        // Split toning (independent shadow / highlight tint)
+        {
+            const auto& sc = transforms.image_transform.split_shadow_color;
+            const auto& hc = transforms.image_transform.split_highlight_color;
+            bool        split_active =
+                std::abs(sc[0]) > epsilon || std::abs(sc[1]) > epsilon || std::abs(sc[2]) > epsilon ||
+                std::abs(hc[0]) > epsilon || std::abs(hc[1]) > epsilon || std::abs(hc[2]) > epsilon;
+            if (split_active) {
+                shader_->set("split_tone_enable", true);
+                // Upload swapped to BGR order so .r affects displayed Blue, .b affects displayed Red.
+                shader_->set("split_shadow_color", sc[2], sc[1], sc[0]);
+                shader_->set("split_highlight_color", hc[2], hc[1], hc[0]);
+                shader_->set("split_balance", static_cast<float>(transforms.image_transform.split_balance));
+            } else {
+                shader_->set("split_tone_enable", false);
+            }
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -311,6 +311,14 @@ struct image_kernel::impl
             }
         }
 
+        // Hue shift
+        if (std::abs(transforms.image_transform.hue_shift) > epsilon) {
+            shader_->set("hue_shift_enable", true);
+            shader_->set("hue_shift_degrees", static_cast<float>(transforms.image_transform.hue_shift));
+        } else {
+            shader_->set("hue_shift_enable", false);
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -48,6 +48,12 @@ uniform bool		white_balance;
 uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
 uniform float		wb_tint;        // -1 magenta .. +1 green
 
+// Lift / Midtone / Gain (3-way primary colour corrector)
+uniform bool		lmg_enable;
+uniform vec3		lmg_lift;    // shadow offset per channel, default vec3(0)
+uniform vec3		lmg_midtone; // midtone power per channel,  default vec3(1)
+uniform vec3		lmg_gain;    // highlight multiplier per channel, default vec3(1)
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -539,6 +545,16 @@ vec3 apply_white_balance(vec3 c, float temp, float tint_val)
     return c;
 }
 
+// ---- Lift / Midtone / Gain (3-way colour corrector) ----
+// out = pow(max(c * gain + lift, 0.0), 1.0 / midtone).
+// No upper clamp so HDR values pass through; negatives clamped for pow() safety.
+vec3 apply_lmg(vec3 c, vec3 lift, vec3 midtone, vec3 gain)
+{
+    c = max(c * gain + lift, vec3(0.0));
+    c = pow(c, max(vec3(0.01), 1.0 / midtone));
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -548,6 +564,8 @@ void main()
         color = chroma_key(color);
     if (white_balance)
         color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
+    if (lmg_enable)
+        color.rgb = apply_lmg(color.rgb, lmg_lift, lmg_midtone, lmg_gain);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -69,6 +69,13 @@ uniform vec3		split_shadow_color;
 uniform vec3		split_highlight_color;
 uniform float		split_balance; // crossover 0..1
 
+// ASC CDL (Slope / Offset / Power)
+uniform bool		cdl_enable;
+uniform vec3		cdl_slope;
+uniform vec3		cdl_offset;
+uniform vec3		cdl_power;
+uniform float		cdl_saturation;
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -608,6 +615,17 @@ vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
     return c;
 }
 
+// ---- ASC CDL (Slope/Offset/Power) ----
+// Industry-standard primary grade: out = pow(max(in * slope + offset, 0), power),
+// followed by a saturation adjustment.
+vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
+{
+    c = pow(max(c * slope + off, vec3(0.0)), pwr);
+    float lum = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    c = mix(vec3(lum), c, sat_val);
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -615,6 +633,8 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    if (cdl_enable)
+        color.rgb = apply_cdl(color.rgb, cdl_slope, cdl_offset, cdl_power, cdl_saturation);
     if (white_balance)
         color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
     if (lmg_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -54,6 +54,10 @@ uniform vec3		lmg_lift;    // shadow offset per channel, default vec3(0)
 uniform vec3		lmg_midtone; // midtone power per channel,  default vec3(1)
 uniform vec3		lmg_gain;    // highlight multiplier per channel, default vec3(1)
 
+// Hue shift
+uniform bool		hue_shift_enable;
+uniform float		hue_shift_degrees; // -180..+180
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -555,6 +559,18 @@ vec3 apply_lmg(vec3 c, vec3 lift, vec3 midtone, vec3 gain)
     return c;
 }
 
+// ---- Hue Shift ----
+// Rotate hue in HSV space.  Extract peak luminance, normalise, rotate, re-scale
+// so HDR values (>1.0) are preserved.
+vec3 apply_hue_shift(vec3 c, float degrees)
+{
+    float peak = max(max(c.r, c.g), max(c.b, 0.0001));
+    vec3  norm = c / peak;
+    vec3  hsv  = rgb2hsv(clamp(norm, 0.0, 1.0));
+    hsv.x      = fract(hsv.x + degrees / 360.0);
+    return hsv2rgb(hsv) * peak;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -566,6 +582,8 @@ void main()
         color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
     if (lmg_enable)
         color.rgb = apply_lmg(color.rgb, lmg_lift, lmg_midtone, lmg_gain);
+    if (hue_shift_enable)
+        color.rgb = apply_hue_shift(color.rgb, hue_shift_degrees);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -580,13 +580,21 @@ vec3 apply_lmg(vec3 c, vec3 lift, vec3 midtone, vec3 gain)
 // ---- Hue Shift ----
 // Rotate hue in HSV space.  Extract peak luminance, normalise, rotate, re-scale
 // so HDR values (>1.0) are preserved.
+// The grading chain carries the pixel in the mixer's native BGR order, so c.r holds
+// blue -- see apply_white_balance below and apply_lut3d, both of which say so. rgb2hsv
+// does not know what the channels mean; it treats the first as red, and exchanging red
+// and blue mirrors the hue wheel. Feeding it unswizzled negated every rotation: a
+// requested +15 degrees came out as -15. Only 0 and 180 looked right, because they are
+// their own negations. Swizzling in and back out makes the hue domain a real hue
+// domain. Saturation and value are unchanged by the exchange, which is why nothing
+// else about this function was visibly wrong.
 vec3 apply_hue_shift(vec3 c, float degrees)
 {
     float peak = max(max(c.r, c.g), max(c.b, 0.0001));
     vec3  norm = c / peak;
-    vec3  hsv  = rgb2hsv(clamp(norm, 0.0, 1.0));
+    vec3  hsv  = rgb2hsv(clamp(norm.bgr, 0.0, 1.0));
     hsv.x      = fract(hsv.x + degrees / 360.0);
-    return hsv2rgb(hsv) * peak;
+    return hsv2rgb(hsv).bgr * peak;
 }
 
 // ---- Tonal Balance (Shadows / Highlights separation) ----
@@ -594,7 +602,11 @@ vec3 apply_hue_shift(vec3 c, float degrees)
 // headroom is preserved for downstream tonemapping.
 vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
 {
-    float lum         = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    // dot(c.bgr, ...) — c is BGR here, so an unswizzled dot applies red's Rec.709
+    // coefficient to blue and blue's to red. Greys are unaffected by the exchange,
+    // which is why only saturated colour was ever wrong. ContrastSaturationBrightness
+    // above already does this by hand via luma_coeff.bgr.
+    float lum         = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722));
     float shadow_mask = 1.0 - smoothstep(0.0, 0.6, lum);
     float hl_mask     = smoothstep(0.4, 1.0, lum);
     c += vec3(shadows    * 0.5 * shadow_mask);
@@ -607,7 +619,7 @@ vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
 // with a crossover controlled by bal.
 vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
 {
-    float lum     = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float lum     = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722)); // BGR — see apply_tone_balance
     float shad_mk = 1.0 - smoothstep(bal - 0.3, bal + 0.3, lum);
     float hi_mk   = smoothstep(bal - 0.3, bal + 0.3, lum);
     c += shad_col * shad_mk;
@@ -621,7 +633,7 @@ vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
 vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
 {
     c = pow(max(c * slope + off, vec3(0.0)), pwr);
-    float lum = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float lum = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722)); // BGR — see apply_tone_balance
     c = mix(vec3(lum), c, sat_val);
     return c;
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -63,6 +63,12 @@ uniform bool		tonebalance_enable;
 uniform float		tb_shadows;    // -1..+1
 uniform float		tb_highlights; // -1..+1
 
+// Split toning (independent shadow / highlight tint)
+uniform bool		split_tone_enable;
+uniform vec3		split_shadow_color;
+uniform vec3		split_highlight_color;
+uniform float		split_balance; // crossover 0..1
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -589,6 +595,19 @@ vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
     return c;
 }
 
+// ---- Split Toning ----
+// Luminance-based tint: additive colour offsets for shadows and highlights,
+// with a crossover controlled by bal.
+vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
+{
+    float lum     = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float shad_mk = 1.0 - smoothstep(bal - 0.3, bal + 0.3, lum);
+    float hi_mk   = smoothstep(bal - 0.3, bal + 0.3, lum);
+    c += shad_col * shad_mk;
+    c += hi_col   * hi_mk;
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -604,6 +623,8 @@ void main()
         color.rgb = apply_hue_shift(color.rgb, hue_shift_degrees);
     if (tonebalance_enable)
         color.rgb = apply_tone_balance(color.rgb, tb_shadows, tb_highlights);
+    if (split_tone_enable)
+        color.rgb = apply_split_tone(color.rgb, split_shadow_color, split_highlight_color, split_balance);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -574,6 +574,16 @@ vec4 get_rgba_color()
 // every channel-order defect in here. Test with asymmetric per-channel values.
 // ===============================================================================
 
+// Luma of the working colour, using the channel's own coefficients.
+//
+// luma_coeff is uploaded in RGB order and holds Rec.601, Rec.709 or Rec.2020 weights
+// depending on the source (image_kernel.cpp), so a grade no longer hard-codes Rec.709
+// and no longer disagrees with ContrastSaturationBrightness, which has always read this
+// uniform. The `.bgr` is the working-order swizzle described above -- dot(c.bgr, k) and
+// dot(c, k.bgr) are the same sum, and swizzling the three-element uniform rather than
+// the pixel keeps this the only place the order is mentioned.
+float working_luma(vec3 c) { return dot(c, luma_coeff.bgr); }
+
 // ---- White Balance ----
 // temp: -1=cool (blue), +1=warm (orange); tint_val: -1=magenta, +1=green.
 // Diagonal gain matrix, no clamping so HDR headroom is preserved.
@@ -622,11 +632,7 @@ vec3 apply_hue_shift(vec3 c, float degrees)
 // headroom is preserved for downstream tonemapping.
 vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
 {
-    // dot(c.bgr, ...) — c is BGR here, so an unswizzled dot applies red's Rec.709
-    // coefficient to blue and blue's to red. Greys are unaffected by the exchange,
-    // which is why only saturated colour was ever wrong. ContrastSaturationBrightness
-    // above already does this by hand via luma_coeff.bgr.
-    float lum         = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722));
+    float lum         = working_luma(c);
     float shadow_mask = 1.0 - smoothstep(0.0, 0.6, lum);
     float hl_mask     = smoothstep(0.4, 1.0, lum);
     c += vec3(shadows    * 0.5 * shadow_mask);
@@ -639,7 +645,7 @@ vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
 // with a crossover controlled by bal.
 vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
 {
-    float lum     = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722)); // BGR — see apply_tone_balance
+    float lum     = working_luma(c);
     float shad_mk = 1.0 - smoothstep(bal - 0.3, bal + 0.3, lum);
     float hi_mk   = smoothstep(bal - 0.3, bal + 0.3, lum);
     c += shad_col * shad_mk;
@@ -653,7 +659,7 @@ vec3 apply_split_tone(vec3 c, vec3 shad_col, vec3 hi_col, float bal)
 vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
 {
     c = pow(max(c * slope + off, vec3(0.0)), pwr);
-    float lum = dot(c.bgr, vec3(0.2126, 0.7152, 0.0722)); // BGR — see apply_tone_balance
+    float lum = working_luma(c);
     c = mix(vec3(lum), c, sat_val);
     return c;
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,6 +43,11 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
+// White balance (temperature / tint)
+uniform bool		white_balance;
+uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
+uniform float		wb_tint;        // -1 magenta .. +1 green
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -519,6 +524,21 @@ vec4 get_rgba_color()
     return vec4(0.0, 0.0, 0.0, 0.0);
 }
 
+// ---- White Balance ----
+// temp: -1=cool (blue), +1=warm (orange); tint_val: -1=magenta, +1=green.
+// Diagonal gain matrix, no clamping so HDR headroom is preserved.
+// Note: working colour is in BGR order (c.r=displayed Blue, c.b=displayed Red).
+vec3 apply_white_balance(vec3 c, float temp, float tint_val)
+{
+    float r_gain = 1.0 + temp     * 0.20; // warm -> more red
+    float g_gain = 1.0 + tint_val * 0.10; // tint -> more green
+    float b_gain = 1.0 - temp     * 0.20; // warm -> less blue
+    c.r *= b_gain; // .r = Blue in BGR convention
+    c.g *= g_gain;
+    c.b *= r_gain; // .b = Red in BGR convention
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -526,6 +546,8 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    if (white_balance)
+        color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -569,11 +569,16 @@ vec3 apply_white_balance(vec3 c, float temp, float tint_val)
 
 // ---- Lift / Midtone / Gain (3-way colour corrector) ----
 // out = pow(max(c * gain + lift, 0.0), 1.0 / midtone).
-// No upper clamp so HDR values pass through; negatives clamped for pow() safety.
+// midtone is clamped before the reciprocal, not after: at midtone == 0 the
+// reciprocal is +Inf and pow() collapses the channel to 0 (or Inf above 1.0),
+// and clamping the exponent cannot undo that -- max(0.01, Inf) is Inf. A
+// negative midtone would likewise invert the curve. Clamping the base to
+// [0.01, 100] bounds the exponent to [0.01, 100] and covers both.
+// No upper clamp on the colour so HDR values pass through; negatives clamped for pow() safety.
 vec3 apply_lmg(vec3 c, vec3 lift, vec3 midtone, vec3 gain)
 {
     c = max(c * gain + lift, vec3(0.0));
-    c = pow(c, max(vec3(0.01), 1.0 / midtone));
+    c = pow(c, 1.0 / clamp(midtone, vec3(0.01), vec3(100.0)));
     return c;
 }
 

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -49,6 +49,8 @@ uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
 uniform float		wb_tint;        // -1 magenta .. +1 green
 
 // Lift / Midtone / Gain (3-way primary colour corrector)
+// Per-channel uniforms are uploaded in RGB order and swizzled to the working order
+// where they are used, in main() -- see the note above the grading functions below.
 uniform bool		lmg_enable;
 uniform vec3		lmg_lift;    // shadow offset per channel, default vec3(0)
 uniform vec3		lmg_midtone; // midtone power per channel,  default vec3(1)
@@ -552,19 +554,35 @@ vec4 get_rgba_color()
     return vec4(0.0, 0.0, 0.0, 0.0);
 }
 
+// ============================ Primary grading chain ============================
+//
+// CHANNEL ORDER. The colour vector carried through this shader is in BGR order:
+// `color.r` holds displayed blue. That is this shader's own long-standing
+// convention, not something the grading chain introduced -- see `fragColor =
+// color.bgra` at the end of main(), which swaps back on output, and
+// `LumCoeff = luma_coeff.bgr` in ContrastSaturationBrightness above, which
+// swizzles an RGB-order uniform at its point of use.
+//
+// The grading functions below therefore follow the same rule as
+// ContrastSaturationBrightness: they take and return the working (BGR) vector,
+// and anything that needs a real RGB triple -- a Rec.709 luma dot product, a hue
+// conversion, a per-channel uniform -- swizzles it at the point of use. All
+// per-channel uniforms are uploaded from C++ in plain RGB order and get their
+// `.bgr` in main(), so the convention lives in exactly one file.
+//
+// Note that greys are invariant under a red/blue exchange, so a grey ramp passes
+// every channel-order defect in here. Test with asymmetric per-channel values.
+// ===============================================================================
+
 // ---- White Balance ----
 // temp: -1=cool (blue), +1=warm (orange); tint_val: -1=magenta, +1=green.
 // Diagonal gain matrix, no clamping so HDR headroom is preserved.
-// Note: working colour is in BGR order (c.r=displayed Blue, c.b=displayed Red).
 vec3 apply_white_balance(vec3 c, float temp, float tint_val)
 {
-    float r_gain = 1.0 + temp     * 0.20; // warm -> more red
-    float g_gain = 1.0 + tint_val * 0.10; // tint -> more green
-    float b_gain = 1.0 - temp     * 0.20; // warm -> less blue
-    c.r *= b_gain; // .r = Blue in BGR convention
-    c.g *= g_gain;
-    c.b *= r_gain; // .b = Red in BGR convention
-    return c;
+    vec3 gain_rgb = vec3(1.0 + temp     * 0.20,  // warm -> more red
+                         1.0 + tint_val * 0.10,  // tint -> more green
+                         1.0 - temp     * 0.20); // warm -> less blue
+    return c * gain_rgb.bgr;
 }
 
 // ---- Lift / Midtone / Gain (3-way colour corrector) ----
@@ -585,14 +603,11 @@ vec3 apply_lmg(vec3 c, vec3 lift, vec3 midtone, vec3 gain)
 // ---- Hue Shift ----
 // Rotate hue in HSV space.  Extract peak luminance, normalise, rotate, re-scale
 // so HDR values (>1.0) are preserved.
-// The grading chain carries the pixel in the mixer's native BGR order, so c.r holds
-// blue -- see apply_white_balance below and apply_lut3d, both of which say so. rgb2hsv
-// does not know what the channels mean; it treats the first as red, and exchanging red
-// and blue mirrors the hue wheel. Feeding it unswizzled negated every rotation: a
-// requested +15 degrees came out as -15. Only 0 and 180 looked right, because they are
-// their own negations. Swizzling in and back out makes the hue domain a real hue
-// domain. Saturation and value are unchanged by the exchange, which is why nothing
-// else about this function was visibly wrong.
+// rgb2hsv does not know what the channels mean; it treats the first as red, and
+// exchanging red and blue mirrors the hue wheel. Feeding it the working vector
+// unswizzled negated every rotation: a requested +15 degrees came out as -15, and only
+// 0 and 180 looked right because they are their own negations. Saturation and value are
+// unchanged by the exchange, which is why nothing else about this function was wrong.
 vec3 apply_hue_shift(vec3 c, float degrees)
 {
     float peak = max(max(c.r, c.g), max(c.b, 0.0001));
@@ -650,18 +665,21 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    // Per-channel uniforms arrive in RGB order and are swizzled to the working order
+    // here -- see the channel-order note above the grading functions.
     if (cdl_enable)
-        color.rgb = apply_cdl(color.rgb, cdl_slope, cdl_offset, cdl_power, cdl_saturation);
+        color.rgb = apply_cdl(color.rgb, cdl_slope.bgr, cdl_offset.bgr, cdl_power.bgr, cdl_saturation);
     if (white_balance)
         color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
     if (lmg_enable)
-        color.rgb = apply_lmg(color.rgb, lmg_lift, lmg_midtone, lmg_gain);
+        color.rgb = apply_lmg(color.rgb, lmg_lift.bgr, lmg_midtone.bgr, lmg_gain.bgr);
     if (hue_shift_enable)
         color.rgb = apply_hue_shift(color.rgb, hue_shift_degrees);
     if (tonebalance_enable)
         color.rgb = apply_tone_balance(color.rgb, tb_shadows, tb_highlights);
     if (split_tone_enable)
-        color.rgb = apply_split_tone(color.rgb, split_shadow_color, split_highlight_color, split_balance);
+        color.rgb =
+            apply_split_tone(color.rgb, split_shadow_color.bgr, split_highlight_color.bgr, split_balance);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -58,6 +58,11 @@ uniform vec3		lmg_gain;    // highlight multiplier per channel, default vec3(1)
 uniform bool		hue_shift_enable;
 uniform float		hue_shift_degrees; // -180..+180
 
+// Tonal balance (shadows / highlights separation)
+uniform bool		tonebalance_enable;
+uniform float		tb_shadows;    // -1..+1
+uniform float		tb_highlights; // -1..+1
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -571,6 +576,19 @@ vec3 apply_hue_shift(vec3 c, float degrees)
     return hsv2rgb(hsv) * peak;
 }
 
+// ---- Tonal Balance (Shadows / Highlights separation) ----
+// Soft luminance-based masks drive additive offsets.  No clamping so HDR
+// headroom is preserved for downstream tonemapping.
+vec3 apply_tone_balance(vec3 c, float shadows, float highlights)
+{
+    float lum         = dot(c, vec3(0.2126, 0.7152, 0.0722));
+    float shadow_mask = 1.0 - smoothstep(0.0, 0.6, lum);
+    float hl_mask     = smoothstep(0.4, 1.0, lum);
+    c += vec3(shadows    * 0.5 * shadow_mask);
+    c += vec3(highlights * 0.5 * hl_mask);
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -584,6 +602,8 @@ void main()
         color.rgb = apply_lmg(color.rgb, lmg_lift, lmg_midtone, lmg_gain);
     if (hue_shift_enable)
         color.rgb = apply_hue_shift(color.rgb, hue_shift_degrees);
+    if (tonebalance_enable)
+        color.rgb = apply_tone_balance(color.rgb, tb_shadows, tb_highlights);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/util/shader.cpp
+++ b/src/accelerator/ogl/util/shader.cpp
@@ -132,7 +132,7 @@ struct shader::impl
         GL(glUniform3f(get_uniform_location(name.c_str()),
                        static_cast<float>(value0),
                        static_cast<float>(value1),
-                       static_cast<float>(value1)));
+                       static_cast<float>(value2)));
     }
 
     void set(const std::string& name, double value)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -97,12 +97,26 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.shadows    += other.shadows;
     self.highlights += other.highlights;
 
-    // Split toning: additive colours, balance override if non-default
+    // Split toning: colours add, and the balance of whichever transform actually has
+    // split toning active wins.
+    //
+    // split_balance is a crossover position in luma, not a strength, so no arithmetic
+    // composition of two of them means anything: adding 0.5 and 0.5 gives 1.0 (everything
+    // is shadow), multiplying gives 0.25. And the shader has one crossover and one colour
+    // pair, so two stacked split tones cannot both be represented however they are
+    // combined. Summing the colours and keeping a single crossover is the least-lossy
+    // approximation available. "Is other active" is the same test the mixer uses to decide
+    // whether to enable the effect at all; comparing other.split_balance against its 0.5
+    // default instead would misread a tweened 0.4999999 as an explicit setting.
+    const auto is_set = [](double v) { return v != 0.0; };
+    const bool other_splits =
+        std::any_of(other.split_shadow_color.begin(), other.split_shadow_color.end(), is_set) ||
+        std::any_of(other.split_highlight_color.begin(), other.split_highlight_color.end(), is_set);
     for (int i = 0; i < 3; ++i) {
         self.split_shadow_color[i]    += other.split_shadow_color[i];
         self.split_highlight_color[i] += other.split_highlight_color[i];
     }
-    if (other.split_balance != 0.5)
+    if (other_splits)
         self.split_balance = other.split_balance;
 
     // ASC CDL: slope/power multiplicative, offset additive, saturation multiplicative

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -72,15 +72,27 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
 
+    // Every combined grading value below is clamped back into the range its MIXER
+    // command accepts (core::grade_limits, the same table the commands validate
+    // against). Two layers at the edge of legal would otherwise reach a value no single
+    // command could set: lift 0.9 over lift 0.9 is 1.8, and a midtone of 0.2 under
+    // another 0.2 is an exponent of 25. Clamping here rather than in the shader keeps
+    // the value the kernel reports and the value it renders the same thing.
+    //
+    // The bounds are wide enough that ordinary stacking is untouched -- gain 2 over
+    // gain 2 is 4, well inside [0, 10]. hue_shift is the exception and is wrapped
+    // instead, below, because rotation is periodic.
+    namespace lim = core::grade_limits;
+
     // White balance: additive
-    self.temperature += other.temperature;
-    self.tint        += other.tint;
+    self.temperature = lim::temperature.clamp(self.temperature + other.temperature);
+    self.tint        = lim::tint.clamp(self.tint + other.tint);
 
     // Lift/Midtone/Gain: additive lift, multiplicative midtone+gain
     for (int i = 0; i < 3; ++i) {
-        self.lift[i]    += other.lift[i];
-        self.midtone[i] *= other.midtone[i];
-        self.gain[i]    *= other.gain[i];
+        self.lift[i]    = lim::lift.clamp(self.lift[i] + other.lift[i]);
+        self.midtone[i] = lim::midtone.clamp(self.midtone[i] * other.midtone[i]);
+        self.gain[i]    = lim::gain.clamp(self.gain[i] * other.gain[i]);
     }
 
     // Hue shift: additive, then wrapped into [-180, 180].
@@ -94,8 +106,8 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.hue_shift = std::remainder(self.hue_shift + other.hue_shift, 360.0);
 
     // Tone balance: additive
-    self.shadows    += other.shadows;
-    self.highlights += other.highlights;
+    self.shadows    = lim::tone.clamp(self.shadows + other.shadows);
+    self.highlights = lim::tone.clamp(self.highlights + other.highlights);
 
     // Split toning: colours add, and the balance of whichever transform actually has
     // split toning active wins.
@@ -113,19 +125,21 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         std::any_of(other.split_shadow_color.begin(), other.split_shadow_color.end(), is_set) ||
         std::any_of(other.split_highlight_color.begin(), other.split_highlight_color.end(), is_set);
     for (int i = 0; i < 3; ++i) {
-        self.split_shadow_color[i]    += other.split_shadow_color[i];
-        self.split_highlight_color[i] += other.split_highlight_color[i];
+        self.split_shadow_color[i] =
+            lim::split_color.clamp(self.split_shadow_color[i] + other.split_shadow_color[i]);
+        self.split_highlight_color[i] =
+            lim::split_color.clamp(self.split_highlight_color[i] + other.split_highlight_color[i]);
     }
     if (other_splits)
-        self.split_balance = other.split_balance;
+        self.split_balance = lim::split_balance.clamp(other.split_balance);
 
     // ASC CDL: slope/power multiplicative, offset additive, saturation multiplicative
     for (int i = 0; i < 3; ++i) {
-        self.cdl_slope[i]  *= other.cdl_slope[i];
-        self.cdl_offset[i] += other.cdl_offset[i];
-        self.cdl_power[i]  *= other.cdl_power[i];
+        self.cdl_slope[i]  = lim::cdl_slope.clamp(self.cdl_slope[i] * other.cdl_slope[i]);
+        self.cdl_offset[i] = lim::cdl_offset.clamp(self.cdl_offset[i] + other.cdl_offset[i]);
+        self.cdl_power[i]  = lim::cdl_power.clamp(self.cdl_power[i] * other.cdl_power[i]);
     }
-    self.cdl_saturation *= other.cdl_saturation;
+    self.cdl_saturation = lim::cdl_saturation.clamp(self.cdl_saturation * other.cdl_saturation);
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -74,6 +74,13 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     // White balance: additive
     self.temperature += other.temperature;
     self.tint        += other.tint;
+
+    // Lift/Midtone/Gain: additive lift, multiplicative midtone+gain
+    for (int i = 0; i < 3; ++i) {
+        self.lift[i]    += other.lift[i];
+        self.midtone[i] *= other.midtone[i];
+        self.gain[i]    *= other.gain[i];
+    }
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -81,6 +81,9 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.midtone[i] *= other.midtone[i];
         self.gain[i]    *= other.gain[i];
     }
+
+    // Hue shift: additive
+    self.hue_shift += other.hue_shift;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -88,6 +88,14 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     // Tone balance: additive
     self.shadows    += other.shadows;
     self.highlights += other.highlights;
+
+    // Split toning: additive colours, balance override if non-default
+    for (int i = 0; i < 3; ++i) {
+        self.split_shadow_color[i]    += other.split_shadow_color[i];
+        self.split_highlight_color[i] += other.split_highlight_color[i];
+    }
+    if (other.split_balance != 0.5)
+        self.split_balance = other.split_balance;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -70,6 +70,10 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.is_mix |= other.is_mix;
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
+
+    // White balance: additive
+    self.temperature += other.temperature;
+    self.tint        += other.tint;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -2,6 +2,7 @@
 #include "transforms.h"
 
 #include <algorithm>
+#include <cmath>
 #include <unordered_set>
 
 namespace caspar::accelerator::ogl {
@@ -82,8 +83,15 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.gain[i]    *= other.gain[i];
     }
 
-    // Hue shift: additive
-    self.hue_shift += other.hue_shift;
+    // Hue shift: additive, then wrapped into [-180, 180].
+    //
+    // Wrapped, not clamped: 200 degrees of rotation is -160, not 180. The shader rotates
+    // with fract(), so rotation is already periodic and this does not change what is
+    // rendered -- what it does is bound the accumulation. Stacking layer, channel and
+    // tweened transforms can otherwise walk hue_shift arbitrarily far from zero, which
+    // costs precision in fract() and makes the "is this effect active" test dishonest:
+    // an accumulated 360 is exactly identity but reads as active and pays for the branch.
+    self.hue_shift = std::remainder(self.hue_shift + other.hue_shift, 360.0);
 
     // Tone balance: additive
     self.shadows    += other.shadows;

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -84,6 +84,10 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
 
     // Hue shift: additive
     self.hue_shift += other.hue_shift;
+
+    // Tone balance: additive
+    self.shadows    += other.shadows;
+    self.highlights += other.highlights;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -96,6 +96,14 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     }
     if (other.split_balance != 0.5)
         self.split_balance = other.split_balance;
+
+    // ASC CDL: slope/power multiplicative, offset additive, saturation multiplicative
+    for (int i = 0; i < 3; ++i) {
+        self.cdl_slope[i]  *= other.cdl_slope[i];
+        self.cdl_offset[i] += other.cdl_offset[i];
+        self.cdl_power[i]  *= other.cdl_power[i];
+    }
+    self.cdl_saturation *= other.cdl_saturation;
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -117,6 +117,8 @@ image_transform image_transform::tween(double                 time,
         result.gain[i]    = do_tween(time, source.gain[i], dest.gain[i], duration, tween);
     }
     result.hue_shift = do_tween(time, source.hue_shift, dest.hue_shift, duration, tween);
+    result.shadows    = do_tween(time, source.shadows, dest.shadows, duration, tween);
+    result.highlights = do_tween(time, source.highlights, dest.highlights, duration, tween);
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -157,7 +159,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
-               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) ||
+               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
+               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -109,6 +109,9 @@ image_transform image_transform::tween(double                 time,
     result.blend_mode       = std::max(source.blend_mode, dest.blend_mode);
     result.layer_depth      = dest.layer_depth;
 
+    result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
+    result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
+
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
 
@@ -145,7 +148,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-               lhs.perspective == rhs.perspective ||
+               lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
+               eq(lhs.tint, rhs.tint) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -111,6 +111,11 @@ image_transform image_transform::tween(double                 time,
 
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.lift[i]    = do_tween(time, source.lift[i], dest.lift[i], duration, tween);
+        result.midtone[i] = do_tween(time, source.midtone[i], dest.midtone[i], duration, tween);
+        result.gain[i]    = do_tween(time, source.gain[i], dest.gain[i], duration, tween);
+    }
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -149,7 +154,9 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
-               eq(lhs.tint, rhs.tint) ||
+               eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
+               boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
+               boost::range::equal(lhs.gain, rhs.gain, eq) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -116,6 +116,7 @@ image_transform image_transform::tween(double                 time,
         result.midtone[i] = do_tween(time, source.midtone[i], dest.midtone[i], duration, tween);
         result.gain[i]    = do_tween(time, source.gain[i], dest.gain[i], duration, tween);
     }
+    result.hue_shift = do_tween(time, source.hue_shift, dest.hue_shift, duration, tween);
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -156,7 +157,7 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
-               boost::range::equal(lhs.gain, rhs.gain, eq) ||
+               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -119,6 +119,13 @@ image_transform image_transform::tween(double                 time,
     result.hue_shift = do_tween(time, source.hue_shift, dest.hue_shift, duration, tween);
     result.shadows    = do_tween(time, source.shadows, dest.shadows, duration, tween);
     result.highlights = do_tween(time, source.highlights, dest.highlights, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.split_shadow_color[i] =
+            do_tween(time, source.split_shadow_color[i], dest.split_shadow_color[i], duration, tween);
+        result.split_highlight_color[i] =
+            do_tween(time, source.split_highlight_color[i], dest.split_highlight_color[i], duration, tween);
+    }
+    result.split_balance = do_tween(time, source.split_balance, dest.split_balance, duration, tween);
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -160,7 +167,10 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
                boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
-               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) ||
+               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
+               boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
+               boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
+               eq(lhs.split_balance, rhs.split_balance) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -126,6 +126,12 @@ image_transform image_transform::tween(double                 time,
             do_tween(time, source.split_highlight_color[i], dest.split_highlight_color[i], duration, tween);
     }
     result.split_balance = do_tween(time, source.split_balance, dest.split_balance, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.cdl_slope[i]  = do_tween(time, source.cdl_slope[i], dest.cdl_slope[i], duration, tween);
+        result.cdl_offset[i] = do_tween(time, source.cdl_offset[i], dest.cdl_offset[i], duration, tween);
+        result.cdl_power[i]  = do_tween(time, source.cdl_power[i], dest.cdl_power[i], duration, tween);
+    }
+    result.cdl_saturation = do_tween(time, source.cdl_saturation, dest.cdl_saturation, duration, tween);
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -170,7 +176,11 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
                boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
                boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
-               eq(lhs.split_balance, rhs.split_balance) ||
+               eq(lhs.split_balance, rhs.split_balance) &&
+               boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
+               boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
+               boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
+               eq(lhs.cdl_saturation, rhs.cdl_saturation) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -96,6 +96,8 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    double                temperature = 0.0; // white balance: -1 cool .. +1 warm
+    double                tint        = 0.0; // white balance: -1 magenta .. +1 green
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -98,6 +98,9 @@ struct image_transform final
     core::chroma          chroma;
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
+    std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel
+    std::array<double, 3> midtone = {1.0, 1.0, 1.0}; // midtone power per channel (DaVinci "gamma")
+    std::array<double, 3> gain    = {1.0, 1.0, 1.0}; // highlight multiplier per channel
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -102,6 +102,8 @@ struct image_transform final
     std::array<double, 3> midtone = {1.0, 1.0, 1.0}; // midtone power per channel (DaVinci "gamma")
     std::array<double, 3> gain    = {1.0, 1.0, 1.0}; // highlight multiplier per channel
     double                hue_shift = 0.0; // global hue rotation, degrees -180..+180
+    double                shadows    = 0.0; // tonal balance: shadow region lift/cut -1..+1
+    double                highlights = 0.0; // tonal balance: highlight region lift/cut -1..+1
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -73,6 +73,60 @@ struct rectangle final
     std::array<double, 2> lr = {1.0, 1.0};
 };
 
+/// An inclusive range for a grading parameter, and the clamp that enforces it.
+struct grade_range final
+{
+    double lo;
+    double hi;
+
+    [[nodiscard]] constexpr bool contains(double v) const
+    {
+        // Written as a positive test so a NaN falls outside: every comparison against
+        // NaN is false. std::stod("nan") succeeds, so without this a MIXER command
+        // could put a NaN into the transform and every pixel it touched would go black.
+        return v >= lo && v <= hi;
+    }
+
+    [[nodiscard]] constexpr double clamp(double v) const
+    {
+        if (!(v >= lo)) // also catches NaN, which must not survive as itself
+            return lo;
+        return v > hi ? hi : v;
+    }
+};
+
+/// Legal ranges for the primary grading parameters.
+///
+/// One table, used twice: the MIXER commands refuse anything outside it, and combining
+/// transforms clamps the result back into it. Both have to agree, or a value no single
+/// command could set becomes reachable by stacking two layers.
+///
+/// The bounds are deliberately generous rather than tasteful. They exist to keep the
+/// arithmetic defined and to stop a typo from blacking out a layer, not to enforce a
+/// look, so they sit well outside what a grade would normally use. Where a standard
+/// gives one it is followed: ASC CDL requires slope >= 0, power > 0 and saturation >= 0.
+namespace grade_limits {
+
+inline constexpr grade_range temperature{-1.0, 1.0};
+inline constexpr grade_range tint{-1.0, 1.0};
+inline constexpr grade_range lift{-1.0, 1.0};
+/// The shader raises to 1/midtone, so zero is a division by zero and negatives invert
+/// the curve. Matches the clamp in apply_lmg.
+inline constexpr grade_range midtone{0.01, 100.0};
+inline constexpr grade_range gain{0.0, 10.0};
+/// Rotation is periodic, so this is a wrap rather than a clamp -- see
+/// apply_transform_colour_values. 200 degrees is -160, not 180.
+inline constexpr grade_range hue_shift{-180.0, 180.0};
+inline constexpr grade_range tone{-1.0, 1.0}; // shadows / highlights
+inline constexpr grade_range split_color{-1.0, 1.0};
+inline constexpr grade_range split_balance{0.0, 1.0};
+inline constexpr grade_range cdl_slope{0.0, 10.0};
+inline constexpr grade_range cdl_offset{-1.0, 1.0};
+inline constexpr grade_range cdl_power{0.01, 10.0};
+inline constexpr grade_range cdl_saturation{0.0, 10.0};
+
+} // namespace grade_limits
+
 struct image_transform final
 {
     double opacity    = 1.0;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -101,6 +101,7 @@ struct image_transform final
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel
     std::array<double, 3> midtone = {1.0, 1.0, 1.0}; // midtone power per channel (DaVinci "gamma")
     std::array<double, 3> gain    = {1.0, 1.0, 1.0}; // highlight multiplier per channel
+    double                hue_shift = 0.0; // global hue rotation, degrees -180..+180
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -104,6 +104,9 @@ struct image_transform final
     double                hue_shift = 0.0; // global hue rotation, degrees -180..+180
     double                shadows    = 0.0; // tonal balance: shadow region lift/cut -1..+1
     double                highlights = 0.0; // tonal balance: highlight region lift/cut -1..+1
+    std::array<double, 3> split_shadow_color    = {0.0, 0.0, 0.0}; // split tone: shadow tint RGB
+    std::array<double, 3> split_highlight_color = {0.0, 0.0, 0.0}; // split tone: highlight tint RGB
+    double                split_balance         = 0.5;             // split tone: crossover 0..1
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -107,6 +107,10 @@ struct image_transform final
     std::array<double, 3> split_shadow_color    = {0.0, 0.0, 0.0}; // split tone: shadow tint RGB
     std::array<double, 3> split_highlight_color = {0.0, 0.0, 0.0}; // split tone: highlight tint RGB
     double                split_balance         = 0.5;             // split tone: crossover 0..1
+    std::array<double, 3> cdl_slope      = {1.0, 1.0, 1.0}; // ASC CDL slope
+    std::array<double, 3> cdl_offset     = {0.0, 0.0, 0.0}; // ASC CDL offset
+    std::array<double, 3> cdl_power      = {1.0, 1.0, 1.0}; // ASC CDL power
+    double                cdl_saturation = 1.0;             // ASC CDL saturation
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1339,6 +1339,69 @@ std::future<std::wstring> mixer_splittone_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER CDL sR sG sB oR oG oB pR pG pB [saturation] [duration tween]  -- ASC CDL (Slope/Offset/Power)
+// MIXER CDL RESET
+std::future<std::wstring> mixer_cdl_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            auto f = [](double v) { return std::to_wstring(v); };
+            return L"201 MIXER OK\r\n" + f(t.cdl_slope[0]) + L" " + f(t.cdl_slope[1]) + L" " + f(t.cdl_slope[2]) +
+                   L" " + f(t.cdl_offset[0]) + L" " + f(t.cdl_offset[1]) + L" " + f(t.cdl_offset[2]) + L" " +
+                   f(t.cdl_power[0]) + L" " + f(t.cdl_power[1]) + L" " + f(t.cdl_power[2]) + L" " +
+                   f(t.cdl_saturation) + L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"RESET")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.cdl_slope      = {1.0, 1.0, 1.0};
+                t.image_transform.cdl_offset     = {0.0, 0.0, 0.0};
+                t.image_transform.cdl_power      = {1.0, 1.0, 1.0};
+                t.image_transform.cdl_saturation = 1.0;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    transforms_applier transforms(ctx);
+    double       sR  = std::stod(ctx.parameters.at(0));
+    double       sG  = std::stod(ctx.parameters.at(1));
+    double       sB  = std::stod(ctx.parameters.at(2));
+    double       oR  = std::stod(ctx.parameters.at(3));
+    double       oG  = std::stod(ctx.parameters.at(4));
+    double       oB  = std::stod(ctx.parameters.at(5));
+    double       pR  = std::stod(ctx.parameters.at(6));
+    double       pG  = std::stod(ctx.parameters.at(7));
+    double       pB  = std::stod(ctx.parameters.at(8));
+    double       sat = ctx.parameters.size() > 9 ? std::stod(ctx.parameters[9]) : 1.0;
+    int          dur = ctx.parameters.size() > 10 ? std::stoi(ctx.parameters[10]) : 0;
+    std::wstring tw  = ctx.parameters.size() > 11 ? ctx.parameters[11] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.cdl_slope      = {sR, sG, sB};
+            transform.image_transform.cdl_offset     = {oR, oG, oB};
+            transform.image_transform.cdl_power      = {pR, pG, pB};
+            transform.image_transform.cdl_saturation = sat;
+            return transform;
+        },
+        dur,
+        tw));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1996,6 +2059,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER HUESHIFT", mixer_hueshift_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER TONEBALANCE", mixer_tonebalance_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER SPLITTONE", mixer_splittone_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER CDL", mixer_cdl_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1161,6 +1161,67 @@ std::future<std::wstring> mixer_whitebalance_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// Shared implementation for the three per-channel (R G B) grade wheels.
+template <typename Getter, typename Setter>
+std::future<std::wstring>
+mixer_rgb_triple_command(command_context& ctx, const Getter& getter, const Setter& setter)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2, getter]() -> std::wstring {
+            auto arr = getter(transform2.get().image_transform);
+            return L"201 MIXER OK\r\n" + std::to_wstring(arr[0]) + L" " + std::to_wstring(arr[1]) + L" " +
+                   std::to_wstring(arr[2]) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       r        = std::stod(ctx.parameters.at(0));
+    double       g        = std::stod(ctx.parameters.at(1));
+    double       b        = std::stod(ctx.parameters.at(2));
+    int          duration = ctx.parameters.size() > 3 ? std::stoi(ctx.parameters[3]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 4 ? ctx.parameters[4] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            setter(transform.image_transform, r, g, b);
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
+// MIXER LIFT r g b [duration tween] -- per-channel shadow offset
+std::future<std::wstring> mixer_lift_command(command_context& ctx)
+{
+    return mixer_rgb_triple_command(
+        ctx,
+        [](const image_transform& t) { return t.lift; },
+        [](image_transform& t, double r, double g, double b) { t.lift = {r, g, b}; });
+}
+
+// MIXER MIDTONE r g b [duration tween] -- per-channel midtone power (DaVinci "gamma" wheel)
+std::future<std::wstring> mixer_midtone_command(command_context& ctx)
+{
+    return mixer_rgb_triple_command(
+        ctx,
+        [](const image_transform& t) { return t.midtone; },
+        [](image_transform& t, double r, double g, double b) { t.midtone = {r, g, b}; });
+}
+
+// MIXER GAIN r g b [duration tween] -- per-channel highlight multiplier
+std::future<std::wstring> mixer_gain_command(command_context& ctx)
+{
+    return mixer_rgb_triple_command(
+        ctx,
+        [](const image_transform& t) { return t.gain; },
+        [](image_transform& t, double r, double g, double b) { t.gain = {r, g, b}; });
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1812,6 +1873,9 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER CONTRAST", mixer_contrast_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LEVELS", mixer_levels_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER WHITEBALANCE", mixer_whitebalance_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER LIFT", mixer_lift_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER MIDTONE", mixer_midtone_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER GAIN", mixer_gain_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1130,6 +1130,43 @@ std::future<std::wstring> mixer_levels_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// Parse one grading argument and refuse it if it is outside the parameter's defined
+// range, so a bad value is a 403 naming the offender rather than a silently applied
+// grade -- or, for a NaN, a black layer. `grade_limits` is the same table that
+// apply_transform_colour_values clamps combined transforms to; if the two disagreed,
+// stacking two legal layers could reach a value no command would accept.
+//
+// Scoped to the commands added in this series. The older mixer commands validate
+// nothing (MIXER OPACITY -5 is accepted today) and retrofitting them would change
+// behaviour for existing clients, which belongs in its own change.
+double grade_param(const std::wstring& raw, core::grade_range range, const wchar_t* name)
+{
+    double value = 0.0;
+    try {
+        value = std::stod(raw);
+    } catch (...) {
+        CASPAR_THROW_EXCEPTION(user_error()
+                               << msg_info(std::wstring(name) + L" is not a number: " + raw));
+    }
+    if (!range.contains(value)) {
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(std::wstring(name) + L" must be between " +
+                                                       std::to_wstring(range.lo) + L" and " +
+                                                       std::to_wstring(range.hi) + L", got " + raw));
+    }
+    return value;
+}
+
+// Refuse a short parameter list by name. Without this the .at() below throws
+// std::out_of_range, which surfaces as a generic failure rather than saying which
+// command wanted how many arguments.
+void grade_require(const command_context& ctx, size_t count, const wchar_t* usage)
+{
+    if (ctx.parameters.size() < count) {
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(std::wstring(L"expected at least ") +
+                                                       std::to_wstring(count) + L" parameters: " + usage));
+    }
+}
+
 // MIXER WHITEBALANCE temperature tint [duration tween]
 std::future<std::wstring> mixer_whitebalance_command(command_context& ctx)
 {
@@ -1141,9 +1178,10 @@ std::future<std::wstring> mixer_whitebalance_command(command_context& ctx)
         });
     }
 
+    grade_require(ctx, 2, L"MIXER WHITEBALANCE temperature tint [duration] [tween]");
     transforms_applier transforms(ctx);
-    double       temperature = std::stod(ctx.parameters.at(0));
-    double       tint        = std::stod(ctx.parameters.at(1));
+    double temperature = grade_param(ctx.parameters.at(0), core::grade_limits::temperature, L"temperature");
+    double tint        = grade_param(ctx.parameters.at(1), core::grade_limits::tint, L"tint");
     int          duration    = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
     std::wstring tween       = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
 
@@ -1161,10 +1199,15 @@ std::future<std::wstring> mixer_whitebalance_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
-// Shared implementation for the three per-channel (R G B) grade wheels.
+// Shared implementation for the three per-channel (R G B) grade wheels. `range` and
+// `name` differ per wheel -- lift is an offset, midtone an exponent, gain a multiplier --
+// so they are threaded through rather than assumed.
 template <typename Getter, typename Setter>
-std::future<std::wstring>
-mixer_rgb_triple_command(command_context& ctx, const Getter& getter, const Setter& setter)
+std::future<std::wstring> mixer_rgb_triple_command(command_context&  ctx,
+                                                   const Getter&     getter,
+                                                   const Setter&     setter,
+                                                   core::grade_range range,
+                                                   const wchar_t*    name)
 {
     if (ctx.parameters.empty()) {
         auto transform2 = get_current_transform(ctx).share();
@@ -1175,10 +1218,11 @@ mixer_rgb_triple_command(command_context& ctx, const Getter& getter, const Sette
         });
     }
 
+    grade_require(ctx, 3, L"MIXER <wheel> R G B [duration] [tween]");
     transforms_applier transforms(ctx);
-    double       r        = std::stod(ctx.parameters.at(0));
-    double       g        = std::stod(ctx.parameters.at(1));
-    double       b        = std::stod(ctx.parameters.at(2));
+    double       r        = grade_param(ctx.parameters.at(0), range, name);
+    double       g        = grade_param(ctx.parameters.at(1), range, name);
+    double       b        = grade_param(ctx.parameters.at(2), range, name);
     int          duration = ctx.parameters.size() > 3 ? std::stoi(ctx.parameters[3]) : 0;
     std::wstring tween    = ctx.parameters.size() > 4 ? ctx.parameters[4] : L"linear";
 
@@ -1201,7 +1245,9 @@ std::future<std::wstring> mixer_lift_command(command_context& ctx)
     return mixer_rgb_triple_command(
         ctx,
         [](const image_transform& t) { return t.lift; },
-        [](image_transform& t, double r, double g, double b) { t.lift = {r, g, b}; });
+        [](image_transform& t, double r, double g, double b) { t.lift = {r, g, b}; },
+        core::grade_limits::lift,
+        L"lift");
 }
 
 // MIXER MIDTONE r g b [duration tween] -- per-channel midtone power (DaVinci "gamma" wheel)
@@ -1210,7 +1256,9 @@ std::future<std::wstring> mixer_midtone_command(command_context& ctx)
     return mixer_rgb_triple_command(
         ctx,
         [](const image_transform& t) { return t.midtone; },
-        [](image_transform& t, double r, double g, double b) { t.midtone = {r, g, b}; });
+        [](image_transform& t, double r, double g, double b) { t.midtone = {r, g, b}; },
+        core::grade_limits::midtone,
+        L"midtone");
 }
 
 // MIXER GAIN r g b [duration tween] -- per-channel highlight multiplier
@@ -1219,7 +1267,9 @@ std::future<std::wstring> mixer_gain_command(command_context& ctx)
     return mixer_rgb_triple_command(
         ctx,
         [](const image_transform& t) { return t.gain; },
-        [](image_transform& t, double r, double g, double b) { t.gain = {r, g, b}; });
+        [](image_transform& t, double r, double g, double b) { t.gain = {r, g, b}; },
+        core::grade_limits::gain,
+        L"gain");
 }
 
 // MIXER HUESHIFT degrees [duration tween] -- global hue rotation (-180..+180)
@@ -1232,8 +1282,9 @@ std::future<std::wstring> mixer_hueshift_command(command_context& ctx)
         });
     }
 
+    grade_require(ctx, 1, L"MIXER HUESHIFT degrees [duration] [tween]");
     transforms_applier transforms(ctx);
-    double       value    = std::stod(ctx.parameters.at(0));
+    double       value    = grade_param(ctx.parameters.at(0), core::grade_limits::hue_shift, L"hue shift");
     int          duration = ctx.parameters.size() > 1 ? std::stoi(ctx.parameters[1]) : 0;
     std::wstring tween    = ctx.parameters.size() > 2 ? ctx.parameters[2] : L"linear";
 
@@ -1261,9 +1312,10 @@ std::future<std::wstring> mixer_tonebalance_command(command_context& ctx)
         });
     }
 
+    grade_require(ctx, 2, L"MIXER TONEBALANCE shadows highlights [duration] [tween]");
     transforms_applier transforms(ctx);
-    double       shadows    = std::stod(ctx.parameters.at(0));
-    double       highlights = std::stod(ctx.parameters.at(1));
+    double shadows    = grade_param(ctx.parameters.at(0), core::grade_limits::tone, L"shadows");
+    double highlights = grade_param(ctx.parameters.at(1), core::grade_limits::tone, L"highlights");
     int          duration   = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
     std::wstring tween      = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
 
@@ -1313,14 +1365,21 @@ std::future<std::wstring> mixer_splittone_command(command_context& ctx)
         return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
     }
 
+    grade_require(ctx,
+                  6,
+                  L"MIXER SPLITTONE shadowR shadowG shadowB highlightR highlightG highlightB "
+                  L"[balance] [duration] [tween], or MIXER SPLITTONE RESET");
     transforms_applier transforms(ctx);
-    double       sr    = std::stod(ctx.parameters.at(0));
-    double       sg    = std::stod(ctx.parameters.at(1));
-    double       sb    = std::stod(ctx.parameters.at(2));
-    double       hr    = std::stod(ctx.parameters.at(3));
-    double       hg    = std::stod(ctx.parameters.at(4));
-    double       hb    = std::stod(ctx.parameters.at(5));
-    double       bal   = ctx.parameters.size() > 6 ? std::stod(ctx.parameters[6]) : 0.5;
+    const auto&  sc_lim = core::grade_limits::split_color;
+    double       sr    = grade_param(ctx.parameters.at(0), sc_lim, L"shadow red");
+    double       sg    = grade_param(ctx.parameters.at(1), sc_lim, L"shadow green");
+    double       sb    = grade_param(ctx.parameters.at(2), sc_lim, L"shadow blue");
+    double       hr    = grade_param(ctx.parameters.at(3), sc_lim, L"highlight red");
+    double       hg    = grade_param(ctx.parameters.at(4), sc_lim, L"highlight green");
+    double       hb    = grade_param(ctx.parameters.at(5), sc_lim, L"highlight blue");
+    double       bal   = ctx.parameters.size() > 6
+                             ? grade_param(ctx.parameters[6], core::grade_limits::split_balance, L"balance")
+                             : 0.5;
     int          dur   = ctx.parameters.size() > 7 ? std::stoi(ctx.parameters[7]) : 0;
     std::wstring tween = ctx.parameters.size() > 8 ? ctx.parameters[8] : L"linear";
 
@@ -1372,17 +1431,26 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
         return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
     }
 
+    grade_require(ctx,
+                  9,
+                  L"MIXER CDL slopeR slopeG slopeB offsetR offsetG offsetB powerR powerG powerB "
+                  L"[saturation] [duration] [tween], or MIXER CDL RESET");
     transforms_applier transforms(ctx);
-    double       sR  = std::stod(ctx.parameters.at(0));
-    double       sG  = std::stod(ctx.parameters.at(1));
-    double       sB  = std::stod(ctx.parameters.at(2));
-    double       oR  = std::stod(ctx.parameters.at(3));
-    double       oG  = std::stod(ctx.parameters.at(4));
-    double       oB  = std::stod(ctx.parameters.at(5));
-    double       pR  = std::stod(ctx.parameters.at(6));
-    double       pG  = std::stod(ctx.parameters.at(7));
-    double       pB  = std::stod(ctx.parameters.at(8));
-    double       sat = ctx.parameters.size() > 9 ? std::stod(ctx.parameters[9]) : 1.0;
+    const auto&  sl = core::grade_limits::cdl_slope;
+    const auto&  of = core::grade_limits::cdl_offset;
+    const auto&  pw = core::grade_limits::cdl_power;
+    double       sR  = grade_param(ctx.parameters.at(0), sl, L"CDL slope red");
+    double       sG  = grade_param(ctx.parameters.at(1), sl, L"CDL slope green");
+    double       sB  = grade_param(ctx.parameters.at(2), sl, L"CDL slope blue");
+    double       oR  = grade_param(ctx.parameters.at(3), of, L"CDL offset red");
+    double       oG  = grade_param(ctx.parameters.at(4), of, L"CDL offset green");
+    double       oB  = grade_param(ctx.parameters.at(5), of, L"CDL offset blue");
+    double       pR  = grade_param(ctx.parameters.at(6), pw, L"CDL power red");
+    double       pG  = grade_param(ctx.parameters.at(7), pw, L"CDL power green");
+    double       pB  = grade_param(ctx.parameters.at(8), pw, L"CDL power blue");
+    double       sat = ctx.parameters.size() > 9
+                           ? grade_param(ctx.parameters[9], core::grade_limits::cdl_saturation, L"CDL saturation")
+                           : 1.0;
     int          dur = ctx.parameters.size() > 10 ? std::stoi(ctx.parameters[10]) : 0;
     std::wstring tw  = ctx.parameters.size() > 11 ? ctx.parameters[11] : L"linear";
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1281,6 +1281,64 @@ std::future<std::wstring> mixer_tonebalance_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER SPLITTONE shad_r shad_g shad_b hi_r hi_g hi_b [balance] [duration tween]
+// MIXER SPLITTONE RESET
+std::future<std::wstring> mixer_splittone_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            auto f = [](double v) { return std::to_wstring(v); };
+            return L"201 MIXER OK\r\n" + f(t.split_shadow_color[0]) + L" " + f(t.split_shadow_color[1]) + L" " +
+                   f(t.split_shadow_color[2]) + L" " + f(t.split_highlight_color[0]) + L" " +
+                   f(t.split_highlight_color[1]) + L" " + f(t.split_highlight_color[2]) + L" " + f(t.split_balance) +
+                   L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"RESET")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.split_shadow_color    = {0.0, 0.0, 0.0};
+                t.image_transform.split_highlight_color = {0.0, 0.0, 0.0};
+                t.image_transform.split_balance         = 0.5;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    transforms_applier transforms(ctx);
+    double       sr    = std::stod(ctx.parameters.at(0));
+    double       sg    = std::stod(ctx.parameters.at(1));
+    double       sb    = std::stod(ctx.parameters.at(2));
+    double       hr    = std::stod(ctx.parameters.at(3));
+    double       hg    = std::stod(ctx.parameters.at(4));
+    double       hb    = std::stod(ctx.parameters.at(5));
+    double       bal   = ctx.parameters.size() > 6 ? std::stod(ctx.parameters[6]) : 0.5;
+    int          dur   = ctx.parameters.size() > 7 ? std::stoi(ctx.parameters[7]) : 0;
+    std::wstring tween = ctx.parameters.size() > 8 ? ctx.parameters[8] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.split_shadow_color    = {sr, sg, sb};
+            transform.image_transform.split_highlight_color = {hr, hg, hb};
+            transform.image_transform.split_balance         = bal;
+            return transform;
+        },
+        dur,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1937,6 +1995,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER GAIN", mixer_gain_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER HUESHIFT", mixer_hueshift_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER TONEBALANCE", mixer_tonebalance_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER SPLITTONE", mixer_splittone_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1130,6 +1130,37 @@ std::future<std::wstring> mixer_levels_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER WHITEBALANCE temperature tint [duration tween]
+std::future<std::wstring> mixer_whitebalance_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.temperature) + L" " + std::to_wstring(t.tint) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       temperature = std::stod(ctx.parameters.at(0));
+    double       tint        = std::stod(ctx.parameters.at(1));
+    int          duration    = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween       = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.temperature = temperature;
+            transform.image_transform.tint        = tint;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1780,6 +1811,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER SATURATION", mixer_saturation_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CONTRAST", mixer_contrast_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LEVELS", mixer_levels_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER WHITEBALANCE", mixer_whitebalance_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1250,6 +1250,37 @@ std::future<std::wstring> mixer_hueshift_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+// MIXER TONEBALANCE shadows highlights [duration tween]
+std::future<std::wstring> mixer_tonebalance_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.shadows) + L" " + std::to_wstring(t.highlights) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       shadows    = std::stod(ctx.parameters.at(0));
+    double       highlights = std::stod(ctx.parameters.at(1));
+    int          duration   = ctx.parameters.size() > 2 ? std::stoi(ctx.parameters[2]) : 0;
+    std::wstring tween      = ctx.parameters.size() > 3 ? ctx.parameters[3] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.shadows    = shadows;
+            transform.image_transform.highlights = highlights;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1905,6 +1936,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER MIDTONE", mixer_midtone_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER GAIN", mixer_gain_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER HUESHIFT", mixer_hueshift_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER TONEBALANCE", mixer_tonebalance_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1222,6 +1222,34 @@ std::future<std::wstring> mixer_gain_command(command_context& ctx)
         [](image_transform& t, double r, double g, double b) { t.gain = {r, g, b}; });
 }
 
+// MIXER HUESHIFT degrees [duration tween] -- global hue rotation (-180..+180)
+std::future<std::wstring> mixer_hueshift_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            return L"201 MIXER OK\r\n" + std::to_wstring(transform2.get().image_transform.hue_shift) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    double       value    = std::stod(ctx.parameters.at(0));
+    int          duration = ctx.parameters.size() > 1 ? std::stoi(ctx.parameters[1]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 2 ? ctx.parameters[2] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.hue_shift = value;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -1876,6 +1904,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER LIFT", mixer_lift_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER MIDTONE", mixer_midtone_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER GAIN", mixer_gain_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER HUESHIFT", mixer_hueshift_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER FILL", mixer_fill_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLIP", mixer_clip_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER ANCHOR", mixer_anchor_command, 0);


### PR DESCRIPTION
## Summary

Adds the standard primary color-grading toolset to the OpenGL mixer as per-layer, fully tweenable AMCP `MIXER` commands:

- **`MIXER WHITEBALANCE`** — temperature / tint.
- **`MIXER LIFT` / `MIXER MIDTONE` / `MIXER GAIN`** — DaVinci-style 3-way (shadows / midtones / highlights) per-channel corrector.
- **`MIXER HUESHIFT`** — global hue rotation.
- **`MIXER TONEBALANCE`** — luminance-masked shadow / highlight balance.
- **`MIXER SPLITTONE`** — independent shadow / highlight tint with a crossover.
- **`MIXER CDL`** — ASC CDL (Slope / Offset / Power + saturation), the industry-standard primary grade exchange format.

Every effect is off by default and costs nothing when neutral (the kernel only sets a single `*_enable = false` uniform). All operate in the working color space before the legacy levels/CSB stage and preserve HDR headroom (no clamping).

## Commits

Split into reviewable commits, one tool per commit:

1. `mixer: add MIXER WHITEBALANCE command`
2. `mixer: add MIXER LIFT/MIDTONE/GAIN 3-way color corrector`
3. `mixer: add MIXER HUESHIFT command`
4. `mixer: add MIXER TONEBALANCE command`
5. `mixer: add MIXER SPLITTONE command`
6. `mixer: add MIXER CDL (ASC CDL) command`

## AMCP syntax

```
MIXER <ch-layer> WHITEBALANCE <temperature> <tint> [duration] [tween]
MIXER <ch-layer> LIFT    <r> <g> <b> [duration] [tween]
MIXER <ch-layer> MIDTONE <r> <g> <b> [duration] [tween]
MIXER <ch-layer> GAIN    <r> <g> <b> [duration] [tween]
MIXER <ch-layer> HUESHIFT <degrees> [duration] [tween]
MIXER <ch-layer> TONEBALANCE <shadows> <highlights> [duration] [tween]
MIXER <ch-layer> SPLITTONE <sr> <sg> <sb> <hr> <hg> <hb> [balance] [duration] [tween]
MIXER <ch-layer> SPLITTONE RESET
MIXER <ch-layer> CDL <sR sG sB> <oR oG oB> <pR pG pB> [saturation] [duration] [tween]
MIXER <ch-layer> CDL RESET
```

Sending any command with no parameters queries the current value. Neutral defaults: `WHITEBALANCE 0 0`, `LIFT 0 0 0`, `MIDTONE 1 1 1`, `GAIN 1 1 1`, `HUESHIFT 0`, `TONEBALANCE 0 0`, `SPLITTONE 0 0 0 0 0 0 0.5`.

### Ranges

- `temperature` / `tint`: −1..+1 (cool..warm / magenta..green)
- `hue` degrees: −180..+180
- `shadows` / `highlights`: −1..+1
- split `balance`: 0..1 crossover (default 0.5)

### Examples

```
MIXER 1-10 WHITEBALANCE 0.3 -0.1        # warm up, slight magenta
MIXER 1-10 LIFT 0.02 0.0 -0.02          # cool shadows
MIXER 1-10 GAIN 1.1 1.0 0.95            # warm highlights
MIXER 1-10 HUESHIFT 15                  # rotate hue +15°
MIXER 1-10 TONEBALANCE -0.2 0.15        # crush shadows, lift highlights
MIXER 1-10 SPLITTONE 0.0 0.05 0.1 0.1 0.05 0.0 0.5   # teal shadows, orange highlights
MIXER 1-10 WHITEBALANCE 0.4 0 25 easeinoutsine       # tween over 25 frames
MIXER 1-10 CDL 1.1 1.0 0.9  0.0 0.0 0.02  1.0 1.0 1.0  0.9 (warm slope, slight blue offset, desaturate)
```

## Implementation notes

- Each parameter is added to `image_transform`, wired through `image_transform::tween`, `operator==`, and the transform-combine step, so grades animate and stack like existing mixer values.
- Shader work stays in the existing OGL image pipeline (`shader.frag` grade functions + `image_kernel.cpp` uniform setup). `rgb2hsv`/`hsv2rgb` already existed upstream and are reused for the hue shift.
- Per-channel wheels/split-tone upload RGB swapped to the shader's internal BGR working order.
- Independent of #1758 (ACES color management) and #1762 (image effects) — builds on clean `master`.

## Testing

Builds clean on Windows (VS2026, Release). Wiki docs to follow separately.