### PR TITLE
fix(decklink): free model name string returned by GetModelName()

### DIFF
--- a/src/modules/decklink/decklink_api.h
+++ b/src/modules/decklink/decklink_api.h
@@ -112,6 +112,7 @@ T* get_raw(const CComPtr<T>& ptr)
 #include "linux_interop/DeckLinkAPIConfiguration.h"
 #include "linux_interop/DeckLinkAPIConfiguration_v10_11.h"
 #include "linux_interop/DeckLinkAPI_v10_11.h"
+#include <cstdlib>
 #include <memory>
 #include <typeinfo>
 
@@ -124,7 +125,13 @@ using BOOL     = bool;
 using UINT32   = uint32_t;
 using LONGLONG = int64_t;
 
-static std::wstring to_string(String utf16_string) { return u16(utf16_string); }
+// Takes ownership of utf16_string, matching the BSTR to_string() overload above, which also frees its input.
+static std::wstring to_string(String utf16_string)
+{
+    auto result = u16(utf16_string);
+    free((void*)utf16_string);
+    return result;
+}
 
 static void com_initialize() {}
 


### PR DESCRIPTION
Updated: (Note, this is an AI assisted modification)

### What
`get_model_name()`, `get_mode_name()` and `version()` in
`src/modules/decklink/util/util.h` each obtain a `String` from a DeckLink SDK
`Get*()` call (`GetModelName`/`GetName`/`GetString`) and pass it to
`to_string()`. On non-Windows platforms these calls return a heap-allocated
C string that the caller owns and must free, but `to_string()` only
converted it, leaking it on every call.

### Why
On Windows, `String` is a `BSTR` and `to_string()` already takes ownership
of it via `bstr_t(bstr_string, false)`, whose destructor frees the BSTR.
An earlier version of this PR freed the string again at the `get_model_name()`
call site via `SysFreeString()`, which would double-free on Windows
(as pointed out in review) since `to_string()` already owns and frees it.

### Change
Rework the non-Windows `to_string()` overload in `decklink_api.h` to take
ownership of its input and `free()` it after conversion, mirroring the
existing Windows behaviour. This fixes the leak uniformly for all three
call sites, with no risk of double-freeing on Windows. No behavioral/output
change - this is purely a memory-leak fix.