### PR TITLE
feat(decklink): add disabled keyer option

### DIFF
--- a/src/modules/decklink/consumer/config.cpp
+++ b/src/modules/decklink/consumer/config.cpp
@@ -160,6 +160,8 @@ configuration parse_xml_config(const boost::property_tree::wptree&  ptree,
         config.keyer = configuration::keyer_t::external_keyer;
     } else if (keyer == L"internal") {
         config.keyer = configuration::keyer_t::internal_keyer;
+    } else if (keyer == L"disabled") {
+        config.keyer = configuration::keyer_t::disabled_keyer;
     } else if (keyer == L"external_separate_device") {
         config.keyer = configuration::keyer_t::external_keyer;
 
@@ -219,6 +221,8 @@ configuration parse_amcp_config(const std::vector<std::wstring>&     params,
         config.keyer = configuration::keyer_t::internal_keyer;
     } else if (contains_param(L"EXTERNAL_KEY", params)) {
         config.keyer = configuration::keyer_t::external_keyer;
+    } else if (contains_param(L"DISABLED_KEY", params)) {
+        config.keyer = configuration::keyer_t::disabled_keyer;
     } else {
         config.keyer = configuration::keyer_t::default_keyer;
     }

--- a/src/modules/decklink/consumer/config.h
+++ b/src/modules/decklink/consumer/config.h
@@ -74,6 +74,7 @@ struct configuration
     {
         internal_keyer,
         external_keyer,
+        disabled_keyer,
         default_keyer = external_keyer
     };
 

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -157,6 +157,12 @@ void set_keyer(const com_iface_ptr<IDeckLinkProfileAttributes>& attributes,
                BMDPixelFormat                                   pixel_format,
                const std::wstring&                              print)
 {
+    if (keyer == configuration::keyer_t::disabled_keyer) {
+        decklink_keyer->Disable();
+        CASPAR_LOG(info) << print << L" Keyer disabled.";
+        return;
+    }
+
     if (keyer == configuration::keyer_t::internal_keyer || keyer == configuration::keyer_t::external_keyer) {
         BMDDisplayMode actualMode = bmdModeUnknown;
         BOOL           supported  = FALSE;

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -158,7 +158,6 @@ void set_keyer(const com_iface_ptr<IDeckLinkProfileAttributes>& attributes,
                const std::wstring&                              print)
 {
     if (keyer == configuration::keyer_t::disabled_keyer) {
-        decklink_keyer->Disable();
         CASPAR_LOG(info) << print << L" Keyer disabled.";
         return;
     }

--- a/src/modules/decklink/consumer/monitor.cpp
+++ b/src/modules/decklink/consumer/monitor.cpp
@@ -62,6 +62,8 @@ core::monitor::state get_state_for_config(const configuration& config, const cor
         state["decklink/keyer"] = std::wstring(L"external");
     } else if (config.keyer == configuration::keyer_t::internal_keyer) {
         state["decklink/keyer"] = std::wstring(L"internal");
+    } else if (config.keyer == configuration::keyer_t::disabled_keyer) {
+        state["decklink/keyer"] = std::wstring(L"disabled");
     }
 
     if (config.latency == configuration::latency_t::low_latency) {

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -89,7 +89,7 @@
                 <key-device>device + 1 [1..] (This is only used with the external_separate_device mode)</key-device>
                 <embedded-audio>false [true|false]</embedded-audio>
                 <latency>normal [normal|low|default]</latency>
-                <keyer>external [external|external_separate_device|internal|default]</keyer>
+                <keyer>external [external|external_separate_device|internal|disabled|default]</keyer>
                 <key-only>false [true|false]</key-only>
                 <buffer-depth>3 [1..]</buffer-depth>
                 <pixel-format>[yuv|rgba](default is rgba for 8bit channels, yuv for high bit-depth channels)</pixel-format>


### PR DESCRIPTION
## Summary

Adds a `disabled` keyer option for the DeckLink consumer, allowing the
keyer to be skipped entirely instead of being enabled as `internal` or
`external`.

## Motivation

Not every DeckLink output is used for keying — a given device/connector
may be dedicated to plain playout while another output on the same
device is used for a different purpose. With the current
`internal`/`external`/`default` options, the consumer always attempts
to enable the keyer regardless of whether that output is actually
intended to key anything, which can produce a spurious
`Failed to enable external keyer` error when the connector isn't wired
or configured for keying and an internal keyer is missing. This adds an explicit `disabled` option so an
output can be configured to skip keyer setup entirely when it isn't
needed for that channel.

## Changes

- `config.h`: add `disabled_keyer` to the `keyer_t` enum
- `config.cpp`: support `<keyer>disabled</keyer>` in XML config and
  `DISABLED_KEY` as an AMCP consumer parameter
- `decklink_consumer.cpp`: `set_keyer()` now returns early with an
  info-level log (`Keyer disabled.`) when `disabled_keyer` is
  configured, without touching the hardware keyer
- `monitor.cpp`: report `decklink/keyer` as `"disabled"` in the OSC/
  monitor state when this option is active
- `casparcg.config`: document the new `disabled` option alongside the
  existing `keyer` choices

## Testing

- Verified config parsing for both XML (`<keyer>disabled</keyer>`) and
  AMCP (`DISABLED_KEY`) paths
- Verified `decklink/keyer` monitor state reports `disabled` correctly
- No changes to existing `internal`/`external`/`default` keyer
  behavior