### PR TITLE
Add LUT-backed grading: MIXER LUT3D, CURVES, HUECURVE

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -163,6 +163,7 @@ struct image_kernel::impl
     GLuint                  lut3d_tex_id_   = 0;
     const core::lut3d_data* lut3d_data_ptr_ = nullptr; // tracks which LUT data is uploaded
     GLuint                  curve_lut_tex_id_ = 0;
+    GLuint                  hue_curve_tex_id_ = 0;
 
     explicit impl(const spl::shared_ptr<device>& ogl)
         : ogl_(ogl)
@@ -183,6 +184,8 @@ struct image_kernel::impl
                 GL(glDeleteTextures(1, &lut3d_tex_id_));
             if (curve_lut_tex_id_)
                 GL(glDeleteTextures(1, &curve_lut_tex_id_));
+            if (hue_curve_tex_id_)
+                GL(glDeleteTextures(1, &hue_curve_tex_id_));
         });
     }
 
@@ -509,6 +512,27 @@ struct image_kernel::impl
                 shader_->set("curve_lut_tex", static_cast<int>(texture_id::curve_lut_tex));
             } else {
                 shader_->set("curves_enable", false);
+            }
+        }
+
+        // Hue-vs-Hue / Hue-vs-Sat curves
+        {
+            const auto& hc = transforms.image_transform.hue_curves;
+            if (hc && !hc->data.empty()) {
+                if (!hue_curve_tex_id_) {
+                    GL(glCreateTextures(GL_TEXTURE_2D, 1, &hue_curve_tex_id_));
+                    GL(glTextureStorage2D(hue_curve_tex_id_, 1, GL_RGBA32F, 256, 1));
+                    GL(glTextureParameteri(hue_curve_tex_id_, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+                    GL(glTextureParameteri(hue_curve_tex_id_, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+                    GL(glTextureParameteri(hue_curve_tex_id_, GL_TEXTURE_WRAP_S, GL_REPEAT));
+                    GL(glTextureParameteri(hue_curve_tex_id_, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+                }
+                GL(glTextureSubImage2D(hue_curve_tex_id_, 0, 0, 0, 256, 1, GL_RGBA, GL_FLOAT, hc->data.data()));
+                GL(glBindTextureUnit(static_cast<int>(texture_id::hue_curve_tex), hue_curve_tex_id_));
+                shader_->set("hue_curve_enable", true);
+                shader_->set("hue_curve_tex", static_cast<int>(texture_id::hue_curve_tex));
+            } else {
+                shader_->set("hue_curve_enable", false);
             }
         }
 

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -132,8 +132,14 @@ static std::array<float, 256> build_curve_lut(const core::curve_channel& cc)
             lut[k] = static_cast<float>(std::max(0.0, std::min(1.0, pts.back().second)));
             continue;
         }
+        // n - 1, not n - 2: there are n-1 intervals between n control points, and the
+        // search has to be able to reach the last one. With n - 2 the interval
+        // [pts[n-2], pts[n-1]) matched no iteration, seg kept its initial 0, and the
+        // final stretch of every curve with three or more points was evaluated with
+        // the FIRST segment's control points and tangents at a parameter far outside
+        // [0,1].
         int seg = 0;
-        for (int i = 0; i < n - 2; ++i)
+        for (int i = 0; i < n - 1; ++i)
             if (t >= pts[i].first && t < pts[i + 1].first) {
                 seg = i;
                 break;

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -39,6 +39,9 @@
 
 #include <array>
 #include <cmath>
+#include <algorithm>
+#include <utility>
+#include <vector>
 
 namespace caspar::accelerator::ogl {
 
@@ -78,6 +81,77 @@ bool is_outside_screen(const std::vector<core::frame_geometry::coord>& coords)
            boost::algorithm::all_of(y_coords, &is_above_screen) || boost::algorithm::all_of(y_coords, &is_below_screen);
 }
 
+// Builds a 256-entry 1D LUT from control points using Fritsch-Carlson monotone
+// cubic Hermite interpolation. Guarantees no overshoot (safe for colour values).
+// If fewer than 2 points, returns a linear identity LUT.
+static std::array<float, 256> build_curve_lut(const core::curve_channel& cc)
+{
+    std::array<float, 256> lut;
+    if (cc.count < 2) {
+        for (int i = 0; i < 256; ++i)
+            lut[i] = i / 255.0f;
+        return lut;
+    }
+    std::vector<std::pair<double, double>> pts;
+    pts.reserve(cc.count);
+    for (int i = 0; i < cc.count; ++i)
+        pts.push_back({cc.points[i].x, cc.points[i].y});
+    std::sort(pts.begin(), pts.end());
+
+    int                 n = static_cast<int>(pts.size());
+    std::vector<double> dx(n - 1), dy(n - 1), delta(n - 1), m(n);
+    for (int i = 0; i < n - 1; ++i) {
+        dx[i]    = pts[i + 1].first - pts[i].first;
+        dy[i]    = pts[i + 1].second - pts[i].second;
+        delta[i] = (dx[i] > 1e-10) ? dy[i] / dx[i] : 0.0;
+    }
+    m[0]     = delta[0];
+    m[n - 1] = delta[n - 2];
+    for (int i = 1; i < n - 1; ++i)
+        m[i] = (delta[i - 1] + delta[i]) * 0.5;
+    for (int i = 0; i < n - 1; ++i) {
+        if (std::abs(delta[i]) < 1e-10) {
+            m[i] = m[i + 1] = 0.0;
+            continue;
+        }
+        double a = m[i] / delta[i];
+        double b = m[i + 1] / delta[i];
+        double h = std::sqrt(a * a + b * b);
+        if (h > 3.0) {
+            m[i] *= 3.0 / h;
+            m[i + 1] *= 3.0 / h;
+        }
+    }
+    for (int k = 0; k < 256; ++k) {
+        double t = k / 255.0;
+        if (t <= pts.front().first) {
+            lut[k] = static_cast<float>(std::max(0.0, std::min(1.0, pts.front().second)));
+            continue;
+        }
+        if (t >= pts.back().first) {
+            lut[k] = static_cast<float>(std::max(0.0, std::min(1.0, pts.back().second)));
+            continue;
+        }
+        int seg = 0;
+        for (int i = 0; i < n - 2; ++i)
+            if (t >= pts[i].first && t < pts[i + 1].first) {
+                seg = i;
+                break;
+            }
+        double h_  = dx[seg];
+        double t_  = (h_ > 1e-10) ? (t - pts[seg].first) / h_ : 0.0;
+        double t2  = t_ * t_;
+        double t3  = t2 * t_;
+        double h00 = 2 * t3 - 3 * t2 + 1;
+        double h10 = t3 - 2 * t2 + t_;
+        double h01 = -2 * t3 + 3 * t2;
+        double h11 = t3 - t2;
+        double val = h00 * pts[seg].second + h10 * h_ * m[seg] + h01 * pts[seg + 1].second + h11 * h_ * m[seg + 1];
+        lut[k]     = static_cast<float>(std::max(0.0, std::min(1.0, val)));
+    }
+    return lut;
+}
+
 static const double epsilon = 0.001;
 
 struct image_kernel::impl
@@ -88,6 +162,7 @@ struct image_kernel::impl
     GLuint                  vbo_;
     GLuint                  lut3d_tex_id_   = 0;
     const core::lut3d_data* lut3d_data_ptr_ = nullptr; // tracks which LUT data is uploaded
+    GLuint                  curve_lut_tex_id_ = 0;
 
     explicit impl(const spl::shared_ptr<device>& ogl)
         : ogl_(ogl)
@@ -106,6 +181,8 @@ struct image_kernel::impl
             GL(glDeleteBuffers(1, &vbo_));
             if (lut3d_tex_id_)
                 GL(glDeleteTextures(1, &lut3d_tex_id_));
+            if (curve_lut_tex_id_)
+                GL(glDeleteTextures(1, &curve_lut_tex_id_));
         });
     }
 
@@ -399,6 +476,39 @@ struct image_kernel::impl
                 shader_->set("lut3d_enable", false);
                 if (lut3d_tex_id_ && !lut)
                     lut3d_data_ptr_ = nullptr;
+            }
+        }
+
+        // Tone curves: build 256-entry LUTs on the CPU, pack into an RGBA32F 256x1 texture.
+        {
+            const auto& cv = transforms.image_transform.curves;
+            if (cv.enable) {
+                auto lut_r = build_curve_lut(cv.red);
+                auto lut_g = build_curve_lut(cv.green);
+                auto lut_b = build_curve_lut(cv.blue);
+                auto lut_m = build_curve_lut(cv.master);
+                std::vector<float> rgba(256 * 4);
+                for (int i = 0; i < 256; ++i) {
+                    // BGR working order: .r slot = displayed Blue, .b slot = displayed Red.
+                    rgba[i * 4 + 0] = lut_b[i];
+                    rgba[i * 4 + 1] = lut_g[i];
+                    rgba[i * 4 + 2] = lut_r[i];
+                    rgba[i * 4 + 3] = lut_m[i];
+                }
+                if (!curve_lut_tex_id_) {
+                    GL(glCreateTextures(GL_TEXTURE_2D, 1, &curve_lut_tex_id_));
+                    GL(glTextureStorage2D(curve_lut_tex_id_, 1, GL_RGBA32F, 256, 1));
+                    GL(glTextureParameteri(curve_lut_tex_id_, GL_TEXTURE_MIN_FILTER, GL_NEAREST));
+                    GL(glTextureParameteri(curve_lut_tex_id_, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+                    GL(glTextureParameteri(curve_lut_tex_id_, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+                    GL(glTextureParameteri(curve_lut_tex_id_, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+                }
+                GL(glTextureSubImage2D(curve_lut_tex_id_, 0, 0, 0, 256, 1, GL_RGBA, GL_FLOAT, rgba.data()));
+                GL(glBindTextureUnit(static_cast<int>(texture_id::curve_lut_tex), curve_lut_tex_id_));
+                shader_->set("curves_enable", true);
+                shader_->set("curve_lut_tex", static_cast<int>(texture_id::curve_lut_tex));
+            } else {
+                shader_->set("curves_enable", false);
             }
         }
 

--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -86,6 +86,8 @@ struct image_kernel::impl
     spl::shared_ptr<shader> shader_;
     GLuint                  vao_;
     GLuint                  vbo_;
+    GLuint                  lut3d_tex_id_   = 0;
+    const core::lut3d_data* lut3d_data_ptr_ = nullptr; // tracks which LUT data is uploaded
 
     explicit impl(const spl::shared_ptr<device>& ogl)
         : ogl_(ogl)
@@ -102,6 +104,8 @@ struct image_kernel::impl
         ogl_->dispatch_sync([&] {
             GL(glDeleteVertexArrays(1, &vao_));
             GL(glDeleteBuffers(1, &vbo_));
+            if (lut3d_tex_id_)
+                GL(glDeleteTextures(1, &lut3d_tex_id_));
         });
     }
 
@@ -364,6 +368,37 @@ struct image_kernel::impl
                 shader_->set("cdl_saturation", static_cast<float>(cs));
             } else {
                 shader_->set("cdl_enable", false);
+            }
+        }
+
+        // 3D LUT
+        {
+            const auto& lut = transforms.image_transform.lut3d;
+            if (lut && lut->size > 0 && !lut->data.empty()) {
+                // Re-upload only when the data pointer changes (a new LUT was loaded).
+                if (lut.get() != lut3d_data_ptr_) {
+                    if (lut3d_tex_id_)
+                        GL(glDeleteTextures(1, &lut3d_tex_id_));
+                    GL(glCreateTextures(GL_TEXTURE_3D, 1, &lut3d_tex_id_));
+                    GL(glTextureStorage3D(lut3d_tex_id_, 1, GL_RGB32F, lut->size, lut->size, lut->size));
+                    GL(glTextureParameteri(lut3d_tex_id_, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+                    GL(glTextureParameteri(lut3d_tex_id_, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+                    GL(glTextureParameteri(lut3d_tex_id_, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+                    GL(glTextureParameteri(lut3d_tex_id_, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+                    GL(glTextureParameteri(lut3d_tex_id_, GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE));
+                    GL(glTextureSubImage3D(lut3d_tex_id_, 0, 0, 0, 0,
+                                           lut->size, lut->size, lut->size,
+                                           GL_RGB, GL_FLOAT, lut->data.data()));
+                    lut3d_data_ptr_ = lut.get();
+                }
+                GL(glBindTextureUnit(static_cast<int>(texture_id::lut3d_tex), lut3d_tex_id_));
+                shader_->set("lut3d_enable", true);
+                shader_->set("lut3d_tex", static_cast<int>(texture_id::lut3d_tex));
+                shader_->set("lut3d_strength", transforms.image_transform.lut3d_strength);
+            } else {
+                shader_->set("lut3d_enable", false);
+                if (lut3d_tex_id_ && !lut)
+                    lut3d_data_ptr_ = nullptr;
             }
         }
 

--- a/src/accelerator/ogl/image/image_shader.h
+++ b/src/accelerator/ogl/image/image_shader.h
@@ -37,7 +37,8 @@ enum class texture_id
     local_key,
     layer_key,
     background,
-    lut3d_tex
+    lut3d_tex,
+    curve_lut_tex
 };
 
 std::shared_ptr<shader> get_image_shader(const spl::shared_ptr<device>& ogl);

--- a/src/accelerator/ogl/image/image_shader.h
+++ b/src/accelerator/ogl/image/image_shader.h
@@ -36,7 +36,8 @@ enum class texture_id
     plane3,
     local_key,
     layer_key,
-    background
+    background,
+    lut3d_tex
 };
 
 std::shared_ptr<shader> get_image_shader(const spl::shared_ptr<device>& ogl);

--- a/src/accelerator/ogl/image/image_shader.h
+++ b/src/accelerator/ogl/image/image_shader.h
@@ -38,7 +38,8 @@ enum class texture_id
     layer_key,
     background,
     lut3d_tex,
-    curve_lut_tex
+    curve_lut_tex,
+    hue_curve_tex
 };
 
 std::shared_ptr<shader> get_image_shader(const spl::shared_ptr<device>& ogl);

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -13,6 +13,10 @@ uniform sampler3D	lut3d_tex;
 uniform bool		lut3d_enable;
 uniform float		lut3d_strength;
 
+// Tone curves (per-channel + master, 256-entry LUT packed as RGBA32F 256x1)
+uniform sampler2D	curve_lut_tex;
+uniform bool		curves_enable;
+
 uniform bool        is_straight_alpha;
 
 uniform mat3		color_matrix;
@@ -679,6 +683,36 @@ vec3 apply_lut3d(vec3 c, float strength)
     return mix(c, rgb_out.bgr, strength);
 }
 
+// ---- Tone Curves: bilinear sample of a 256-entry float LUT ----
+// ch: 0=R slot, 1=G slot, 2=B slot, 3=Master. The kernel packs the LUT so the
+// .r slot holds the displayed-Blue curve and .b slot the displayed-Red curve.
+float sample_lut_256(float val, int ch)
+{
+    float s  = clamp(val, 0.0, 1.0) * 255.0;
+    int   lo = int(s);
+    int   hi = min(lo + 1, 255);
+    float f  = fract(s);
+    vec4 lo4 = texelFetch(curve_lut_tex, ivec2(lo, 0), 0);
+    vec4 hi4 = texelFetch(curve_lut_tex, ivec2(hi, 0), 0);
+    vec4 v4  = mix(lo4, hi4, f);
+    if (ch == 0) return v4.r;
+    if (ch == 1) return v4.g;
+    if (ch == 2) return v4.b;
+    return v4.a;
+}
+
+vec3 apply_curves(vec3 c)
+{
+    // Per-channel curves first, then the master curve as a global tone.
+    c.r = sample_lut_256(c.r, 0);
+    c.g = sample_lut_256(c.g, 1);
+    c.b = sample_lut_256(c.b, 2);
+    c.r = sample_lut_256(c.r, 3);
+    c.g = sample_lut_256(c.g, 3);
+    c.b = sample_lut_256(c.b, 3);
+    return c;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -688,6 +722,8 @@ void main()
         color = chroma_key(color);
     if (lut3d_enable)
         color.rgb = apply_lut3d(color.rgb, lut3d_strength);
+    if (curves_enable)
+        color.rgb = apply_curves(color.rgb);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -17,6 +17,10 @@ uniform float		lut3d_strength;
 uniform sampler2D	curve_lut_tex;
 uniform bool		curves_enable;
 
+// Hue-vs-Hue / Hue-vs-Sat / Hue-vs-Lum / Sat-vs-Sat curves (256x1 RGBA32F)
+uniform sampler2D	hue_curve_tex;
+uniform bool		hue_curve_enable;
+
 uniform bool        is_straight_alpha;
 
 uniform mat3		color_matrix;
@@ -713,6 +717,22 @@ vec3 apply_curves(vec3 c)
     return c;
 }
 
+// ---- Hue-vs-Hue / Hue-vs-Sat / Hue-vs-Lum / Sat-vs-Sat curves ----
+// 4-channel LUT indexed by hue: R=hue offset, G=sat multiplier, B=lum offset,
+// A=sat-vs-sat multiplier (indexed by saturation).
+vec3 apply_hue_curves(vec3 c)
+{
+    vec3 hsv     = rgb2hsv(clamp(c, 0.0, 1.0));
+    vec4 offsets = texture(hue_curve_tex, vec2(hsv.x, 0.5));
+    hsv.x = fract(hsv.x + offsets.r);
+    hsv.y *= offsets.g;
+    vec4 sat_offsets = texture(hue_curve_tex, vec2(hsv.y, 0.5));
+    hsv.y *= sat_offsets.a;
+    vec3 result = hsv2rgb(hsv);
+    result += offsets.b;
+    return result;
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -724,6 +744,8 @@ void main()
         color.rgb = apply_lut3d(color.rgb, lut3d_strength);
     if (curves_enable)
         color.rgb = apply_curves(color.rgb);
+    if (hue_curve_enable)
+        color.rgb = apply_hue_curves(color.rgb);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -8,6 +8,11 @@ uniform sampler2D	plane[4];
 uniform sampler2D	local_key;
 uniform sampler2D	layer_key;
 
+// 3D LUT (creative look)
+uniform sampler3D	lut3d_tex;
+uniform bool		lut3d_enable;
+uniform float		lut3d_strength;
+
 uniform bool        is_straight_alpha;
 
 uniform mat3		color_matrix;
@@ -664,6 +669,16 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
     return c;
 }
 
+// ---- 3D LUT ----
+// Trilinear lookup in a 3D texture. Working colour is BGR, so swizzle to RGB
+// for the lookup and back. Input clamped to the LUT's 0..1 domain.
+vec3 apply_lut3d(vec3 c, float strength)
+{
+    vec3 rgb_in  = clamp(c.bgr, 0.0, 1.0);
+    vec3 rgb_out = texture(lut3d_tex, rgb_in).rgb;
+    return mix(c, rgb_out.bgr, strength);
+}
+
 void main()
 {
     vec4 color = get_rgba_color();
@@ -671,6 +686,8 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
+    if (lut3d_enable)
+        color.rgb = apply_lut3d(color.rgb, lut3d_strength);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -722,13 +722,24 @@ vec3 apply_curves(vec3 c)
 // A=sat-vs-sat multiplier (indexed by saturation).
 vec3 apply_hue_curves(vec3 c)
 {
-    vec3 hsv     = rgb2hsv(clamp(c, 0.0, 1.0));
+    // `c` is BGR-ordered at this point: get_rgba_color() swizzles to .bgra on
+    // the way in and main() writes fragColor = color.bgra on the way out, so the
+    // two cancel for a straight pass-through but everything in between sees blue
+    // in the red slot. rgb2hsv treats the first component as red regardless, and
+    // exchanging red and blue mirrors the hue wheel, so an unswizzled call here
+    // delivers the negation of the requested offset -- +0.25 comes out as -0.25.
+    // Only 0.0 and 0.5 look right, being their own negations.
+    //
+    // ContrastSaturationBrightness already accounts for this ordering with
+    // luma_coeff.bgr; this does the same. Saturation and value are unchanged by
+    // the exchange, so only hue-vs-hue was affected.
+    vec3 hsv     = rgb2hsv(clamp(c.bgr, 0.0, 1.0));
     vec4 offsets = texture(hue_curve_tex, vec2(hsv.x, 0.5));
     hsv.x = fract(hsv.x + offsets.r);
     hsv.y *= offsets.g;
     vec4 sat_offsets = texture(hue_curve_tex, vec2(hsv.y, 0.5));
     hsv.y *= sat_offsets.a;
-    vec3 result = hsv2rgb(hsv);
+    vec3 result = hsv2rgb(hsv).bgr;
     result += offsets.b;
     return result;
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -680,9 +680,18 @@ vec3 apply_cdl(vec3 c, vec3 slope, vec3 off, vec3 pwr, float sat_val)
 // ---- 3D LUT ----
 // Trilinear lookup in a 3D texture. Working colour is BGR, so swizzle to RGB
 // for the lookup and back. Input clamped to the LUT's 0..1 domain.
+// Entry k of an N-cube describes input k/(N-1) and lives at texel centre (k+0.5)/N,
+// so the colour has to be rescaled before it is used as a coordinate. Passing it
+// straight in puts value v at texel position v*N - 0.5 instead of v*(N-1): correct
+// only at v = 0.5 and off by up to half a texel at the ends. Measured with an
+// identity cube, where a correct LUT returns its input unchanged, that is up to 7 LSB
+// on a 17-cube and 4 on a 33-cube. textureSize() rather than a uniform, so the value
+// cannot go stale when the LUT is swapped.
 vec3 apply_lut3d(vec3 c, float strength)
 {
+    float n      = float(textureSize(lut3d_tex, 0).x);
     vec3 rgb_in  = clamp(c.bgr, 0.0, 1.0);
+    rgb_in       = (rgb_in * (n - 1.0) + 0.5) / n;
     vec3 rgb_out = texture(lut3d_tex, rgb_in).rgb;
     return mix(c, rgb_out.bgr, strength);
 }

--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -760,27 +760,27 @@ void main()
         color.rgb *= color.a;
     if (chroma)
         color = chroma_key(color);
-    if (lut3d_enable)
-        color.rgb = apply_lut3d(color.rgb, lut3d_strength);
-    if (curves_enable)
-        color.rgb = apply_curves(color.rgb);
-    if (hue_curve_enable)
-        color.rgb = apply_hue_curves(color.rgb);
     // Per-channel uniforms arrive in RGB order and are swizzled to the working order
     // here -- see the channel-order note above the grading functions.
     if (cdl_enable)
         color.rgb = apply_cdl(color.rgb, cdl_slope.bgr, cdl_offset.bgr, cdl_power.bgr, cdl_saturation);
+    if (lut3d_enable)
+        color.rgb = apply_lut3d(color.rgb, lut3d_strength);
     if (white_balance)
         color.rgb = apply_white_balance(color.rgb, wb_temperature, wb_tint);
     if (lmg_enable)
         color.rgb = apply_lmg(color.rgb, lmg_lift.bgr, lmg_midtone.bgr, lmg_gain.bgr);
     if (hue_shift_enable)
         color.rgb = apply_hue_shift(color.rgb, hue_shift_degrees);
+    if (hue_curve_enable)
+        color.rgb = apply_hue_curves(color.rgb);
     if (tonebalance_enable)
         color.rgb = apply_tone_balance(color.rgb, tb_shadows, tb_highlights);
     if (split_tone_enable)
         color.rgb =
             apply_split_tone(color.rgb, split_shadow_color.bgr, split_highlight_color.bgr, split_balance);
+    if (curves_enable)
+        color.rgb = apply_curves(color.rgb);
     if(levels)
         color.rgb = LevelsControl(color.rgb, min_input, gamma, max_input, min_output, max_output);
     if(csb)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -72,21 +72,6 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
 
-    // 3D LUT
-    if (other.lut3d) {
-        self.lut3d          = other.lut3d;
-        self.lut3d_strength = other.lut3d_strength;
-    }
-
-    // Tone curves: override when enabled (curves don't compose additively)
-    if (other.curves.enable) {
-        self.curves = other.curves;
-    }
-
-    // Hue curves
-    if (other.hue_curves) {
-        self.hue_curves = other.hue_curves;
-    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single
@@ -155,6 +140,21 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.cdl_power[i]  = lim::cdl_power.clamp(self.cdl_power[i] * other.cdl_power[i]);
     }
     self.cdl_saturation = lim::cdl_saturation.clamp(self.cdl_saturation * other.cdl_saturation);
+    // 3D LUT
+    if (other.lut3d) {
+        self.lut3d          = other.lut3d;
+        self.lut3d_strength = other.lut3d_strength;
+    }
+
+    // Tone curves: override when enabled (curves don't compose additively)
+    if (other.curves.enable) {
+        self.curves = other.curves;
+    }
+
+    // Hue curves
+    if (other.hue_curves) {
+        self.hue_curves = other.hue_curves;
+    }
 }
 
 bool is_default_perspective(const core::corners& perspective)

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -72,6 +72,11 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     self.blend_mode = std::max(self.blend_mode, other.blend_mode);
     self.layer_depth += other.layer_depth;
 
+    // 3D LUT
+    if (other.lut3d) {
+        self.lut3d          = other.lut3d;
+        self.lut3d_strength = other.lut3d_strength;
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -77,6 +77,11 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
         self.lut3d          = other.lut3d;
         self.lut3d_strength = other.lut3d_strength;
     }
+
+    // Tone curves: override when enabled (curves don't compose additively)
+    if (other.curves.enable) {
+        self.curves = other.curves;
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/accelerator/ogl/util/transforms.cpp
+++ b/src/accelerator/ogl/util/transforms.cpp
@@ -82,6 +82,11 @@ void apply_transform_colour_values(core::image_transform& self, const core::imag
     if (other.curves.enable) {
         self.curves = other.curves;
     }
+
+    // Hue curves
+    if (other.hue_curves) {
+        self.hue_curves = other.hue_curves;
+    }
     // Every combined grading value below is clamped back into the range its MIXER
     // command accepts (core::grade_limits, the same table the commands validate
     // against). Two layers at the edge of legal would otherwise reach a value no single

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -109,6 +109,12 @@ image_transform image_transform::tween(double                 time,
     result.blend_mode       = std::max(source.blend_mode, dest.blend_mode);
     result.layer_depth      = dest.layer_depth;
 
+    result.lut3d          = dest.lut3d; // snap to destination (cannot interpolate LUT data)
+    result.lut3d_strength = static_cast<float>(do_tween(time,
+                                                        static_cast<double>(source.lut3d_strength),
+                                                        static_cast<double>(dest.lut3d_strength),
+                                                        duration,
+                                                        tween));
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
     for (int i = 0; i < 3; ++i) {
@@ -169,6 +175,8 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
+               lhs.perspective == rhs.perspective && lhs.lut3d.get() == rhs.lut3d.get() &&
+               eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
                boost::range::equal(lhs.midtone, rhs.midtone, eq) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -109,14 +109,6 @@ image_transform image_transform::tween(double                 time,
     result.blend_mode       = std::max(source.blend_mode, dest.blend_mode);
     result.layer_depth      = dest.layer_depth;
 
-    result.lut3d          = dest.lut3d; // snap to destination (cannot interpolate LUT data)
-    result.lut3d_strength = static_cast<float>(do_tween(time,
-                                                        static_cast<double>(source.lut3d_strength),
-                                                        static_cast<double>(dest.lut3d_strength),
-                                                        duration,
-                                                        tween));
-    result.curves         = dest.curves; // snap to destination (control-point sets cannot interpolate)
-    result.hue_curves     = dest.hue_curves; // snap to destination
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
     for (int i = 0; i < 3; ++i) {
@@ -140,6 +132,14 @@ image_transform image_transform::tween(double                 time,
         result.cdl_power[i]  = do_tween(time, source.cdl_power[i], dest.cdl_power[i], duration, tween);
     }
     result.cdl_saturation = do_tween(time, source.cdl_saturation, dest.cdl_saturation, duration, tween);
+    result.lut3d          = dest.lut3d; // snap to destination (cannot interpolate LUT data)
+    result.lut3d_strength = static_cast<float>(do_tween(time,
+                                                        static_cast<double>(source.lut3d_strength),
+                                                        static_cast<double>(dest.lut3d_strength),
+                                                        duration,
+                                                        tween));
+    result.curves         = dest.curves; // snap to destination (control-point sets cannot interpolate)
+    result.hue_curves     = dest.hue_curves; // snap to destination
 
     do_tween_rectangle(source.crop, dest.crop, result.crop, time, duration, tween);
     do_tween_corners(source.perspective, dest.perspective, result.perspective, time, duration, tween);
@@ -177,7 +177,19 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.softness, rhs.chroma.softness) &&
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
-               lhs.perspective == rhs.perspective && lhs.lut3d.get() == rhs.lut3d.get() &&
+               lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
+               eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
+               boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
+               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
+               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
+               boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
+               boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
+               eq(lhs.split_balance, rhs.split_balance) &&
+               boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
+               boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
+               boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
+               eq(lhs.cdl_saturation, rhs.cdl_saturation) &&
+               lhs.lut3d.get() == rhs.lut3d.get() &&
                eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) &&
                lhs.hue_curves.get() == rhs.hue_curves.get() && lhs.curves.enable == rhs.curves.enable &&
                [&]() {
@@ -193,19 +205,6 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                    return cc_eq(lhs.curves.master, rhs.curves.master) && cc_eq(lhs.curves.red, rhs.curves.red) &&
                           cc_eq(lhs.curves.green, rhs.curves.green) && cc_eq(lhs.curves.blue, rhs.curves.blue);
                }() ||
-               eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) ||
-               lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
-               eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&
-               boost::range::equal(lhs.midtone, rhs.midtone, eq) &&
-               boost::range::equal(lhs.gain, rhs.gain, eq) && eq(lhs.hue_shift, rhs.hue_shift) &&
-               eq(lhs.shadows, rhs.shadows) && eq(lhs.highlights, rhs.highlights) &&
-               boost::range::equal(lhs.split_shadow_color, rhs.split_shadow_color, eq) &&
-               boost::range::equal(lhs.split_highlight_color, rhs.split_highlight_color, eq) &&
-               eq(lhs.split_balance, rhs.split_balance) &&
-               boost::range::equal(lhs.cdl_slope, rhs.cdl_slope, eq) &&
-               boost::range::equal(lhs.cdl_offset, rhs.cdl_offset, eq) &&
-               boost::range::equal(lhs.cdl_power, rhs.cdl_power, eq) &&
-               eq(lhs.cdl_saturation, rhs.cdl_saturation) ||
            lhs.enable_geometry_modifiers == rhs.enable_geometry_modifiers;
 }
 

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -115,6 +115,7 @@ image_transform image_transform::tween(double                 time,
                                                         static_cast<double>(dest.lut3d_strength),
                                                         duration,
                                                         tween));
+    result.curves         = dest.curves; // snap to destination (control-point sets cannot interpolate)
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
     for (int i = 0; i < 3; ++i) {
@@ -176,6 +177,21 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.spill_suppress, rhs.chroma.spill_suppress) &&
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
                lhs.perspective == rhs.perspective && lhs.lut3d.get() == rhs.lut3d.get() &&
+               eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) &&
+               lhs.curves.enable == rhs.curves.enable &&
+               [&]() {
+                   auto cc_eq = [](const core::curve_channel& a, const core::curve_channel& b) {
+                       if (a.count != b.count)
+                           return false;
+                       for (int i = 0; i < a.count; ++i)
+                           if (std::abs(a.points[i].x - b.points[i].x) >= 5e-8 ||
+                               std::abs(a.points[i].y - b.points[i].y) >= 5e-8)
+                               return false;
+                       return true;
+                   };
+                   return cc_eq(lhs.curves.master, rhs.curves.master) && cc_eq(lhs.curves.red, rhs.curves.red) &&
+                          cc_eq(lhs.curves.green, rhs.curves.green) && cc_eq(lhs.curves.blue, rhs.curves.blue);
+               }() ||
                eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) ||
                lhs.perspective == rhs.perspective && eq(lhs.temperature, rhs.temperature) &&
                eq(lhs.tint, rhs.tint) && boost::range::equal(lhs.lift, rhs.lift, eq) &&

--- a/src/core/frame/frame_transform.cpp
+++ b/src/core/frame/frame_transform.cpp
@@ -116,6 +116,7 @@ image_transform image_transform::tween(double                 time,
                                                         duration,
                                                         tween));
     result.curves         = dest.curves; // snap to destination (control-point sets cannot interpolate)
+    result.hue_curves     = dest.hue_curves; // snap to destination
     result.temperature = do_tween(time, source.temperature, dest.temperature, duration, tween);
     result.tint        = do_tween(time, source.tint, dest.tint, duration, tween);
     for (int i = 0; i < 3; ++i) {
@@ -178,7 +179,7 @@ bool operator==(const image_transform& lhs, const image_transform& rhs)
                eq(lhs.chroma.spill_suppress_saturation, rhs.chroma.spill_suppress_saturation) && lhs.crop == rhs.crop &&
                lhs.perspective == rhs.perspective && lhs.lut3d.get() == rhs.lut3d.get() &&
                eq(static_cast<double>(lhs.lut3d_strength), static_cast<double>(rhs.lut3d_strength)) &&
-               lhs.curves.enable == rhs.curves.enable &&
+               lhs.hue_curves.get() == rhs.hue_curves.get() && lhs.curves.enable == rhs.curves.enable &&
                [&]() {
                    auto cc_eq = [](const core::curve_channel& a, const core::curve_channel& b) {
                        if (a.count != b.count)

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -26,9 +26,18 @@
 #include <core/mixer/image/blend_modes.h>
 
 #include <array>
+#include <memory>
 #include <optional>
+#include <vector>
 
 namespace caspar { namespace core {
+
+// 3D LUT data (parsed from .cube files).
+struct lut3d_data final
+{
+    int                size = 0; // LUT dimension (e.g. 33 for a 33x33x33 LUT)
+    std::vector<float> data;      // size*size*size*3 RGB float values
+};
 
 struct chroma
 {
@@ -150,6 +159,8 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
+    std::shared_ptr<const lut3d_data> lut3d;                // nullptr = disabled
+    float                             lut3d_strength = 1.0f; // 0..1 mix factor
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -39,6 +39,29 @@ struct lut3d_data final
     std::vector<float> data;      // size*size*size*3 RGB float values
 };
 
+// Tone curve control points (per-channel + master, up to 16 points each).
+struct curve_point final
+{
+    double x = 0.0;
+    double y = 0.0;
+};
+
+// count == 0 means "identity" (the LUT builder returns a linear ramp).
+struct curve_channel final
+{
+    int                         count = 0;
+    std::array<curve_point, 16> points{};
+};
+
+struct tone_curves final
+{
+    bool          enable = false;
+    curve_channel master; // applied as a global tone after per-channel curves
+    curve_channel red;
+    curve_channel green;
+    curve_channel blue;
+};
+
 struct chroma
 {
     enum class legacy_type
@@ -161,6 +184,7 @@ struct image_transform final
     core::chroma          chroma;
     std::shared_ptr<const lut3d_data> lut3d;                // nullptr = disabled
     float                             lut3d_strength = 1.0f; // 0..1 mix factor
+    core::tone_curves                 curves;               // per-channel + master tone curves
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -62,6 +62,12 @@ struct tone_curves final
     curve_channel blue;
 };
 
+// Hue-curve data (Hue-vs-Hue, Hue-vs-Sat, Hue-vs-Lum, Sat-vs-Sat).
+struct hue_curve_data final
+{
+    std::vector<float> data; // 256*4 floats (R=HvH, G=HvS, B=HvL, A=SvS)
+};
+
 struct chroma
 {
     enum class legacy_type
@@ -185,6 +191,7 @@ struct image_transform final
     std::shared_ptr<const lut3d_data> lut3d;                // nullptr = disabled
     float                             lut3d_strength = 1.0f; // 0..1 mix factor
     core::tone_curves                 curves;               // per-channel + master tone curves
+    std::shared_ptr<const hue_curve_data> hue_curves;       // nullptr = disabled
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel

--- a/src/core/frame/frame_transform.h
+++ b/src/core/frame/frame_transform.h
@@ -163,6 +163,14 @@ inline constexpr grade_range cdl_offset{-1.0, 1.0};
 inline constexpr grade_range cdl_power{0.01, 10.0};
 inline constexpr grade_range cdl_saturation{0.0, 10.0};
 
+/// Curve control points are normalised on both axes.
+inline constexpr grade_range lut3d_strength{0.0, 1.0};
+inline constexpr grade_range curve_coord{0.0, 1.0};
+/// HUE_HUE and HUE_LUM are signed offsets (neutral 0); HUE_SAT and SAT_SAT are
+/// multipliers (neutral 1). Chosen by the curve the command names.
+inline constexpr grade_range hue_curve_offset{-1.0, 1.0};
+inline constexpr grade_range hue_curve_scale{0.0, 4.0};
+
 } // namespace grade_limits
 
 struct image_transform final
@@ -188,10 +196,6 @@ struct image_transform final
     corners               perspective;
     core::levels          levels;
     core::chroma          chroma;
-    std::shared_ptr<const lut3d_data> lut3d;                // nullptr = disabled
-    float                             lut3d_strength = 1.0f; // 0..1 mix factor
-    core::tone_curves                 curves;               // per-channel + master tone curves
-    std::shared_ptr<const hue_curve_data> hue_curves;       // nullptr = disabled
     double                temperature = 0.0; // white balance: -1 cool .. +1 warm
     double                tint        = 0.0; // white balance: -1 magenta .. +1 green
     std::array<double, 3> lift    = {0.0, 0.0, 0.0}; // shadow offset per channel
@@ -207,6 +211,10 @@ struct image_transform final
     std::array<double, 3> cdl_offset     = {0.0, 0.0, 0.0}; // ASC CDL offset
     std::array<double, 3> cdl_power      = {1.0, 1.0, 1.0}; // ASC CDL power
     double                cdl_saturation = 1.0;             // ASC CDL saturation
+    std::shared_ptr<const lut3d_data> lut3d;                // nullptr = disabled
+    float                             lut3d_strength = 1.0f; // 0..1 mix factor
+    core::tone_curves                 curves;               // per-channel + master tone curves
+    std::shared_ptr<const hue_curve_data> hue_curves;       // nullptr = disabled
 
     bool             is_key      = false;
     bool             invert      = false;

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1470,6 +1470,104 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+std::future<std::wstring> mixer_lut3d_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            if (!t.lut3d)
+                return L"201 MIXER OK\r\nNONE\r\n";
+            return L"201 MIXER OK\r\nACTIVE " + std::to_wstring(t.lut3d->size) + L" " +
+                   std::to_wstring(t.lut3d_strength) + L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"NONE")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.lut3d          = nullptr;
+                t.image_transform.lut3d_strength = 1.0f;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    // Resolve the path: try as given, else relative to the media folder.
+    std::wstring path = ctx.parameters.at(0);
+    if (!std::ifstream(path).is_open())
+        path = caspar::env::media_folder() + L"/" + path;
+
+    auto lut = parse_cube_file(path);
+    if (!lut)
+        return make_ready_future<std::wstring>(L"404 LUT3D LOAD FAILED\r\n");
+
+    float strength = ctx.parameters.size() > 1 ? std::stof(ctx.parameters[1]) : 1.0f;
+
+    transforms_applier transforms(ctx);
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.lut3d          = lut;
+            transform.image_transform.lut3d_strength = strength;
+            return transform;
+        },
+        0,
+        L"linear"));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
+static std::shared_ptr<const core::lut3d_data> parse_cube_file(const std::wstring& path)
+{
+    std::ifstream file(path);
+    if (!file.is_open())
+        return nullptr;
+
+    auto        lut = std::make_shared<core::lut3d_data>();
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#')
+            continue;
+        size_t start = line.find_first_not_of(" \t\r\n");
+        if (start == std::string::npos)
+            continue;
+        line = line.substr(start);
+
+        if (line.rfind("TITLE", 0) == 0 || line.rfind("DOMAIN_MIN", 0) == 0 || line.rfind("DOMAIN_MAX", 0) == 0)
+            continue;
+
+        if (line.rfind("LUT_3D_SIZE", 0) == 0) {
+            lut->size = std::stoi(line.substr(12));
+            lut->data.reserve(static_cast<size_t>(lut->size) * lut->size * lut->size * 3);
+            continue;
+        }
+        if (line.rfind("LUT_1D_SIZE", 0) == 0)
+            continue; // skip 1D LUT sections
+
+        if (lut->size > 0) {
+            float r, g, b;
+            if (std::sscanf(line.c_str(), "%f %f %f", &r, &g, &b) == 3) {
+                lut->data.push_back(r);
+                lut->data.push_back(g);
+                lut->data.push_back(b);
+            }
+        }
+    }
+
+    size_t expected = static_cast<size_t>(lut->size) * lut->size * lut->size * 3;
+    if (lut->size <= 0 || lut->data.size() != expected)
+        return nullptr;
+
+    return lut;
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2139,6 +2237,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER GRID", mixer_grid_command, 1);
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER LUT3D", mixer_lut3d_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1568,6 +1568,97 @@ static std::shared_ptr<const core::lut3d_data> parse_cube_file(const std::wstrin
     return lut;
 }
 
+std::future<std::wstring> mixer_curves_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto t2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [t2]() -> std::wstring {
+            const auto& cv = t2.get().image_transform.curves;
+            if (!cv.enable)
+                return L"201 MIXER OK\r\nDISABLED\r\n";
+            auto dump = [](const core::curve_channel& c) -> std::wstring {
+                std::wstring s;
+                for (int i = 0; i < c.count; ++i)
+                    s += std::to_wstring(c.points[i].x) + L" " + std::to_wstring(c.points[i].y) + L" ";
+                return s;
+            };
+            return L"201 MIXER OK\r\nMASTER " + dump(cv.master) + L"\r\nR " + dump(cv.red) + L"\r\nG " +
+                   dump(cv.green) + L"\r\nB " + dump(cv.blue) + L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"RESET")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.curves = core::tone_curves{};
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    const std::wstring& ch_str = ctx.parameters.at(0);
+    int                 ch     = -1;
+    if (boost::iequals(ch_str, L"MASTER"))
+        ch = 0;
+    else if (boost::iequals(ch_str, L"R") || boost::iequals(ch_str, L"RED"))
+        ch = 1;
+    else if (boost::iequals(ch_str, L"G") || boost::iequals(ch_str, L"GREEN"))
+        ch = 2;
+    else if (boost::iequals(ch_str, L"B") || boost::iequals(ch_str, L"BLUE"))
+        ch = 3;
+
+    if (ch < 0)
+        return make_ready_future<std::wstring>(L"400 ERROR\r\n");
+
+    if (ctx.parameters.size() == 1) {
+        auto t2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [t2, ch]() -> std::wstring {
+            const auto&                cv = t2.get().image_transform.curves;
+            const core::curve_channel& cc = (ch == 0) ? cv.master : (ch == 1) ? cv.red : (ch == 2) ? cv.green : cv.blue;
+            std::wstring               s  = L"201 MIXER OK\r\n";
+            for (int i = 0; i < cc.count; ++i)
+                s += std::to_wstring(cc.points[i].x) + L" " + std::to_wstring(cc.points[i].y) + L" ";
+            return s + L"\r\n";
+        });
+    }
+
+    int n_params = static_cast<int>(ctx.parameters.size()) - 1;
+    if (n_params < 4 || n_params % 2 != 0 || n_params / 2 > 16)
+        return make_ready_future<std::wstring>(L"400 ERROR\r\n");
+
+    core::curve_channel new_cc;
+    new_cc.count = n_params / 2;
+    for (int i = 0; i < new_cc.count; ++i) {
+        new_cc.points[i].x = std::stod(ctx.parameters.at(1 + i * 2));
+        new_cc.points[i].y = std::stod(ctx.parameters.at(2 + i * 2));
+    }
+
+    transforms_applier transforms(ctx);
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            auto& cv  = transform.image_transform.curves;
+            cv.enable = true;
+            switch (ch) {
+                case 0: cv.master = new_cc; break;
+                case 1: cv.red = new_cc; break;
+                case 2: cv.green = new_cc; break;
+                case 3: cv.blue = new_cc; break;
+            }
+            return transform;
+        },
+        0,
+        L"linear"));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2238,6 +2329,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER COMMIT", mixer_commit_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LUT3D", mixer_lut3d_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER CURVES", mixer_curves_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1659,6 +1659,118 @@ std::future<std::wstring> mixer_curves_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
+static std::shared_ptr<core::hue_curve_data>
+build_hue_curve_lut(const std::vector<std::pair<float, float>>& points, int channel)
+{
+    // 256-entry LUT built from control points by linear interpolation.
+    // channel: 0=HvH, 1=HvS, 2=HvL, 3=SvS. Defaults are identity per channel.
+    auto data = std::make_shared<core::hue_curve_data>();
+    data->data.resize(256 * 4, 0.0f);
+    for (int i = 0; i < 256; ++i) {
+        data->data[i * 4 + 0] = 0.0f; // HvH offset
+        data->data[i * 4 + 1] = 1.0f; // HvS multiplier
+        data->data[i * 4 + 2] = 0.0f; // HvL offset
+        data->data[i * 4 + 3] = 1.0f; // SvS multiplier
+    }
+
+    if (points.size() < 2)
+        return data;
+
+    auto sorted = points;
+    std::sort(sorted.begin(), sorted.end());
+
+    for (int i = 0; i < 256; ++i) {
+        float x   = static_cast<float>(i) / 255.0f;
+        float val = 0.0f;
+        if (x <= sorted.front().first) {
+            val = sorted.front().second;
+        } else if (x >= sorted.back().first) {
+            val = sorted.back().second;
+        } else {
+            for (size_t j = 0; j + 1 < sorted.size(); ++j) {
+                if (x >= sorted[j].first && x <= sorted[j + 1].first) {
+                    float t = (x - sorted[j].first) / (sorted[j + 1].first - sorted[j].first);
+                    val     = sorted[j].second + t * (sorted[j + 1].second - sorted[j].second);
+                    break;
+                }
+            }
+        }
+        data->data[i * 4 + channel] = val;
+    }
+    return data;
+}
+
+std::future<std::wstring> mixer_huecurve_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            return t.hue_curves ? L"201 MIXER OK\r\nACTIVE\r\n" : L"201 MIXER OK\r\nDISABLED\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"RESET")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.hue_curves = nullptr;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    int channel = -1;
+    if (boost::iequals(ctx.parameters.at(0), L"HUE_HUE"))
+        channel = 0;
+    else if (boost::iequals(ctx.parameters.at(0), L"HUE_SAT"))
+        channel = 1;
+    else if (boost::iequals(ctx.parameters.at(0), L"HUE_LUM"))
+        channel = 2;
+    else if (boost::iequals(ctx.parameters.at(0), L"SAT_SAT"))
+        channel = 3;
+    if (channel < 0)
+        return make_ready_future<std::wstring>(L"400 ERROR\r\n");
+
+    int n_params = static_cast<int>(ctx.parameters.size()) - 1;
+    if (n_params < 4 || n_params % 2 != 0)
+        return make_ready_future<std::wstring>(L"400 ERROR\r\n");
+
+    std::vector<std::pair<float, float>> points;
+    for (int i = 0; i < n_params / 2; ++i) {
+        float h = std::stof(ctx.parameters.at(1 + i * 2));
+        float v = std::stof(ctx.parameters.at(2 + i * 2));
+        points.emplace_back(h, v);
+    }
+
+    auto lut = build_hue_curve_lut(points, channel);
+
+    transforms_applier transforms(ctx);
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            // Merge this channel into any existing hue curves.
+            if (transform.image_transform.hue_curves) {
+                auto merged = std::make_shared<core::hue_curve_data>(*transform.image_transform.hue_curves);
+                for (int i = 0; i < 256; ++i)
+                    merged->data[i * 4 + channel] = lut->data[i * 4 + channel];
+                transform.image_transform.hue_curves = merged;
+            } else {
+                transform.image_transform.hue_curves = lut;
+            }
+            return transform;
+        },
+        0,
+        L"linear"));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+}
+
 std::future<std::wstring> mixer_fill_command(command_context& ctx)
 {
     if (ctx.parameters.empty()) {
@@ -2330,6 +2442,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_channel_command(L"Mixer Commands", L"MIXER CLEAR", mixer_clear_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER LUT3D", mixer_lut3d_command, 0);
     repo->register_channel_command(L"Mixer Commands", L"MIXER CURVES", mixer_curves_command, 0);
+    repo->register_channel_command(L"Mixer Commands", L"MIXER HUECURVE", mixer_huecurve_command, 0);
     repo->register_command(L"Mixer Commands", L"CHANNEL_GRID", channel_grid_command, 0);
 
     repo->register_command(L"Thumbnail Commands", L"THUMBNAIL LIST", thumbnail_list_command, 0);

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1470,64 +1470,8 @@ std::future<std::wstring> mixer_cdl_command(command_context& ctx)
     return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
-std::future<std::wstring> mixer_lut3d_command(command_context& ctx)
-{
-    if (ctx.parameters.empty()) {
-        auto transform2 = get_current_transform(ctx).share();
-        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
-            auto t = transform2.get().image_transform;
-            if (!t.lut3d)
-                return L"201 MIXER OK\r\nNONE\r\n";
-            return L"201 MIXER OK\r\nACTIVE " + std::to_wstring(t.lut3d->size) + L" " +
-                   std::to_wstring(t.lut3d_strength) + L"\r\n";
-        });
-    }
-
-    if (boost::iequals(ctx.parameters.at(0), L"NONE")) {
-        transforms_applier transforms(ctx);
-        transforms.add(stage::transform_tuple_t(
-            ctx.layer_index(),
-            [](frame_transform t) {
-                t.image_transform.lut3d          = nullptr;
-                t.image_transform.lut3d_strength = 1.0f;
-                return t;
-            },
-            0,
-            L"linear"));
-        transforms.apply();
-        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
-    }
-
-    // Resolve the path: try as given, else relative to the media folder.
-    std::wstring path = ctx.parameters.at(0);
-    if (!boost::filesystem::exists(boost::filesystem::path(path)))
-        path = caspar::env::media_folder() + L"/" + path;
-
-    auto lut = parse_cube_file(path);
-    if (!lut)
-        return make_ready_future<std::wstring>(L"404 LUT3D LOAD FAILED\r\n");
-
-    float strength = ctx.parameters.size() > 1 ? std::stof(ctx.parameters[1]) : 1.0f;
-
-    transforms_applier transforms(ctx);
-    transforms.add(stage::transform_tuple_t(
-        ctx.layer_index(),
-        [=](frame_transform transform) -> frame_transform {
-            transform.image_transform.lut3d          = lut;
-            transform.image_transform.lut3d_strength = strength;
-            return transform;
-        },
-        0,
-        L"linear"));
-    transforms.apply();
-
-    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
-}
-
 static std::shared_ptr<const core::lut3d_data> parse_cube_file(const std::wstring& path)
 {
-    // std::ifstream takes a wide path only as an MSVC extension; boost's does it
-    // portably, which is what the Linux build needs.
     boost::filesystem::path     cube_path(path);
     boost::filesystem::ifstream file(cube_path);
     if (!file.is_open())
@@ -1569,6 +1513,63 @@ static std::shared_ptr<const core::lut3d_data> parse_cube_file(const std::wstrin
         return nullptr;
 
     return lut;
+}
+
+std::future<std::wstring> mixer_lut3d_command(command_context& ctx)
+{
+    if (ctx.parameters.empty()) {
+        auto transform2 = get_current_transform(ctx).share();
+        return std::async(std::launch::deferred, [transform2]() -> std::wstring {
+            auto t = transform2.get().image_transform;
+            if (!t.lut3d)
+                return L"201 MIXER OK\r\nNONE\r\n";
+            return L"201 MIXER OK\r\nACTIVE " + std::to_wstring(t.lut3d->size) + L" " +
+                   std::to_wstring(t.lut3d_strength) + L"\r\n";
+        });
+    }
+
+    if (boost::iequals(ctx.parameters.at(0), L"NONE")) {
+        transforms_applier transforms(ctx);
+        transforms.add(stage::transform_tuple_t(
+            ctx.layer_index(),
+            [](frame_transform t) {
+                t.image_transform.lut3d          = nullptr;
+                t.image_transform.lut3d_strength = 1.0f;
+                return t;
+            },
+            0,
+            L"linear"));
+        transforms.apply();
+        return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
+    }
+
+    // Resolve the path: try as given, else relative to the media folder.
+    std::wstring path = ctx.parameters.at(0);
+    if (!boost::filesystem::exists(boost::filesystem::path(path)))
+        path = caspar::env::media_folder() + L"/" + path;
+
+    auto lut = parse_cube_file(path);
+    if (!lut)
+        return make_ready_future<std::wstring>(L"404 LUT3D LOAD FAILED\r\n");
+
+    float strength = ctx.parameters.size() > 1
+                         ? static_cast<float>(grade_param(ctx.parameters[1], core::grade_limits::lut3d_strength,
+                                                          L"LUT strength"))
+                         : 1.0f;
+
+    transforms_applier transforms(ctx);
+    transforms.add(stage::transform_tuple_t(
+        ctx.layer_index(),
+        [=](frame_transform transform) -> frame_transform {
+            transform.image_transform.lut3d          = lut;
+            transform.image_transform.lut3d_strength = strength;
+            return transform;
+        },
+        0,
+        L"linear"));
+    transforms.apply();
+
+    return make_ready_future<std::wstring>(L"202 MIXER OK\r\n");
 }
 
 std::future<std::wstring> mixer_curves_command(command_context& ctx)
@@ -1637,8 +1638,8 @@ std::future<std::wstring> mixer_curves_command(command_context& ctx)
     core::curve_channel new_cc;
     new_cc.count = n_params / 2;
     for (int i = 0; i < new_cc.count; ++i) {
-        new_cc.points[i].x = std::stod(ctx.parameters.at(1 + i * 2));
-        new_cc.points[i].y = std::stod(ctx.parameters.at(2 + i * 2));
+        new_cc.points[i].x = grade_param(ctx.parameters.at(1 + i * 2), core::grade_limits::curve_coord, L"curve x");
+        new_cc.points[i].y = grade_param(ctx.parameters.at(2 + i * 2), core::grade_limits::curve_coord, L"curve y");
     }
 
     transforms_applier transforms(ctx);
@@ -1745,8 +1746,13 @@ std::future<std::wstring> mixer_huecurve_command(command_context& ctx)
 
     std::vector<std::pair<float, float>> points;
     for (int i = 0; i < n_params / 2; ++i) {
-        float h = std::stof(ctx.parameters.at(1 + i * 2));
-        float v = std::stof(ctx.parameters.at(2 + i * 2));
+        float h = static_cast<float>(
+            grade_param(ctx.parameters.at(1 + i * 2), core::grade_limits::curve_coord, L"hue"));
+        // channel 1 (HUE_SAT) and 3 (SAT_SAT) scale; 0 (HUE_HUE) and 2 (HUE_LUM) offset.
+        const auto& v_range = (channel == 1 || channel == 3) ? core::grade_limits::hue_curve_scale
+                                                             : core::grade_limits::hue_curve_offset;
+        float v = static_cast<float>(
+            grade_param(ctx.parameters.at(2 + i * 2), v_range, L"hue curve value"));
         points.emplace_back(h, v);
     }
 

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1500,7 +1500,7 @@ std::future<std::wstring> mixer_lut3d_command(command_context& ctx)
 
     // Resolve the path: try as given, else relative to the media folder.
     std::wstring path = ctx.parameters.at(0);
-    if (!std::ifstream(path).is_open())
+    if (!boost::filesystem::exists(boost::filesystem::path(path)))
         path = caspar::env::media_folder() + L"/" + path;
 
     auto lut = parse_cube_file(path);
@@ -1526,7 +1526,10 @@ std::future<std::wstring> mixer_lut3d_command(command_context& ctx)
 
 static std::shared_ptr<const core::lut3d_data> parse_cube_file(const std::wstring& path)
 {
-    std::ifstream file(path);
+    // std::ifstream takes a wide path only as an MSVC extension; boost's does it
+    // portably, which is what the Linux build needs.
+    boost::filesystem::path     cube_path(path);
+    boost::filesystem::ifstream file(cube_path);
     if (!file.is_open())
         return nullptr;
 


### PR DESCRIPTION
## Summary

Adds the LUT/texture-backed grading tools to the OpenGL mixer as per-layer AMCP `MIXER` commands:

- **`MIXER LUT3D`** — load an Adobe `.cube` 3D LUT (creative look) and apply it with an adjustable strength mix.
- **`MIXER CURVES`** — per-channel + master tone curves defined by control points (monotone-cubic spline → 1D LUT).
- **`MIXER HUECURVE`** — hue-vs-hue / hue-vs-sat / hue-vs-lum / sat-vs-sat curves.

All are off by default with zero cost when unused, and operate in the working color space before the legacy levels/CSB stage.

## Shared infrastructure

These three features share the GPU plumbing this PR introduces:
- New `texture_id` enum entries (`lut3d_tex`, `curve_lut_tex`, `hue_curve_tex`).
- Managed GL LUT textures in the image kernel with explicit create/upload/delete lifetime (freed in the kernel dtor; the 3D LUT re-uploads only when its data pointer changes).
- CPU-side LUT builders: a `.cube` parser (`parse_cube_file`), a Fritsch–Carlson monotone-cubic Hermite curve builder (`build_curve_lut`, no overshoot), and a hue-curve LUT builder.

## Commits

1. `mixer: add MIXER LUT3D command (.cube 3D LUT loader)`
2. `mixer: add MIXER CURVES command (tone curves)`
3. `mixer: add MIXER HUECURVE command (hue curves)`

## AMCP syntax

```
MIXER <ch-layer> LUT3D <path.cube> [strength]
MIXER <ch-layer> LUT3D NONE
MIXER <ch-layer> CURVES R|G|B|MASTER x1 y1 x2 y2 ...   (2–16 points, x ascending in 0..1)
MIXER <ch-layer> CURVES RESET
MIXER <ch-layer> HUECURVE <HUE_HUE|HUE_SAT|HUE_LUM|SAT_SAT> h1 v1 h2 v2 ...
MIXER <ch-layer> HUECURVE RESET
```

Any command with no parameters queries the current state. `.cube` paths are resolved as given, otherwise relative to the configured media folder. `CURVES`/`HUECURVE` also support per-channel queries.

### Examples

```
MIXER 1-10 LUT3D looks/teal_orange.cube 0.8      # load a look at 80% strength
MIXER 1-10 LUT3D NONE                            # disable
MIXER 1-10 CURVES MASTER 0 0 0.5 0.6 1 1         # lift midtones (S-curve-ish)
MIXER 1-10 CURVES R 0 0.05 1 0.95                # tame red contrast
MIXER 1-10 HUECURVE HUE_SAT 0.33 1.4             # boost saturation around green
MIXER 1-10 HUECURVE RESET
```

## Implementation notes

- Each field is added to `image_transform` and wired through `tween`, `operator==`, and the transform-combine step. LUT/curve data is snapped (not interpolated) across transitions; the 3D LUT strength tweens. Combine overrides when the incoming transform has a LUT/curve set.
- Curve LUTs are packed to match the shader's internal BGR working order (the `.r` slot holds the displayed-Blue curve, `.b` the displayed-Red curve). The 3D LUT swizzles `.bgr` for the lookup and back.
- `rgb2hsv`/`hsv2rgb` already existed upstream and are reused by the hue curves.
- Independent of #1758, #1762, #1765, and #1766 — builds on clean `master`.

## Testing

Builds clean on Windows (VS2026, Release). Wiki docs to follow.