### PR TITLE
fix(html): work around CEF utility subprocess stack-smashing crash

### DIFF
--- a/src/modules/html/html.cpp
+++ b/src/modules/html/html.cpp
@@ -203,6 +203,14 @@ class renderer_application
         command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
         command_line->AppendSwitchWithValue("remote-allow-origins", "*");
 
+        // Component updates (e.g. CRLSet) are irrelevant for an embedded playout renderer, and starting
+        // the updater's Unzipper utility process has been observed to crash with a stack-smashing abort
+        // on Linux (mismatched stack-protector settings across the prebuilt CEF binary after fork()).
+        // Disabling updates avoids ever spawning that process; the flag below is Chromium's own workaround
+        // for the same class of crash, kept as a defense in depth.
+        command_line->AppendSwitch("disable-component-update");
+        command_line->AppendSwitchWithValue("change-stack-guard-on-fork", "disable");
+
         if (process_type.empty() && !enable_gpu_) {
             // This gives more performance, but disabled gpu effects. Without it a single 1080p producer cannot be run
             // smoothly


### PR DESCRIPTION
## Problem
Reported crash: `/usr/bin/casparcg-server-beta --type=utility --utility-sub-type=unzip.mojom.Unzipper` terminates with `SIGABRT` and `*** stack smashing detected ***: terminated`, on Ubuntu 24.04 with CasparCG 2.5.0 (CEF 142). Stack trace: `CefExecuteProcess()` → `__stack_chk_fail()` → `__fortify_fail(...)`.

This happens when CEF/Chromium's component updater downloads a component (in the report, Chromium's CRLSet — component ID `hfnkpimlhhgieaddgfemjhofmfblmnib`) and spawns the `Unzipper` utility subprocess to extract it. The main CasparCG process and all playout channels are unaffected — this is isolated to the short-lived utility subprocess.

A near-identical report exists against JetBrains' own CEF (jcef) with the same `unzip.mojom.Unzipper` + `CefExecuteProcess`/`__stack_chk_fail` signature, suggesting this is a general CEF-on-Linux issue (changing the stack canary after `fork()` requires every function on the return path to be built with matching stack-protector settings — not guaranteed across a prebuilt CEF binary), not something CasparCG's own code is causing.

Searched the issue tracker for related reports (`stack smashing`, `__stack_chk_fail`, `unzip.mojom`, `change-stack-guard`, `component_crx_cache`, and all open `html`-labeled issues) — found nothing related; this appears to be a new report.

## Fix
Both changes are in `renderer_application::OnBeforeCommandLineProcessing()`, which already runs unconditionally for **every** CEF process type — including subprocess re-exec via `CefExecuteProcess` (this is also why a plain CasparCG CLI flag like `--disable-component-update` doesn't propagate to CEF subprocesses today: only switches added in this function do):

```cpp
command_line->AppendSwitch("disable-component-update");
command_line->AppendSwitchWithValue("change-stack-guard-on-fork", "disable");
```

- `disable-component-update`: CasparCG uses CEF purely as an embedded template/graphics renderer, not a general-purpose browser — Chromium's component updater (which is what spawns the Unzipper process in the first place) serves no purpose here. Removes the trigger entirely.
- `change-stack-guard-on-fork=disable`: Chromium's own documented workaround for this exact crash class, kept as defense in depth in case some other path spawns a subprocess.

Both follow the exact same pattern as the several other unconditional switches already set in this function (`disable-web-security`, `autoplay-policy`, etc.).

## Testing
Above is an AI assisted fix.  I tried fixing this one issue a few times before, need to verify if this fix works in casparcg or if something is actually needed in CEF.  (I think they may have fixed some of this in later versions)
