### PR TITLE
Add advanced grade tools: MIXER GAMUTCOMPRESS, QUALIFIER, RGBLEVELS

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -376,6 +376,18 @@ struct image_kernel::impl
             }
         }
 
+        // Gamut compression (ACES 1.3 Reference Gamut Compress)
+        if (transforms.image_transform.gamut_compress) {
+            shader_->set("gamut_compress_enable", true);
+            // BGR order: .r=Blue(yellow), .g=Green(magenta), .b=Red(cyan)
+            shader_->set("gc_limit",
+                         static_cast<float>(transforms.image_transform.gc_yellow),
+                         static_cast<float>(transforms.image_transform.gc_magenta),
+                         static_cast<float>(transforms.image_transform.gc_cyan));
+        } else {
+            shader_->set("gamut_compress_enable", false);
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -405,6 +405,32 @@ struct image_kernel::impl
             shader_->set("qualifier_enable", false);
         }
 
+        // Per-channel RGB levels
+        {
+            const auto& rl = transforms.image_transform.per_channel_levels;
+            if (rl.enable) {
+                shader_->set("rgb_levels_enable", true);
+                // BGR order: index [0]=Blue, [1]=Green, [2]=Red -> upload user's channels swapped.
+                shader_->set("rgb_levels_min_input[0]", static_cast<float>(rl.b.min_input));
+                shader_->set("rgb_levels_min_input[1]", static_cast<float>(rl.g.min_input));
+                shader_->set("rgb_levels_min_input[2]", static_cast<float>(rl.r.min_input));
+                shader_->set("rgb_levels_max_input[0]", static_cast<float>(rl.b.max_input));
+                shader_->set("rgb_levels_max_input[1]", static_cast<float>(rl.g.max_input));
+                shader_->set("rgb_levels_max_input[2]", static_cast<float>(rl.r.max_input));
+                shader_->set("rgb_levels_gamma[0]", static_cast<float>(rl.b.gamma));
+                shader_->set("rgb_levels_gamma[1]", static_cast<float>(rl.g.gamma));
+                shader_->set("rgb_levels_gamma[2]", static_cast<float>(rl.r.gamma));
+                shader_->set("rgb_levels_min_output[0]", static_cast<float>(rl.b.min_output));
+                shader_->set("rgb_levels_min_output[1]", static_cast<float>(rl.g.min_output));
+                shader_->set("rgb_levels_min_output[2]", static_cast<float>(rl.r.min_output));
+                shader_->set("rgb_levels_max_output[0]", static_cast<float>(rl.b.max_output));
+                shader_->set("rgb_levels_max_output[1]", static_cast<float>(rl.g.max_output));
+                shader_->set("rgb_levels_max_output[2]", static_cast<float>(rl.r.max_output));
+            } else {
+                shader_->set("rgb_levels_enable", false);
+            }
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -289,6 +289,61 @@ struct image_kernel::impl
             shader_->set("csb", false);
         }
 
+        // Gamut compression (ACES 1.3 Reference Gamut Compress)
+        if (transforms.image_transform.gamut_compress) {
+            shader_->set("gamut_compress_enable", true);
+            // BGR order: .r=Blue(yellow), .g=Green(magenta), .b=Red(cyan)
+            shader_->set("gc_limit",
+                         static_cast<float>(transforms.image_transform.gc_cyan),
+                         static_cast<float>(transforms.image_transform.gc_magenta),
+                         static_cast<float>(transforms.image_transform.gc_yellow));
+        } else {
+            shader_->set("gamut_compress_enable", false);
+        }
+
+        // Secondary qualifier (HSL key + grade)
+        if (transforms.image_transform.qualifier_enable) {
+            shader_->set("qualifier_enable", true);
+            shader_->set("qual_target_hue", static_cast<float>(transforms.image_transform.qual_target_hue));
+            shader_->set("qual_hue_width", static_cast<float>(transforms.image_transform.qual_hue_width));
+            shader_->set("qual_min_sat", static_cast<float>(transforms.image_transform.qual_min_sat));
+            shader_->set("qual_max_sat", static_cast<float>(transforms.image_transform.qual_max_sat));
+            shader_->set("qual_min_lum", static_cast<float>(transforms.image_transform.qual_min_lum));
+            shader_->set("qual_max_lum", static_cast<float>(transforms.image_transform.qual_max_lum));
+            shader_->set("qual_softness", static_cast<float>(transforms.image_transform.qual_softness));
+            shader_->set("qual_exposure", static_cast<float>(transforms.image_transform.qual_exposure));
+            shader_->set("qual_sat_offset", static_cast<float>(transforms.image_transform.qual_sat_offset));
+            shader_->set("qual_hue_offset", static_cast<float>(transforms.image_transform.qual_hue_offset));
+        } else {
+            shader_->set("qualifier_enable", false);
+        }
+
+        // Per-channel RGB levels
+        {
+            const auto& rl = transforms.image_transform.per_channel_levels;
+            if (rl.enable) {
+                shader_->set("rgb_levels_enable", true);
+                // BGR order: index [0]=Blue, [1]=Green, [2]=Red -> upload user's channels swapped.
+                shader_->set("rgb_levels_min_input[0]", static_cast<float>(rl.b.min_input));
+                shader_->set("rgb_levels_min_input[1]", static_cast<float>(rl.g.min_input));
+                shader_->set("rgb_levels_min_input[2]", static_cast<float>(rl.r.min_input));
+                shader_->set("rgb_levels_max_input[0]", static_cast<float>(rl.b.max_input));
+                shader_->set("rgb_levels_max_input[1]", static_cast<float>(rl.g.max_input));
+                shader_->set("rgb_levels_max_input[2]", static_cast<float>(rl.r.max_input));
+                shader_->set("rgb_levels_gamma[0]", static_cast<float>(rl.b.gamma));
+                shader_->set("rgb_levels_gamma[1]", static_cast<float>(rl.g.gamma));
+                shader_->set("rgb_levels_gamma[2]", static_cast<float>(rl.r.gamma));
+                shader_->set("rgb_levels_min_output[0]", static_cast<float>(rl.b.min_output));
+                shader_->set("rgb_levels_min_output[1]", static_cast<float>(rl.g.min_output));
+                shader_->set("rgb_levels_min_output[2]", static_cast<float>(rl.r.min_output));
+                shader_->set("rgb_levels_max_output[0]", static_cast<float>(rl.b.max_output));
+                shader_->set("rgb_levels_max_output[1]", static_cast<float>(rl.g.max_output));
+                shader_->set("rgb_levels_max_output[2]", static_cast<float>(rl.r.max_output));
+            } else {
+                shader_->set("rgb_levels_enable", false);
+            }
+        }
+
         // White balance (temperature / tint)
         if (std::abs(transforms.image_transform.temperature) > epsilon ||
             std::abs(transforms.image_transform.tint) > epsilon) {
@@ -373,61 +428,6 @@ struct image_kernel::impl
                 shader_->set("cdl_saturation", static_cast<float>(cs));
             } else {
                 shader_->set("cdl_enable", false);
-            }
-        }
-
-        // Gamut compression (ACES 1.3 Reference Gamut Compress)
-        if (transforms.image_transform.gamut_compress) {
-            shader_->set("gamut_compress_enable", true);
-            // BGR order: .r=Blue(yellow), .g=Green(magenta), .b=Red(cyan)
-            shader_->set("gc_limit",
-                         static_cast<float>(transforms.image_transform.gc_yellow),
-                         static_cast<float>(transforms.image_transform.gc_magenta),
-                         static_cast<float>(transforms.image_transform.gc_cyan));
-        } else {
-            shader_->set("gamut_compress_enable", false);
-        }
-
-        // Secondary qualifier (HSL key + grade)
-        if (transforms.image_transform.qualifier_enable) {
-            shader_->set("qualifier_enable", true);
-            shader_->set("qual_target_hue", static_cast<float>(transforms.image_transform.qual_target_hue));
-            shader_->set("qual_hue_width", static_cast<float>(transforms.image_transform.qual_hue_width));
-            shader_->set("qual_min_sat", static_cast<float>(transforms.image_transform.qual_min_sat));
-            shader_->set("qual_max_sat", static_cast<float>(transforms.image_transform.qual_max_sat));
-            shader_->set("qual_min_lum", static_cast<float>(transforms.image_transform.qual_min_lum));
-            shader_->set("qual_max_lum", static_cast<float>(transforms.image_transform.qual_max_lum));
-            shader_->set("qual_softness", static_cast<float>(transforms.image_transform.qual_softness));
-            shader_->set("qual_exposure", static_cast<float>(transforms.image_transform.qual_exposure));
-            shader_->set("qual_sat_offset", static_cast<float>(transforms.image_transform.qual_sat_offset));
-            shader_->set("qual_hue_offset", static_cast<float>(transforms.image_transform.qual_hue_offset));
-        } else {
-            shader_->set("qualifier_enable", false);
-        }
-
-        // Per-channel RGB levels
-        {
-            const auto& rl = transforms.image_transform.per_channel_levels;
-            if (rl.enable) {
-                shader_->set("rgb_levels_enable", true);
-                // BGR order: index [0]=Blue, [1]=Green, [2]=Red -> upload user's channels swapped.
-                shader_->set("rgb_levels_min_input[0]", static_cast<float>(rl.b.min_input));
-                shader_->set("rgb_levels_min_input[1]", static_cast<float>(rl.g.min_input));
-                shader_->set("rgb_levels_min_input[2]", static_cast<float>(rl.r.min_input));
-                shader_->set("rgb_levels_max_input[0]", static_cast<float>(rl.b.max_input));
-                shader_->set("rgb_levels_max_input[1]", static_cast<float>(rl.g.max_input));
-                shader_->set("rgb_levels_max_input[2]", static_cast<float>(rl.r.max_input));
-                shader_->set("rgb_levels_gamma[0]", static_cast<float>(rl.b.gamma));
-                shader_->set("rgb_levels_gamma[1]", static_cast<float>(rl.g.gamma));
-                shader_->set("rgb_levels_gamma[2]", static_cast<float>(rl.r.gamma));
-                shader_->set("rgb_levels_min_output[0]", static_cast<float>(rl.b.min_output));
-                shader_->set("rgb_levels_min_output[1]", static_cast<float>(rl.g.min_output));
-                shader_->set("rgb_levels_min_output[2]", static_cast<float>(rl.r.min_output));
-                shader_->set("rgb_levels_max_output[0]", static_cast<float>(rl.b.max_output));
-                shader_->set("rgb_levels_max_output[1]", static_cast<float>(rl.g.max_output));
-                shader_->set("rgb_levels_max_output[2]", static_cast<float>(rl.r.max_output));
-            } else {
-                shader_->set("rgb_levels_enable", false);
             }
         }
 

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -324,21 +324,21 @@ struct image_kernel::impl
             if (rl.enable) {
                 shader_->set("rgb_levels_enable", true);
                 // BGR order: index [0]=Blue, [1]=Green, [2]=Red -> upload user's channels swapped.
-                shader_->set("rgb_levels_min_input[0]", static_cast<float>(rl.b.min_input));
+                shader_->set("rgb_levels_min_input[0]", static_cast<float>(rl.r.min_input));
                 shader_->set("rgb_levels_min_input[1]", static_cast<float>(rl.g.min_input));
-                shader_->set("rgb_levels_min_input[2]", static_cast<float>(rl.r.min_input));
-                shader_->set("rgb_levels_max_input[0]", static_cast<float>(rl.b.max_input));
+                shader_->set("rgb_levels_min_input[2]", static_cast<float>(rl.b.min_input));
+                shader_->set("rgb_levels_max_input[0]", static_cast<float>(rl.r.max_input));
                 shader_->set("rgb_levels_max_input[1]", static_cast<float>(rl.g.max_input));
-                shader_->set("rgb_levels_max_input[2]", static_cast<float>(rl.r.max_input));
-                shader_->set("rgb_levels_gamma[0]", static_cast<float>(rl.b.gamma));
+                shader_->set("rgb_levels_max_input[2]", static_cast<float>(rl.b.max_input));
+                shader_->set("rgb_levels_gamma[0]", static_cast<float>(rl.r.gamma));
                 shader_->set("rgb_levels_gamma[1]", static_cast<float>(rl.g.gamma));
-                shader_->set("rgb_levels_gamma[2]", static_cast<float>(rl.r.gamma));
-                shader_->set("rgb_levels_min_output[0]", static_cast<float>(rl.b.min_output));
+                shader_->set("rgb_levels_gamma[2]", static_cast<float>(rl.b.gamma));
+                shader_->set("rgb_levels_min_output[0]", static_cast<float>(rl.r.min_output));
                 shader_->set("rgb_levels_min_output[1]", static_cast<float>(rl.g.min_output));
-                shader_->set("rgb_levels_min_output[2]", static_cast<float>(rl.r.min_output));
-                shader_->set("rgb_levels_max_output[0]", static_cast<float>(rl.b.max_output));
+                shader_->set("rgb_levels_min_output[2]", static_cast<float>(rl.b.min_output));
+                shader_->set("rgb_levels_max_output[0]", static_cast<float>(rl.r.max_output));
                 shader_->set("rgb_levels_max_output[1]", static_cast<float>(rl.g.max_output));
-                shader_->set("rgb_levels_max_output[2]", static_cast<float>(rl.r.max_output));
+                shader_->set("rgb_levels_max_output[2]", static_cast<float>(rl.b.max_output));
             } else {
                 shader_->set("rgb_levels_enable", false);
             }

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -289,7 +289,7 @@ struct image_kernel::impl
             shader_->set("csb", false);
         }
 
-        // Gamut compression (ACES 1.3 Reference Gamut Compress)
+        // Gamut compression, with ACES 1.3's limits
         if (transforms.image_transform.gamut_compress) {
             shader_->set("gamut_compress_enable", true);
             // BGR order: .r=Blue(yellow), .g=Green(magenta), .b=Red(cyan)

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -388,6 +388,23 @@ struct image_kernel::impl
             shader_->set("gamut_compress_enable", false);
         }
 
+        // Secondary qualifier (HSL key + grade)
+        if (transforms.image_transform.qualifier_enable) {
+            shader_->set("qualifier_enable", true);
+            shader_->set("qual_target_hue", static_cast<float>(transforms.image_transform.qual_target_hue));
+            shader_->set("qual_hue_width", static_cast<float>(transforms.image_transform.qual_hue_width));
+            shader_->set("qual_min_sat", static_cast<float>(transforms.image_transform.qual_min_sat));
+            shader_->set("qual_max_sat", static_cast<float>(transforms.image_transform.qual_max_sat));
+            shader_->set("qual_min_lum", static_cast<float>(transforms.image_transform.qual_min_lum));
+            shader_->set("qual_max_lum", static_cast<float>(transforms.image_transform.qual_max_lum));
+            shader_->set("qual_softness", static_cast<float>(transforms.image_transform.qual_softness));
+            shader_->set("qual_exposure", static_cast<float>(transforms.image_transform.qual_exposure));
+            shader_->set("qual_sat_offset", static_cast<float>(transforms.image_transform.qual_sat_offset));
+            shader_->set("qual_hue_offset", static_cast<float>(transforms.image_transform.qual_hue_offset));
+        } else {
+            shader_->set("qualifier_enable", false);
+        }
+
         // Setup drawing area
 
         GL(glViewport(0, 0, params.background->width(), params.background->height()));

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,7 +43,7 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
-// Gamut compression (ACES 1.3 Reference Gamut Compress)
+// Gamut compression, with ACES 1.3's limits
 uniform bool		gamut_compress_enable;
 // Per-channel limits in RGB order (cyan=red, magenta=green, yellow=blue).
 uniform vec3		gc_limit;
@@ -590,9 +590,12 @@ vec4 get_rgba_color()
     return vec4(0.0, 0.0, 0.0, 0.0);
 }
 
-// ---- Gamut Compression (ACES 1.3 Reference Gamut Compress) ----
+// ---- Gamut Compression ----
 // Compresses out-of-gamut values toward the achromatic axis using a smooth
 // toe function.  Operates per-channel on the distance from achromatic.
+// An approximation with ACES 1.3's limits, not the ACES algorithm: one threshold
+// rather than three, a rational curve rather than the power form, and all-negative
+// pixels left untouched.
 vec3 apply_gamut_compress(vec3 c, vec3 lim)
 {
     float achromatic = max(max(c.r, c.g), max(c.b, 0.0));

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -715,7 +715,12 @@ vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_
                      float min_l, float max_l, float soft, float exp_off,
                      float sat_off, float hue_off)
 {
-    vec3  hsv      = rgb2hsv(clamp(c, 0.0, 1.0));
+    // c is BGR here -- this backend carries the pixel through grading in the mixer's
+    // native BGR channel order, as gc_limit above and ContrastSaturationBrightness
+    // already account for. rgb2hsv treats its first component as red, so feeding it
+    // unswizzled puts the pixel's hue on the opposite side of the wheel from the
+    // target the user asked for, and the qualifier keys the wrong colour entirely.
+    vec3  hsv      = rgb2hsv(clamp(c.bgr, 0.0, 1.0));
     float hue_dist = AngleDiff(hsv.x, tgt_hue) * 2.0;
     float hue_mask = 1.0 - smoothstep(hue_w - soft, hue_w + soft, hue_dist);
     float sat_mask = smoothstep(min_s - soft, min_s + soft, hsv.y) *
@@ -727,14 +732,16 @@ vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_
         return c;
     vec3 graded = c;
     graded *= (1.0 + exp_off);
-    float glum = dot(graded, vec3(0.2126, 0.7152, 0.0722));
+    // .bgr for the same reason: unswizzled, this applies red's Rec.709 coefficient to
+    // blue and blue's to red. Greys are unaffected, so only saturated colour was wrong.
+    float glum = dot(graded.bgr, vec3(0.2126, 0.7152, 0.0722));
     graded     = mix(vec3(glum), graded, 1.0 + sat_off);
     if (abs(hue_off) > 0.01) {
         // HDR-safe hue rotation: normalise by peak, rotate, re-scale.
         float peak = max(max(graded.r, graded.g), max(graded.b, 0.0001));
-        vec3  ghsv = rgb2hsv(clamp(graded / peak, 0.0, 1.0));
+        vec3  ghsv = rgb2hsv(clamp((graded / peak).bgr, 0.0, 1.0));
         ghsv.x     = fract(ghsv.x + hue_off / 360.0);
-        graded     = hsv2rgb(ghsv) * peak;
+        graded     = hsv2rgb(ghsv).bgr * peak;
     }
     return mix(c, graded, mask);
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -43,6 +43,9 @@ uniform float		chroma_softness;
 uniform float		chroma_spill_suppress;
 uniform float		chroma_spill_suppress_saturation;
 
+// Gamut compression (ACES 1.3 Reference Gamut Compress)
+uniform bool		gamut_compress_enable;
+uniform vec3		gc_limit; // .r=yellow(B) .g=magenta(G) .b=cyan(R) in BGR order
 // White balance (temperature / tint)
 uniform bool		white_balance;
 uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
@@ -664,6 +667,26 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
     return c;
 }
 
+// ---- Gamut Compression (ACES 1.3 Reference Gamut Compress) ----
+// Compresses out-of-gamut values toward the achromatic axis using a smooth
+// toe function.  Operates per-channel on the distance from achromatic.
+vec3 apply_gamut_compress(vec3 c, vec3 lim)
+{
+    float achromatic = max(max(c.r, c.g), max(c.b, 0.0));
+    if (achromatic <= 0.0)
+        return c;
+    vec3  dist = (achromatic - c) / abs(achromatic);
+    float thr  = 0.815;
+    for (int i = 0; i < 3; ++i) {
+        if (dist[i] > thr && lim[i] > 1.0001) {
+            float nd = (dist[i] - thr) / (lim[i] - thr);
+            float cd = nd / (1.0 + nd);
+            dist[i]  = thr + cd * (lim[i] - thr);
+        }
+    }
+    return achromatic - dist * abs(achromatic);
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -671,6 +694,8 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    if (gamut_compress_enable)
+        color.rgb = apply_gamut_compress(color.rgb, gc_limit);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -45,7 +45,30 @@ uniform float		chroma_spill_suppress_saturation;
 
 // Gamut compression (ACES 1.3 Reference Gamut Compress)
 uniform bool		gamut_compress_enable;
-uniform vec3		gc_limit; // .r=yellow(B) .g=magenta(G) .b=cyan(R) in BGR order
+// Per-channel limits in RGB order (cyan=red, magenta=green, yellow=blue).
+uniform vec3		gc_limit;
+
+// Secondary qualifier (HSL key + grade)
+uniform bool		qualifier_enable;
+uniform float		qual_target_hue;
+uniform float		qual_hue_width;
+uniform float		qual_min_sat;
+uniform float		qual_max_sat;
+uniform float		qual_min_lum;
+uniform float		qual_max_lum;
+uniform float		qual_softness;
+uniform float		qual_exposure;
+uniform float		qual_sat_offset;
+uniform float		qual_hue_offset;
+
+// Per-channel RGB Levels (independent levels per channel)
+uniform bool		rgb_levels_enable;
+uniform float		rgb_levels_min_input[3];
+uniform float		rgb_levels_max_input[3];
+uniform float		rgb_levels_gamma[3];
+uniform float		rgb_levels_min_output[3];
+uniform float		rgb_levels_max_output[3];
+
 // White balance (temperature / tint)
 uniform bool		white_balance;
 uniform float		wb_temperature; // -1 cool (blue) .. +1 warm (orange)
@@ -81,26 +104,15 @@ uniform vec3		cdl_offset;
 uniform vec3		cdl_power;
 uniform float		cdl_saturation;
 
-// Secondary qualifier (HSL key + grade)
-uniform bool		qualifier_enable;
-uniform float		qual_target_hue;
-uniform float		qual_hue_width;
-uniform float		qual_min_sat;
-uniform float		qual_max_sat;
-uniform float		qual_min_lum;
-uniform float		qual_max_lum;
-uniform float		qual_softness;
-uniform float		qual_exposure;
-uniform float		qual_sat_offset;
-uniform float		qual_hue_offset;
-
-// Per-channel RGB Levels (independent levels per channel)
-uniform bool		rgb_levels_enable;
-uniform float		rgb_levels_min_input[3];
-uniform float		rgb_levels_max_input[3];
-uniform float		rgb_levels_gamma[3];
-uniform float		rgb_levels_min_output[3];
-uniform float		rgb_levels_max_output[3];
+// Luma of the working colour, using the channel's own coefficients.
+//
+// luma_coeff is uploaded in RGB order and holds Rec.601, Rec.709 or Rec.2020 weights
+// depending on the source (image_kernel.cpp), so a grade no longer hard-codes Rec.709
+// and no longer disagrees with ContrastSaturationBrightness, which has always read this
+// uniform. The `.bgr` is the working-order swizzle described above -- dot(c.bgr, k) and
+// dot(c, k.bgr) are the same sum, and swizzling the three-element uniform rather than
+// the pixel keeps this the only place the order is mentioned.
+float working_luma(vec3 c) { return dot(c, luma_coeff.bgr); }
 
 /*
 ** Contrast, saturation, brightness
@@ -578,6 +590,78 @@ vec4 get_rgba_color()
     return vec4(0.0, 0.0, 0.0, 0.0);
 }
 
+// ---- Gamut Compression (ACES 1.3 Reference Gamut Compress) ----
+// Compresses out-of-gamut values toward the achromatic axis using a smooth
+// toe function.  Operates per-channel on the distance from achromatic.
+vec3 apply_gamut_compress(vec3 c, vec3 lim)
+{
+    float achromatic = max(max(c.r, c.g), max(c.b, 0.0));
+    if (achromatic <= 0.0)
+        return c;
+    vec3  dist = (achromatic - c) / abs(achromatic);
+    float thr  = 0.815;
+    for (int i = 0; i < 3; ++i) {
+        if (dist[i] > thr && lim[i] > 1.0001) {
+            float nd = (dist[i] - thr) / (lim[i] - thr);
+            float cd = nd / (1.0 + nd);
+            dist[i]  = thr + cd * (lim[i] - thr);
+        }
+    }
+    return achromatic - dist * abs(achromatic);
+}
+
+// ---- Secondary Qualifier (HSL key + grade) ----
+// Isolates a colour range and applies exposure/saturation/hue corrections only
+// to the qualified pixels, using soft masks for smooth transitions.
+vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_s,
+                     float min_l, float max_l, float soft, float exp_off,
+                     float sat_off, float hue_off)
+{
+    // c is BGR here -- this backend carries the pixel through grading in the mixer's
+    // native BGR channel order, as gc_limit above and ContrastSaturationBrightness
+    // already account for. rgb2hsv treats its first component as red, so feeding it
+    // unswizzled puts the pixel's hue on the opposite side of the wheel from the
+    // target the user asked for, and the qualifier keys the wrong colour entirely.
+    vec3  hsv      = rgb2hsv(clamp(c.bgr, 0.0, 1.0));
+    float hue_dist = AngleDiff(hsv.x, tgt_hue) * 2.0;
+    float hue_mask = 1.0 - smoothstep(hue_w - soft, hue_w + soft, hue_dist);
+    float sat_mask = smoothstep(min_s - soft, min_s + soft, hsv.y) *
+                     (1.0 - smoothstep(max_s - soft, max_s + soft, hsv.y));
+    float lum_mask = smoothstep(min_l - soft, min_l + soft, hsv.z) *
+                     (1.0 - smoothstep(max_l - soft, max_l + soft, hsv.z));
+    float mask     = hue_mask * sat_mask * lum_mask;
+    if (mask < 0.001)
+        return c;
+    vec3 graded = c;
+    graded *= (1.0 + exp_off);
+    float glum = working_luma(graded);
+    graded     = mix(vec3(glum), graded, 1.0 + sat_off);
+    if (abs(hue_off) > 0.01) {
+        // HDR-safe hue rotation: normalise by peak, rotate, re-scale.
+        float peak = max(max(graded.r, graded.g), max(graded.b, 0.0001));
+        vec3  ghsv = rgb2hsv(clamp((graded / peak).bgr, 0.0, 1.0));
+        ghsv.x     = fract(ghsv.x + hue_off / 360.0);
+        graded     = hsv2rgb(ghsv).bgr * peak;
+    }
+    return mix(c, graded, mask);
+}
+
+// ---- Per-channel RGB Levels ----
+// Independent input range, gamma, and output range per channel.
+vec3 apply_rgb_levels(vec3 c)
+{
+    c.r = clamp((c.r - rgb_levels_min_input[0]) / max(rgb_levels_max_input[0] - rgb_levels_min_input[0], 0.0001), 0.0, 1.0);
+    c.r = pow(c.r, 1.0 / max(rgb_levels_gamma[0], 0.01));
+    c.r = mix(rgb_levels_min_output[0], rgb_levels_max_output[0], c.r);
+    c.g = clamp((c.g - rgb_levels_min_input[1]) / max(rgb_levels_max_input[1] - rgb_levels_min_input[1], 0.0001), 0.0, 1.0);
+    c.g = pow(c.g, 1.0 / max(rgb_levels_gamma[1], 0.01));
+    c.g = mix(rgb_levels_min_output[1], rgb_levels_max_output[1], c.g);
+    c.b = clamp((c.b - rgb_levels_min_input[2]) / max(rgb_levels_max_input[2] - rgb_levels_min_input[2], 0.0001), 0.0, 1.0);
+    c.b = pow(c.b, 1.0 / max(rgb_levels_gamma[2], 0.01));
+    c.b = mix(rgb_levels_min_output[2], rgb_levels_max_output[2], c.b);
+    return c;
+}
+
 // ============================ Primary grading chain ============================
 //
 // CHANNEL ORDER. The colour vector carried through this shader is in BGR order:
@@ -598,15 +682,6 @@ vec4 get_rgba_color()
 // every channel-order defect in here. Test with asymmetric per-channel values.
 // ===============================================================================
 
-// Luma of the working colour, using the channel's own coefficients.
-//
-// luma_coeff is uploaded in RGB order and holds Rec.601, Rec.709 or Rec.2020 weights
-// depending on the source (image_kernel.cpp), so a grade no longer hard-codes Rec.709
-// and no longer disagrees with ContrastSaturationBrightness, which has always read this
-// uniform. The `.bgr` is the working-order swizzle described above -- dot(c.bgr, k) and
-// dot(c, k.bgr) are the same sum, and swizzling the three-element uniform rather than
-// the pixel keeps this the only place the order is mentioned.
-float working_luma(vec3 c) { return dot(c, luma_coeff.bgr); }
 
 // ---- White Balance ----
 // temp: -1=cool (blue), +1=warm (orange); tint_val: -1=magenta, +1=green.
@@ -688,80 +763,6 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
     return c;
 }
 
-// ---- Gamut Compression (ACES 1.3 Reference Gamut Compress) ----
-// Compresses out-of-gamut values toward the achromatic axis using a smooth
-// toe function.  Operates per-channel on the distance from achromatic.
-vec3 apply_gamut_compress(vec3 c, vec3 lim)
-{
-    float achromatic = max(max(c.r, c.g), max(c.b, 0.0));
-    if (achromatic <= 0.0)
-        return c;
-    vec3  dist = (achromatic - c) / abs(achromatic);
-    float thr  = 0.815;
-    for (int i = 0; i < 3; ++i) {
-        if (dist[i] > thr && lim[i] > 1.0001) {
-            float nd = (dist[i] - thr) / (lim[i] - thr);
-            float cd = nd / (1.0 + nd);
-            dist[i]  = thr + cd * (lim[i] - thr);
-        }
-    }
-    return achromatic - dist * abs(achromatic);
-}
-
-// ---- Secondary Qualifier (HSL key + grade) ----
-// Isolates a colour range and applies exposure/saturation/hue corrections only
-// to the qualified pixels, using soft masks for smooth transitions.
-vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_s,
-                     float min_l, float max_l, float soft, float exp_off,
-                     float sat_off, float hue_off)
-{
-    // c is BGR here -- this backend carries the pixel through grading in the mixer's
-    // native BGR channel order, as gc_limit above and ContrastSaturationBrightness
-    // already account for. rgb2hsv treats its first component as red, so feeding it
-    // unswizzled puts the pixel's hue on the opposite side of the wheel from the
-    // target the user asked for, and the qualifier keys the wrong colour entirely.
-    vec3  hsv      = rgb2hsv(clamp(c.bgr, 0.0, 1.0));
-    float hue_dist = AngleDiff(hsv.x, tgt_hue) * 2.0;
-    float hue_mask = 1.0 - smoothstep(hue_w - soft, hue_w + soft, hue_dist);
-    float sat_mask = smoothstep(min_s - soft, min_s + soft, hsv.y) *
-                     (1.0 - smoothstep(max_s - soft, max_s + soft, hsv.y));
-    float lum_mask = smoothstep(min_l - soft, min_l + soft, hsv.z) *
-                     (1.0 - smoothstep(max_l - soft, max_l + soft, hsv.z));
-    float mask     = hue_mask * sat_mask * lum_mask;
-    if (mask < 0.001)
-        return c;
-    vec3 graded = c;
-    graded *= (1.0 + exp_off);
-    // .bgr for the same reason: unswizzled, this applies red's Rec.709 coefficient to
-    // blue and blue's to red. Greys are unaffected, so only saturated colour was wrong.
-    float glum = dot(graded.bgr, vec3(0.2126, 0.7152, 0.0722));
-    graded     = mix(vec3(glum), graded, 1.0 + sat_off);
-    if (abs(hue_off) > 0.01) {
-        // HDR-safe hue rotation: normalise by peak, rotate, re-scale.
-        float peak = max(max(graded.r, graded.g), max(graded.b, 0.0001));
-        vec3  ghsv = rgb2hsv(clamp((graded / peak).bgr, 0.0, 1.0));
-        ghsv.x     = fract(ghsv.x + hue_off / 360.0);
-        graded     = hsv2rgb(ghsv).bgr * peak;
-    }
-    return mix(c, graded, mask);
-}
-
-// ---- Per-channel RGB Levels ----
-// Independent input range, gamma, and output range per channel.
-vec3 apply_rgb_levels(vec3 c)
-{
-    c.r = clamp((c.r - rgb_levels_min_input[0]) / max(rgb_levels_max_input[0] - rgb_levels_min_input[0], 0.0001), 0.0, 1.0);
-    c.r = pow(c.r, 1.0 / max(rgb_levels_gamma[0], 0.01));
-    c.r = mix(rgb_levels_min_output[0], rgb_levels_max_output[0], c.r);
-    c.g = clamp((c.g - rgb_levels_min_input[1]) / max(rgb_levels_max_input[1] - rgb_levels_min_input[1], 0.0001), 0.0, 1.0);
-    c.g = pow(c.g, 1.0 / max(rgb_levels_gamma[1], 0.01));
-    c.g = mix(rgb_levels_min_output[1], rgb_levels_max_output[1], c.g);
-    c.b = clamp((c.b - rgb_levels_min_input[2]) / max(rgb_levels_max_input[2] - rgb_levels_min_input[2], 0.0001), 0.0, 1.0);
-    c.b = pow(c.b, 1.0 / max(rgb_levels_gamma[2], 0.01));
-    c.b = mix(rgb_levels_min_output[2], rgb_levels_max_output[2], c.b);
-    return c;
-}
-
 void main()
 {
     vec4 color = get_rgba_color();
@@ -769,14 +770,9 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    // Before the primaries, so the rest of the chain sees in-gamut colour.
     if (gamut_compress_enable)
-        color.rgb = apply_gamut_compress(color.rgb, gc_limit);
-    if (qualifier_enable)
-        color.rgb = apply_qualifier(color.rgb, qual_target_hue, qual_hue_width,
-                                    qual_min_sat, qual_max_sat, qual_min_lum, qual_max_lum,
-                                    qual_softness, qual_exposure, qual_sat_offset, qual_hue_offset);
-    if (rgb_levels_enable)
-        color.rgb = apply_rgb_levels(color.rgb);
+        color.rgb = apply_gamut_compress(color.rgb, gc_limit.bgr);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)
@@ -792,6 +788,13 @@ void main()
     if (split_tone_enable)
         color.rgb =
             apply_split_tone(color.rgb, split_shadow_color.bgr, split_highlight_color.bgr, split_balance);
+    // Secondary: keys the already-graded image.
+    if (qualifier_enable)
+        color.rgb = apply_qualifier(color.rgb, qual_target_hue, qual_hue_width,
+                                    qual_min_sat, qual_max_sat, qual_min_lum, qual_max_lum,
+                                    qual_softness, qual_exposure, qual_sat_offset, qual_hue_offset);
+    if (rgb_levels_enable)
+        color.rgb = apply_rgb_levels(color.rgb);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -81,6 +81,19 @@ uniform vec3		cdl_offset;
 uniform vec3		cdl_power;
 uniform float		cdl_saturation;
 
+// Secondary qualifier (HSL key + grade)
+uniform bool		qualifier_enable;
+uniform float		qual_target_hue;
+uniform float		qual_hue_width;
+uniform float		qual_min_sat;
+uniform float		qual_max_sat;
+uniform float		qual_min_lum;
+uniform float		qual_max_lum;
+uniform float		qual_softness;
+uniform float		qual_exposure;
+uniform float		qual_sat_offset;
+uniform float		qual_hue_offset;
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -687,6 +700,37 @@ vec3 apply_gamut_compress(vec3 c, vec3 lim)
     return achromatic - dist * abs(achromatic);
 }
 
+// ---- Secondary Qualifier (HSL key + grade) ----
+// Isolates a colour range and applies exposure/saturation/hue corrections only
+// to the qualified pixels, using soft masks for smooth transitions.
+vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_s,
+                     float min_l, float max_l, float soft, float exp_off,
+                     float sat_off, float hue_off)
+{
+    vec3  hsv      = rgb2hsv(clamp(c, 0.0, 1.0));
+    float hue_dist = AngleDiff(hsv.x, tgt_hue) * 2.0;
+    float hue_mask = 1.0 - smoothstep(hue_w - soft, hue_w + soft, hue_dist);
+    float sat_mask = smoothstep(min_s - soft, min_s + soft, hsv.y) *
+                     (1.0 - smoothstep(max_s - soft, max_s + soft, hsv.y));
+    float lum_mask = smoothstep(min_l - soft, min_l + soft, hsv.z) *
+                     (1.0 - smoothstep(max_l - soft, max_l + soft, hsv.z));
+    float mask     = hue_mask * sat_mask * lum_mask;
+    if (mask < 0.001)
+        return c;
+    vec3 graded = c;
+    graded *= (1.0 + exp_off);
+    float glum = dot(graded, vec3(0.2126, 0.7152, 0.0722));
+    graded     = mix(vec3(glum), graded, 1.0 + sat_off);
+    if (abs(hue_off) > 0.01) {
+        // HDR-safe hue rotation: normalise by peak, rotate, re-scale.
+        float peak = max(max(graded.r, graded.g), max(graded.b, 0.0001));
+        vec3  ghsv = rgb2hsv(clamp(graded / peak, 0.0, 1.0));
+        ghsv.x     = fract(ghsv.x + hue_off / 360.0);
+        graded     = hsv2rgb(ghsv) * peak;
+    }
+    return mix(c, graded, mask);
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -696,6 +740,10 @@ void main()
         color = chroma_key(color);
     if (gamut_compress_enable)
         color.rgb = apply_gamut_compress(color.rgb, gc_limit);
+    if (qualifier_enable)
+        color.rgb = apply_qualifier(color.rgb, qual_target_hue, qual_hue_width,
+                                    qual_min_sat, qual_max_sat, qual_min_lum, qual_max_lum,
+                                    qual_softness, qual_exposure, qual_sat_offset, qual_hue_offset);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -94,6 +94,14 @@ uniform float		qual_exposure;
 uniform float		qual_sat_offset;
 uniform float		qual_hue_offset;
 
+// Per-channel RGB Levels (independent levels per channel)
+uniform bool		rgb_levels_enable;
+uniform float		rgb_levels_min_input[3];
+uniform float		rgb_levels_max_input[3];
+uniform float		rgb_levels_gamma[3];
+uniform float		rgb_levels_min_output[3];
+uniform float		rgb_levels_max_output[3];
+
 /*
 ** Contrast, saturation, brightness
 ** Code of this function is from TGM's shader pack
@@ -731,6 +739,22 @@ vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_
     return mix(c, graded, mask);
 }
 
+// ---- Per-channel RGB Levels ----
+// Independent input range, gamma, and output range per channel.
+vec3 apply_rgb_levels(vec3 c)
+{
+    c.r = clamp((c.r - rgb_levels_min_input[0]) / max(rgb_levels_max_input[0] - rgb_levels_min_input[0], 0.0001), 0.0, 1.0);
+    c.r = pow(c.r, 1.0 / max(rgb_levels_gamma[0], 0.01));
+    c.r = mix(rgb_levels_min_output[0], rgb_levels_max_output[0], c.r);
+    c.g = clamp((c.g - rgb_levels_min_input[1]) / max(rgb_levels_max_input[1] - rgb_levels_min_input[1], 0.0001), 0.0, 1.0);
+    c.g = pow(c.g, 1.0 / max(rgb_levels_gamma[1], 0.01));
+    c.g = mix(rgb_levels_min_output[1], rgb_levels_max_output[1], c.g);
+    c.b = clamp((c.b - rgb_levels_min_input[2]) / max(rgb_levels_max_input[2] - rgb_levels_min_input[2], 0.0001), 0.0, 1.0);
+    c.b = pow(c.b, 1.0 / max(rgb_levels_gamma[2], 0.01));
+    c.b = mix(rgb_levels_min_output[2], rgb_levels_max_output[2], c.b);
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -744,6 +768,8 @@ void main()
         color.rgb = apply_qualifier(color.rgb, qual_target_hue, qual_hue_width,
                                     qual_min_sat, qual_max_sat, qual_min_lum, qual_max_lum,
                                     qual_softness, qual_exposure, qual_sat_offset, qual_hue_offset);
+    if (rgb_levels_enable)
+        color.rgb = apply_rgb_levels(color.rgb);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -648,17 +648,19 @@ vec3 apply_qualifier(vec3 c, float tgt_hue, float hue_w, float min_s, float max_
 
 // ---- Per-channel RGB Levels ----
 // Independent input range, gamma, and output range per channel.
+// Uniforms are in RGB order; the working vector is BGR, so each channel reads its
+// own RGB slot: c.r (blue) -> [2], c.g -> [1], c.b (red) -> [0].
 vec3 apply_rgb_levels(vec3 c)
 {
-    c.r = clamp((c.r - rgb_levels_min_input[0]) / max(rgb_levels_max_input[0] - rgb_levels_min_input[0], 0.0001), 0.0, 1.0);
-    c.r = pow(c.r, 1.0 / max(rgb_levels_gamma[0], 0.01));
-    c.r = mix(rgb_levels_min_output[0], rgb_levels_max_output[0], c.r);
+    c.r = clamp((c.r - rgb_levels_min_input[2]) / max(rgb_levels_max_input[2] - rgb_levels_min_input[2], 0.0001), 0.0, 1.0);
+    c.r = pow(c.r, 1.0 / max(rgb_levels_gamma[2], 0.01));
+    c.r = mix(rgb_levels_min_output[2], rgb_levels_max_output[2], c.r);
     c.g = clamp((c.g - rgb_levels_min_input[1]) / max(rgb_levels_max_input[1] - rgb_levels_min_input[1], 0.0001), 0.0, 1.0);
     c.g = pow(c.g, 1.0 / max(rgb_levels_gamma[1], 0.01));
     c.g = mix(rgb_levels_min_output[1], rgb_levels_max_output[1], c.g);
-    c.b = clamp((c.b - rgb_levels_min_input[2]) / max(rgb_levels_max_input[2] - rgb_levels_min_input[2], 0.0001), 0.0, 1.0);
-    c.b = pow(c.b, 1.0 / max(rgb_levels_gamma[2], 0.01));
-    c.b = mix(rgb_levels_min_output[2], rgb_levels_max_output[2], c.b);
+    c.b = clamp((c.b - rgb_levels_min_input[0]) / max(rgb_levels_max_input[0] - rgb_levels_min_input[0], 0.0001), 0.0, 1.0);
+    c.b = pow(c.b, 1.0 / max(rgb_levels_gamma[0], 0.01));
+    c.b = mix(rgb_levels_min_output[0], rgb_levels_max_output[0], c.b);
     return c;
 }
 

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -94,6 +94,21 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.qual_sat_offset  = other.qual_sat_offset;
         self.qual_hue_offset  = other.qual_hue_offset;
     }
+
+    // Per-channel RGB levels: intersect input range, multiply gamma, intersect output range
+    if (other.per_channel_levels.enable) {
+        self.per_channel_levels.enable = true;
+        auto merge_ch = [](core::rgb_levels_channel& s, const core::rgb_levels_channel& o) {
+            s.min_input  = std::max(s.min_input, o.min_input);
+            s.max_input  = std::min(s.max_input, o.max_input);
+            s.gamma     *= o.gamma;
+            s.min_output = std::max(s.min_output, o.min_output);
+            s.max_output = std::min(s.max_output, o.max_output);
+        };
+        merge_ch(self.per_channel_levels.r, other.per_channel_levels.r);
+        merge_ch(self.per_channel_levels.g, other.per_channel_levels.g);
+        merge_ch(self.per_channel_levels.b, other.per_channel_levels.b);
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -79,6 +79,21 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.gc_magenta     = other.gc_magenta;
         self.gc_yellow      = other.gc_yellow;
     }
+
+    // Secondary qualifier
+    if (other.qualifier_enable) {
+        self.qualifier_enable = true;
+        self.qual_target_hue  = other.qual_target_hue;
+        self.qual_hue_width   = other.qual_hue_width;
+        self.qual_min_sat     = other.qual_min_sat;
+        self.qual_max_sat     = other.qual_max_sat;
+        self.qual_min_lum     = other.qual_min_lum;
+        self.qual_max_lum     = other.qual_max_lum;
+        self.qual_softness    = other.qual_softness;
+        self.qual_exposure    = other.qual_exposure;
+        self.qual_sat_offset  = other.qual_sat_offset;
+        self.qual_hue_offset  = other.qual_hue_offset;
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -72,6 +72,13 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
 
+    // Gamut compression
+    if (other.gamut_compress) {
+        self.gamut_compress = true;
+        self.gc_cyan        = other.gc_cyan;
+        self.gc_magenta     = other.gc_magenta;
+        self.gc_yellow      = other.gc_yellow;
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -109,6 +109,7 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         merge_ch(self.per_channel_levels.g, other.per_channel_levels.g);
         merge_ch(self.per_channel_levels.b, other.per_channel_levels.b);
     }
+
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -113,29 +113,6 @@ image_transform image_transform::tween(double                 time,
     result.gc_cyan    = do_tween(time, source.gc_cyan, dest.gc_cyan, duration, tween);
     result.gc_magenta = do_tween(time, source.gc_magenta, dest.gc_magenta, duration, tween);
     result.gc_yellow  = do_tween(time, source.gc_yellow, dest.gc_yellow, duration, tween);
-    result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
-    result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
-    for (int i = 0; i < 3; ++i) {
-        result.lift[i]    = do_tween(time, source.lift[i], dest.lift[i], duration, tween);
-        result.midtone[i] = do_tween(time, source.midtone[i], dest.midtone[i], duration, tween);
-        result.gain[i]    = do_tween(time, source.gain[i], dest.gain[i], duration, tween);
-    }
-    result.hue_shift = do_tween(time, source.hue_shift, dest.hue_shift, duration, tween);
-    result.shadows    = do_tween(time, source.shadows, dest.shadows, duration, tween);
-    result.highlights = do_tween(time, source.highlights, dest.highlights, duration, tween);
-    for (int i = 0; i < 3; ++i) {
-        result.split_shadow_color[i] =
-            do_tween(time, source.split_shadow_color[i], dest.split_shadow_color[i], duration, tween);
-        result.split_highlight_color[i] =
-            do_tween(time, source.split_highlight_color[i], dest.split_highlight_color[i], duration, tween);
-    }
-    result.split_balance = do_tween(time, source.split_balance, dest.split_balance, duration, tween);
-    for (int i = 0; i < 3; ++i) {
-        result.cdl_slope[i]  = do_tween(time, source.cdl_slope[i], dest.cdl_slope[i], duration, tween);
-        result.cdl_offset[i] = do_tween(time, source.cdl_offset[i], dest.cdl_offset[i], duration, tween);
-        result.cdl_power[i]  = do_tween(time, source.cdl_power[i], dest.cdl_power[i], duration, tween);
-    }
-    result.cdl_saturation = do_tween(time, source.cdl_saturation, dest.cdl_saturation, duration, tween);
 
     result.qualifier_enable = dest.qualifier_enable;
     result.qual_target_hue  = do_tween(time, source.qual_target_hue, dest.qual_target_hue, duration, tween);
@@ -166,6 +143,30 @@ image_transform image_transform::tween(double                 time,
     result.per_channel_levels.b.gamma      = rl(source.per_channel_levels.b.gamma, dest.per_channel_levels.b.gamma);
     result.per_channel_levels.b.min_output = rl(source.per_channel_levels.b.min_output, dest.per_channel_levels.b.min_output);
     result.per_channel_levels.b.max_output = rl(source.per_channel_levels.b.max_output, dest.per_channel_levels.b.max_output);
+
+    result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
+    result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.lift[i]    = do_tween(time, source.lift[i], dest.lift[i], duration, tween);
+        result.midtone[i] = do_tween(time, source.midtone[i], dest.midtone[i], duration, tween);
+        result.gain[i]    = do_tween(time, source.gain[i], dest.gain[i], duration, tween);
+    }
+    result.hue_shift = do_tween(time, source.hue_shift, dest.hue_shift, duration, tween);
+    result.shadows    = do_tween(time, source.shadows, dest.shadows, duration, tween);
+    result.highlights = do_tween(time, source.highlights, dest.highlights, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.split_shadow_color[i] =
+            do_tween(time, source.split_shadow_color[i], dest.split_shadow_color[i], duration, tween);
+        result.split_highlight_color[i] =
+            do_tween(time, source.split_highlight_color[i], dest.split_highlight_color[i], duration, tween);
+    }
+    result.split_balance = do_tween(time, source.split_balance, dest.split_balance, duration, tween);
+    for (int i = 0; i < 3; ++i) {
+        result.cdl_slope[i]  = do_tween(time, source.cdl_slope[i], dest.cdl_slope[i], duration, tween);
+        result.cdl_offset[i] = do_tween(time, source.cdl_offset[i], dest.cdl_offset[i], duration, tween);
+        result.cdl_power[i]  = do_tween(time, source.cdl_power[i], dest.cdl_power[i], duration, tween);
+    }
+    result.cdl_saturation = do_tween(time, source.cdl_saturation, dest.cdl_saturation, duration, tween);
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -203,14 +204,33 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-               lhs.perspective == rhs.perspective && lhs.gamut_compress == rhs.gamut_compress &&
-               eq(lhs.gc_cyan, rhs.gc_cyan) && eq(lhs.gc_magenta, rhs.gc_magenta) &&
-               eq(lhs.gc_yellow, rhs.gc_yellow) && lhs.qualifier_enable == rhs.qualifier_enable &&
-               eq(lhs.qual_target_hue, rhs.qual_target_hue) && eq(lhs.qual_hue_width, rhs.qual_hue_width) &&
-               eq(lhs.qual_min_sat, rhs.qual_min_sat) && eq(lhs.qual_max_sat, rhs.qual_max_sat) &&
-               eq(lhs.qual_min_lum, rhs.qual_min_lum) && eq(lhs.qual_max_lum, rhs.qual_max_lum) &&
-               eq(lhs.qual_softness, rhs.qual_softness) && eq(lhs.qual_exposure, rhs.qual_exposure) &&
-               eq(lhs.qual_sat_offset, rhs.qual_sat_offset) && eq(lhs.qual_hue_offset, rhs.qual_hue_offset) &&
+               lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
+               eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
+               boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
+               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
+               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
+               boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
+               boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
+               eq(lhs.split_balance, rhs.split_balance) &&
+               boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
+               boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
+               boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
+               eq(lhs.cdl_saturation, rhs.cdl_saturation) &&
+               lhs.gamut_compress == rhs.gamut_compress &&
+               eq(lhs.gc_cyan, rhs.gc_cyan) &&
+               eq(lhs.gc_magenta, rhs.gc_magenta) &&
+               eq(lhs.gc_yellow, rhs.gc_yellow) &&
+               lhs.qualifier_enable == rhs.qualifier_enable &&
+               eq(lhs.qual_target_hue, rhs.qual_target_hue) &&
+               eq(lhs.qual_hue_width, rhs.qual_hue_width) &&
+               eq(lhs.qual_min_sat, rhs.qual_min_sat) &&
+               eq(lhs.qual_max_sat, rhs.qual_max_sat) &&
+               eq(lhs.qual_min_lum, rhs.qual_min_lum) &&
+               eq(lhs.qual_max_lum, rhs.qual_max_lum) &&
+               eq(lhs.qual_softness, rhs.qual_softness) &&
+               eq(lhs.qual_exposure, rhs.qual_exposure) &&
+               eq(lhs.qual_sat_offset, rhs.qual_sat_offset) &&
+               eq(lhs.qual_hue_offset, rhs.qual_hue_offset) &&
                lhs.per_channel_levels.enable == rhs.per_channel_levels.enable &&
                eq(lhs.per_channel_levels.r.min_input, rhs.per_channel_levels.r.min_input) &&
                eq(lhs.per_channel_levels.r.max_input, rhs.per_channel_levels.r.max_input) &&
@@ -227,20 +247,6 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.per_channel_levels.b.gamma, rhs.per_channel_levels.b.gamma) &&
                eq(lhs.per_channel_levels.b.min_output, rhs.per_channel_levels.b.min_output) &&
                eq(lhs.per_channel_levels.b.max_output, rhs.per_channel_levels.b.max_output) ||
-               eq(lhs.qual_sat_offset, rhs.qual_sat_offset) && eq(lhs.qual_hue_offset, rhs.qual_hue_offset) ||
-               eq(lhs.gc_yellow, rhs.gc_yellow) ||
-               lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
-               eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
-               boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
-               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
-               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
-               boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
-               boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
-               eq(lhs.split_balance, rhs.split_balance) &&
-               boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
-               boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
-               boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
-               eq(lhs.cdl_saturation, rhs.cdl_saturation) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -149,6 +149,24 @@ image_transform image_transform::tween(double                 time,
     result.qual_sat_offset  = do_tween(time, source.qual_sat_offset, dest.qual_sat_offset, duration, tween);
     result.qual_hue_offset  = do_tween(time, source.qual_hue_offset, dest.qual_hue_offset, duration, tween);
 
+    auto rl = [&](double s, double d) { return do_tween(time, s, d, duration, tween); };
+    result.per_channel_levels.enable       = dest.per_channel_levels.enable;
+    result.per_channel_levels.r.min_input  = rl(source.per_channel_levels.r.min_input, dest.per_channel_levels.r.min_input);
+    result.per_channel_levels.r.max_input  = rl(source.per_channel_levels.r.max_input, dest.per_channel_levels.r.max_input);
+    result.per_channel_levels.r.gamma      = rl(source.per_channel_levels.r.gamma, dest.per_channel_levels.r.gamma);
+    result.per_channel_levels.r.min_output = rl(source.per_channel_levels.r.min_output, dest.per_channel_levels.r.min_output);
+    result.per_channel_levels.r.max_output = rl(source.per_channel_levels.r.max_output, dest.per_channel_levels.r.max_output);
+    result.per_channel_levels.g.min_input  = rl(source.per_channel_levels.g.min_input, dest.per_channel_levels.g.min_input);
+    result.per_channel_levels.g.max_input  = rl(source.per_channel_levels.g.max_input, dest.per_channel_levels.g.max_input);
+    result.per_channel_levels.g.gamma      = rl(source.per_channel_levels.g.gamma, dest.per_channel_levels.g.gamma);
+    result.per_channel_levels.g.min_output = rl(source.per_channel_levels.g.min_output, dest.per_channel_levels.g.min_output);
+    result.per_channel_levels.g.max_output = rl(source.per_channel_levels.g.max_output, dest.per_channel_levels.g.max_output);
+    result.per_channel_levels.b.min_input  = rl(source.per_channel_levels.b.min_input, dest.per_channel_levels.b.min_input);
+    result.per_channel_levels.b.max_input  = rl(source.per_channel_levels.b.max_input, dest.per_channel_levels.b.max_input);
+    result.per_channel_levels.b.gamma      = rl(source.per_channel_levels.b.gamma, dest.per_channel_levels.b.gamma);
+    result.per_channel_levels.b.min_output = rl(source.per_channel_levels.b.min_output, dest.per_channel_levels.b.min_output);
+    result.per_channel_levels.b.max_output = rl(source.per_channel_levels.b.max_output, dest.per_channel_levels.b.max_output);
+
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
 
@@ -192,6 +210,23 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.qual_min_sat, rhs.qual_min_sat) && eq(lhs.qual_max_sat, rhs.qual_max_sat) &&
                eq(lhs.qual_min_lum, rhs.qual_min_lum) && eq(lhs.qual_max_lum, rhs.qual_max_lum) &&
                eq(lhs.qual_softness, rhs.qual_softness) && eq(lhs.qual_exposure, rhs.qual_exposure) &&
+               eq(lhs.qual_sat_offset, rhs.qual_sat_offset) && eq(lhs.qual_hue_offset, rhs.qual_hue_offset) &&
+               lhs.per_channel_levels.enable == rhs.per_channel_levels.enable &&
+               eq(lhs.per_channel_levels.r.min_input, rhs.per_channel_levels.r.min_input) &&
+               eq(lhs.per_channel_levels.r.max_input, rhs.per_channel_levels.r.max_input) &&
+               eq(lhs.per_channel_levels.r.gamma, rhs.per_channel_levels.r.gamma) &&
+               eq(lhs.per_channel_levels.r.min_output, rhs.per_channel_levels.r.min_output) &&
+               eq(lhs.per_channel_levels.r.max_output, rhs.per_channel_levels.r.max_output) &&
+               eq(lhs.per_channel_levels.g.min_input, rhs.per_channel_levels.g.min_input) &&
+               eq(lhs.per_channel_levels.g.max_input, rhs.per_channel_levels.g.max_input) &&
+               eq(lhs.per_channel_levels.g.gamma, rhs.per_channel_levels.g.gamma) &&
+               eq(lhs.per_channel_levels.g.min_output, rhs.per_channel_levels.g.min_output) &&
+               eq(lhs.per_channel_levels.g.max_output, rhs.per_channel_levels.g.max_output) &&
+               eq(lhs.per_channel_levels.b.min_input, rhs.per_channel_levels.b.min_input) &&
+               eq(lhs.per_channel_levels.b.max_input, rhs.per_channel_levels.b.max_input) &&
+               eq(lhs.per_channel_levels.b.gamma, rhs.per_channel_levels.b.gamma) &&
+               eq(lhs.per_channel_levels.b.min_output, rhs.per_channel_levels.b.min_output) &&
+               eq(lhs.per_channel_levels.b.max_output, rhs.per_channel_levels.b.max_output) ||
                eq(lhs.qual_sat_offset, rhs.qual_sat_offset) && eq(lhs.qual_hue_offset, rhs.qual_hue_offset) ||
                eq(lhs.gc_yellow, rhs.gc_yellow) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -137,6 +137,18 @@ image_transform image_transform::tween(double                 time,
     }
     result.cdl_saturation = do_tween(time, source.cdl_saturation, dest.cdl_saturation, duration, tween);
 
+    result.qualifier_enable = dest.qualifier_enable;
+    result.qual_target_hue  = do_tween(time, source.qual_target_hue, dest.qual_target_hue, duration, tween);
+    result.qual_hue_width   = do_tween(time, source.qual_hue_width, dest.qual_hue_width, duration, tween);
+    result.qual_min_sat     = do_tween(time, source.qual_min_sat, dest.qual_min_sat, duration, tween);
+    result.qual_max_sat     = do_tween(time, source.qual_max_sat, dest.qual_max_sat, duration, tween);
+    result.qual_min_lum     = do_tween(time, source.qual_min_lum, dest.qual_min_lum, duration, tween);
+    result.qual_max_lum     = do_tween(time, source.qual_max_lum, dest.qual_max_lum, duration, tween);
+    result.qual_softness    = do_tween(time, source.qual_softness, dest.qual_softness, duration, tween);
+    result.qual_exposure    = do_tween(time, source.qual_exposure, dest.qual_exposure, duration, tween);
+    result.qual_sat_offset  = do_tween(time, source.qual_sat_offset, dest.qual_sat_offset, duration, tween);
+    result.qual_hue_offset  = do_tween(time, source.qual_hue_offset, dest.qual_hue_offset, duration, tween);
+
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
 
@@ -175,6 +187,12 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
                lhs.perspective == rhs.perspective && lhs.gamut_compress == rhs.gamut_compress &&
                eq(lhs.gc_cyan, rhs.gc_cyan) && eq(lhs.gc_magenta, rhs.gc_magenta) &&
+               eq(lhs.gc_yellow, rhs.gc_yellow) && lhs.qualifier_enable == rhs.qualifier_enable &&
+               eq(lhs.qual_target_hue, rhs.qual_target_hue) && eq(lhs.qual_hue_width, rhs.qual_hue_width) &&
+               eq(lhs.qual_min_sat, rhs.qual_min_sat) && eq(lhs.qual_max_sat, rhs.qual_max_sat) &&
+               eq(lhs.qual_min_lum, rhs.qual_min_lum) && eq(lhs.qual_max_lum, rhs.qual_max_lum) &&
+               eq(lhs.qual_softness, rhs.qual_softness) && eq(lhs.qual_exposure, rhs.qual_exposure) &&
+               eq(lhs.qual_sat_offset, rhs.qual_sat_offset) && eq(lhs.qual_hue_offset, rhs.qual_hue_offset) ||
                eq(lhs.gc_yellow, rhs.gc_yellow) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -109,6 +109,10 @@ image_transform image_transform::tween(double                 time,
     result.blend_mode       = std::max(source.blend_mode, dest.blend_mode);
     result.layer_depth      = dest.layer_depth;
 
+    result.gamut_compress = dest.gamut_compress;
+    result.gc_cyan    = do_tween(time, source.gc_cyan, dest.gc_cyan, duration, tween);
+    result.gc_magenta = do_tween(time, source.gc_magenta, dest.gc_magenta, duration, tween);
+    result.gc_yellow  = do_tween(time, source.gc_yellow, dest.gc_yellow, duration, tween);
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
     for (int i = 0; i < 3; ++i) {
@@ -169,6 +173,9 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
+               lhs.perspective == rhs.perspective && lhs.gamut_compress == rhs.gamut_compress &&
+               eq(lhs.gc_cyan, rhs.gc_cyan) && eq(lhs.gc_magenta, rhs.gc_magenta) &&
+               eq(lhs.gc_yellow, rhs.gc_yellow) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -154,6 +154,17 @@ struct image_transform final
     double                gc_cyan    = 1.147;     // cyan limit
     double                gc_magenta = 1.264;     // magenta limit
     double                gc_yellow  = 1.312;     // yellow limit
+    bool                  qualifier_enable = false; // secondary HSL qualifier
+    double                qual_target_hue  = 0.0;   // 0..1 (hue angle / 360)
+    double                qual_hue_width   = 0.1;   // 0..0.5
+    double                qual_min_sat     = 0.2;   // 0..1
+    double                qual_max_sat     = 1.0;   // 0..1
+    double                qual_min_lum     = 0.0;   // 0..1
+    double                qual_max_lum     = 1.0;   // 0..1
+    double                qual_softness    = 0.1;   // feather width
+    double                qual_exposure    = 0.0;   // exposure offset for qualified region
+    double                qual_sat_offset  = 0.0;   // saturation offset for qualified region
+    double                qual_hue_offset  = 0.0;   // hue offset for qualified region (degrees)
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -150,6 +150,10 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    bool                  gamut_compress = false; // ACES 1.3 reference gamut compress
+    double                gc_cyan    = 1.147;     // cyan limit
+    double                gc_magenta = 1.264;     // magenta limit
+    double                gc_yellow  = 1.312;     // yellow limit
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -142,6 +142,17 @@ inline constexpr grade_range cdl_offset{-1.0, 1.0};
 inline constexpr grade_range cdl_power{0.01, 10.0};
 inline constexpr grade_range cdl_saturation{0.0, 10.0};
 
+/// Distance threshold from the achromatic axis; meaningless at or below 1.0.
+inline constexpr grade_range gamut_limit{1.0, 2.0};
+/// Absolute position on the wheel, not the signed offset hue_shift uses.
+inline constexpr grade_range hue_degrees{0.0, 360.0};
+inline constexpr grade_range hue_width{0.0, 180.0};
+inline constexpr grade_range unit{0.0, 1.0}; // saturation / luminance bounds, softness
+inline constexpr grade_range offset{-1.0, 1.0};
+/// Gamma shares midtone's bounds: it is the same kind of exponent.
+inline constexpr grade_range level{0.0, 1.0};
+inline constexpr grade_range level_gamma{0.01, 100.0};
+
 } // namespace grade_limits
 
 struct image_transform final

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -59,6 +59,23 @@ struct levels final
     double max_output = 1.0;
 };
 
+struct rgb_levels_channel final
+{
+    double min_input  = 0.0;
+    double max_input  = 1.0;
+    double gamma      = 1.0;
+    double min_output = 0.0;
+    double max_output = 1.0;
+};
+
+struct rgb_levels final
+{
+    bool               enable = false;
+    rgb_levels_channel r;
+    rgb_levels_channel g;
+    rgb_levels_channel b;
+};
+
 struct corners final
 {
     std::array<double, 2> ul = {0.0, 0.0};
@@ -165,6 +182,7 @@ struct image_transform final
     double                qual_exposure    = 0.0;   // exposure offset for qualified region
     double                qual_sat_offset  = 0.0;   // saturation offset for qualified region
     double                qual_hue_offset  = 0.0;   // hue offset for qualified region (degrees)
+    core::rgb_levels      per_channel_levels;       // independent per-channel levels
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1504,6 +1504,74 @@ std::future<std::wstring> mixer_gamutcompress_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_qualifier_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            if (!t.qualifier_enable)
+                return L"201 MIXER OK\r\nDISABLED\r\n";
+            auto f = [](double v) { return std::to_wstring(v); };
+            return L"201 MIXER OK\r\n" + f(t.qual_target_hue) + L" " + f(t.qual_hue_width) + L" " +
+                   f(t.qual_min_sat) + L" " + f(t.qual_max_sat) + L" " + f(t.qual_min_lum) + L" " +
+                   f(t.qual_max_lum) + L" " + f(t.qual_softness) + L" " + f(t.qual_exposure) + L" " +
+                   f(t.qual_sat_offset) + L" " + f(t.qual_hue_offset) + L"\r\n";
+        });
+    }
+
+    // Single param "0" = disable
+    if (ctx.parameters.size() == 1 && ctx.parameters.at(0) == L"0") {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.qualifier_enable = false;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    transforms_applier transforms(ctx);
+    double       tgt_hue  = std::stod(ctx.parameters.at(0));
+    double       hue_w    = std::stod(ctx.parameters.at(1));
+    double       min_sat  = std::stod(ctx.parameters.at(2));
+    double       max_sat  = std::stod(ctx.parameters.at(3));
+    double       min_lum  = std::stod(ctx.parameters.at(4));
+    double       max_lum  = std::stod(ctx.parameters.at(5));
+    double       softness = std::stod(ctx.parameters.at(6));
+    double       exp_off  = std::stod(ctx.parameters.at(7));
+    double       sat_off  = std::stod(ctx.parameters.at(8));
+    double       hue_off  = std::stod(ctx.parameters.at(9));
+    int          duration = ctx.parameters.size() > 10 ? std::stoi(ctx.parameters[10]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 11 ? ctx.parameters[11] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.qualifier_enable = true;
+            transform.image_transform.qual_target_hue  = tgt_hue;
+            transform.image_transform.qual_hue_width   = hue_w;
+            transform.image_transform.qual_min_sat     = min_sat;
+            transform.image_transform.qual_max_sat     = max_sat;
+            transform.image_transform.qual_min_lum     = min_lum;
+            transform.image_transform.qual_max_lum     = max_lum;
+            transform.image_transform.qual_softness    = softness;
+            transform.image_transform.qual_exposure    = exp_off;
+            transform.image_transform.qual_sat_offset  = sat_off;
+            transform.image_transform.qual_hue_offset  = hue_off;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2174,6 +2242,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER GAMUTCOMPRESS", mixer_gamutcompress_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER QUALIFIER", mixer_qualifier_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1484,9 +1484,15 @@ std::future<std::wstring> mixer_gamutcompress_command(command_context& ctx)
 
     transforms_applier transforms(ctx);
     bool   enable  = std::stoi(ctx.parameters.at(0)) != 0;
-    double cyan    = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.147;
-    double magenta = ctx.parameters.size() > 2 ? std::stod(ctx.parameters[2]) : 1.264;
-    double yellow  = ctx.parameters.size() > 3 ? std::stod(ctx.parameters[3]) : 1.312;
+    double cyan    = ctx.parameters.size() > 1
+                         ? grade_param(ctx.parameters[1], core::grade_limits::gamut_limit, L"cyan limit")
+                         : 1.147;
+    double magenta = ctx.parameters.size() > 2
+                         ? grade_param(ctx.parameters[2], core::grade_limits::gamut_limit, L"magenta limit")
+                         : 1.264;
+    double yellow  = ctx.parameters.size() > 3
+                         ? grade_param(ctx.parameters[3], core::grade_limits::gamut_limit, L"yellow limit")
+                         : 1.312;
 
     transforms.add(stage::transform_tuple_t(
         ctx.layer_index(),
@@ -1536,16 +1542,20 @@ std::future<std::wstring> mixer_qualifier_command(command_context& ctx)
     }
 
     transforms_applier transforms(ctx);
-    double       tgt_hue  = std::stod(ctx.parameters.at(0));
-    double       hue_w    = std::stod(ctx.parameters.at(1));
-    double       min_sat  = std::stod(ctx.parameters.at(2));
-    double       max_sat  = std::stod(ctx.parameters.at(3));
-    double       min_lum  = std::stod(ctx.parameters.at(4));
-    double       max_lum  = std::stod(ctx.parameters.at(5));
-    double       softness = std::stod(ctx.parameters.at(6));
-    double       exp_off  = std::stod(ctx.parameters.at(7));
-    double       sat_off  = std::stod(ctx.parameters.at(8));
-    double       hue_off  = std::stod(ctx.parameters.at(9));
+    grade_require(ctx,
+                  10,
+                  L"MIXER QUALIFIER hue width minSat maxSat minLum maxLum softness "
+                  L"exposureOffset satOffset hueOffset [duration] [tween]");
+    double tgt_hue  = grade_param(ctx.parameters.at(0), core::grade_limits::hue_degrees, L"target hue");
+    double hue_w    = grade_param(ctx.parameters.at(1), core::grade_limits::hue_width, L"hue width");
+    double min_sat  = grade_param(ctx.parameters.at(2), core::grade_limits::unit, L"min saturation");
+    double max_sat  = grade_param(ctx.parameters.at(3), core::grade_limits::unit, L"max saturation");
+    double min_lum  = grade_param(ctx.parameters.at(4), core::grade_limits::unit, L"min luminance");
+    double max_lum  = grade_param(ctx.parameters.at(5), core::grade_limits::unit, L"max luminance");
+    double softness = grade_param(ctx.parameters.at(6), core::grade_limits::unit, L"softness");
+    double exp_off  = grade_param(ctx.parameters.at(7), core::grade_limits::offset, L"exposure offset");
+    double sat_off  = grade_param(ctx.parameters.at(8), core::grade_limits::offset, L"saturation offset");
+    double hue_off  = grade_param(ctx.parameters.at(9), core::grade_limits::hue_shift, L"hue offset");
     int          duration = ctx.parameters.size() > 10 ? std::stoi(ctx.parameters[10]) : 0;
     std::wstring tween    = ctx.parameters.size() > 11 ? ctx.parameters[11] : L"linear";
 
@@ -1604,23 +1614,27 @@ std::future<std::wstring> mixer_rgblevels_command(command_context& ctx)
     }
 
     transforms_applier transforms(ctx);
+    grade_require(ctx,
+                  15,
+                  L"MIXER RGBLEVELS rMinIn rMaxIn rGamma rMinOut rMaxOut gMinIn ... "
+                  L"bMaxOut [duration] [tween], or MIXER RGBLEVELS RESET");
     core::rgb_levels rl;
     rl.enable       = true;
-    rl.r.min_input  = std::stod(ctx.parameters.at(0));
-    rl.r.max_input  = std::stod(ctx.parameters.at(1));
-    rl.r.gamma      = std::stod(ctx.parameters.at(2));
-    rl.r.min_output = std::stod(ctx.parameters.at(3));
-    rl.r.max_output = std::stod(ctx.parameters.at(4));
-    rl.g.min_input  = std::stod(ctx.parameters.at(5));
-    rl.g.max_input  = std::stod(ctx.parameters.at(6));
-    rl.g.gamma      = std::stod(ctx.parameters.at(7));
-    rl.g.min_output = std::stod(ctx.parameters.at(8));
-    rl.g.max_output = std::stod(ctx.parameters.at(9));
-    rl.b.min_input  = std::stod(ctx.parameters.at(10));
-    rl.b.max_input  = std::stod(ctx.parameters.at(11));
-    rl.b.gamma      = std::stod(ctx.parameters.at(12));
-    rl.b.min_output = std::stod(ctx.parameters.at(13));
-    rl.b.max_output = std::stod(ctx.parameters.at(14));
+    rl.r.min_input  = grade_param(ctx.parameters.at(0), core::grade_limits::level, L"R min input");
+    rl.r.max_input  = grade_param(ctx.parameters.at(1), core::grade_limits::level, L"R max input");
+    rl.r.gamma      = grade_param(ctx.parameters.at(2), core::grade_limits::level_gamma, L"R gamma");
+    rl.r.min_output = grade_param(ctx.parameters.at(3), core::grade_limits::level, L"R min output");
+    rl.r.max_output = grade_param(ctx.parameters.at(4), core::grade_limits::level, L"R max output");
+    rl.g.min_input  = grade_param(ctx.parameters.at(5), core::grade_limits::level, L"G min input");
+    rl.g.max_input  = grade_param(ctx.parameters.at(6), core::grade_limits::level, L"G max input");
+    rl.g.gamma      = grade_param(ctx.parameters.at(7), core::grade_limits::level_gamma, L"G gamma");
+    rl.g.min_output = grade_param(ctx.parameters.at(8), core::grade_limits::level, L"G min output");
+    rl.g.max_output = grade_param(ctx.parameters.at(9), core::grade_limits::level, L"G max output");
+    rl.b.min_input  = grade_param(ctx.parameters.at(10), core::grade_limits::level, L"B min input");
+    rl.b.max_input  = grade_param(ctx.parameters.at(11), core::grade_limits::level, L"B max input");
+    rl.b.gamma      = grade_param(ctx.parameters.at(12), core::grade_limits::level_gamma, L"B gamma");
+    rl.b.min_output = grade_param(ctx.parameters.at(13), core::grade_limits::level, L"B min output");
+    rl.b.max_output = grade_param(ctx.parameters.at(14), core::grade_limits::level, L"B max output");
     int          duration = ctx.parameters.size() > 15 ? std::stoi(ctx.parameters[15]) : 0;
     std::wstring tween    = ctx.parameters.size() > 16 ? ctx.parameters[16] : L"linear";
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1470,6 +1470,40 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_gamutcompress_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return L"201 MIXER OK\r\n" + std::to_wstring(t.gamut_compress ? 1 : 0) + L" " +
+                   std::to_wstring(t.gc_cyan) + L" " + std::to_wstring(t.gc_magenta) + L" " +
+                   std::to_wstring(t.gc_yellow) + L"\r\n";
+        });
+    }
+
+    transforms_applier transforms(ctx);
+    bool   enable  = std::stoi(ctx.parameters.at(0)) != 0;
+    double cyan    = ctx.parameters.size() > 1 ? std::stod(ctx.parameters[1]) : 1.147;
+    double magenta = ctx.parameters.size() > 2 ? std::stod(ctx.parameters[2]) : 1.264;
+    double yellow  = ctx.parameters.size() > 3 ? std::stod(ctx.parameters[3]) : 1.312;
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.gamut_compress = enable;
+            transform.image_transform.gc_cyan        = cyan;
+            transform.image_transform.gc_magenta     = magenta;
+            transform.image_transform.gc_yellow      = yellow;
+            return transform;
+        },
+        0,
+        L"linear"));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2139,6 +2173,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER GRID", mixer_grid_command, 1);
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER GAMUTCOMPRESS", mixer_gamutcompress_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1572,6 +1572,71 @@ std::future<std::wstring> mixer_qualifier_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_rgblevels_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto t2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [t2]() -> std::wstring {
+            const auto& rl = t2.get().image_transform.per_channel_levels;
+            if (!rl.enable)
+                return L"201 MIXER OK\r\nDISABLED\r\n";
+            auto f   = [](double v) { return std::to_wstring(v); };
+            auto row = [&](const core::rgb_levels_channel& c) {
+                return f(c.min_input) + L" " + f(c.max_input) + L" " + f(c.gamma) + L" " + f(c.min_output) + L" " +
+                       f(c.max_output);
+            };
+            return L"201 MIXER OK\r\n" + row(rl.r) + L" " + row(rl.g) + L" " + row(rl.b) + L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"RESET")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.per_channel_levels = core::rgb_levels{};
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    transforms_applier transforms(ctx);
+    core::rgb_levels rl;
+    rl.enable       = true;
+    rl.r.min_input  = std::stod(ctx.parameters.at(0));
+    rl.r.max_input  = std::stod(ctx.parameters.at(1));
+    rl.r.gamma      = std::stod(ctx.parameters.at(2));
+    rl.r.min_output = std::stod(ctx.parameters.at(3));
+    rl.r.max_output = std::stod(ctx.parameters.at(4));
+    rl.g.min_input  = std::stod(ctx.parameters.at(5));
+    rl.g.max_input  = std::stod(ctx.parameters.at(6));
+    rl.g.gamma      = std::stod(ctx.parameters.at(7));
+    rl.g.min_output = std::stod(ctx.parameters.at(8));
+    rl.g.max_output = std::stod(ctx.parameters.at(9));
+    rl.b.min_input  = std::stod(ctx.parameters.at(10));
+    rl.b.max_input  = std::stod(ctx.parameters.at(11));
+    rl.b.gamma      = std::stod(ctx.parameters.at(12));
+    rl.b.min_output = std::stod(ctx.parameters.at(13));
+    rl.b.max_output = std::stod(ctx.parameters.at(14));
+    int          duration = ctx.parameters.size() > 15 ? std::stoi(ctx.parameters[15]) : 0;
+    std::wstring tween    = ctx.parameters.size() > 16 ? ctx.parameters[16] : L"linear";
+
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.per_channel_levels = rl;
+            return transform;
+        },
+        duration,
+        tween));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2243,6 +2308,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER GAMUTCOMPRESS", mixer_gamutcompress_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER QUALIFIER", mixer_qualifier_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER RGBLEVELS", mixer_rgblevels_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);


### PR DESCRIPTION
## Summary

Adds three more grading tools to the OpenGL mixer as per-layer AMCP `MIXER` commands:

- **`MIXER GAMUTCOMPRESS`** — pulls out-of-gamut values back toward the achromatic axis, using ACES 1.3's limits. An approximation rather than the ACES algorithm — see *Gamut compression: limits, not algorithm* below.
- **`MIXER QUALIFIER`** — secondary HSL qualifier: isolates a hue/sat/lum range and applies exposure / saturation / hue corrections only to the qualified pixels (soft-masked).
- **`MIXER RGBLEVELS`** — independent per-channel (R/G/B) input range, gamma, and output range.

All are off by default with zero cost when unused, operate in the working color space before the legacy levels/CSB stage, and (where continuous) are tweenable.

This is the first half of the "advanced grade" set — the LUT-backed **tone curves** and **hue curves** will follow in a separate PR since they require GPU LUT-texture infrastructure.

## Commits

1. `mixer: add MIXER GAMUTCOMPRESS command`
2. `mixer: add MIXER QUALIFIER command`
3. `mixer: add MIXER RGBLEVELS command`

## AMCP syntax

```
MIXER <ch-layer> GAMUTCOMPRESS <0|1> [cyan_limit] [magenta_limit] [yellow_limit]
MIXER <ch-layer> QUALIFIER <target_hue> <hue_width> <min_sat> <max_sat> <min_lum> <max_lum> <softness> <exp_offset> <sat_offset> <hue_offset> [duration] [tween]
MIXER <ch-layer> QUALIFIER 0            # disable
MIXER <ch-layer> RGBLEVELS <r_min_in r_max_in r_gamma r_min_out r_max_out> <g...> <b...> [duration] [tween]
MIXER <ch-layer> RGBLEVELS RESET
```

Any command with no parameters queries the current value. Gamut-compress limits default to the ACES reference (1.147 / 1.264 / 1.312). Qualifier hue values are normalized 0..1 (hue angle / 360); `hue_offset` is in degrees.

### Examples

```
MIXER 1-10 GAMUTCOMPRESS 1                      # enable with ACES defaults
MIXER 1-10 GAMUTCOMPRESS 1 1.1 1.2 1.3          # custom limits
MIXER 1-10 QUALIFIER 0.05 0.08 0.2 1 0 1 0.1 0 0.3 0   # boost saturation of reds
MIXER 1-10 QUALIFIER 0                          # disable
MIXER 1-10 RGBLEVELS 0 1 1 0 1  0 1 0.9 0 1  0 1 1 0 1  # slight green gamma lift
MIXER 1-10 RGBLEVELS RESET
```

## Implementation notes

- Each parameter is added to `image_transform` and wired through `tween`, `operator==`, and the transform-combine step. Combine semantics: gamut/qualifier override when enabled; RGB levels intersect input/output ranges and multiply gamma per channel.
- Shader work stays in the existing OGL pipeline (`shader.frag` functions + `image_kernel.cpp` uniform setup). The qualifier reuses upstream `rgb2hsv`/`AngleDiff` and inlines an HDR-safe hue rotation (no new shared helper).
- Per-channel uniforms (`rgb_levels_*`, `gc_limit`) upload in RGB order; the shader applies the BGR working-order swizzle at the point of use, so the kernel does not need to know about it.
- Independent of #1758, #1762, and #1765 — builds on clean `master`.

### Gamut compression: limits, not algorithm

The default limits (1.147 / 1.264 / 1.312) are the ACES 1.3 reference values, but the curve
is a fast GPU approximation rather than the ACES transform. Measured against the ACES 1.3
Reference Gamut Compression look: **mean 0.030, max 0.350** in linear ACES units over 4000
samples, from three differences —

- one threshold for all three axes instead of three;
- a rational curve instead of ACES's power form;
- all-negative pixels passed through untouched, where ACES compresses them by up to 0.336.

The curve dominates rather than the thresholds: red shares ACES's 0.815 threshold and still
differs by 0.350 on its own. This is intended — it is a per-pixel shader function on the
frame path — and is recorded so the naming does not imply more than the code does. Anyone
needing the exact transform should use an OCIO look.

## Testing

Builds clean on Windows (VS2026, Release). Wiki docs to follow.
