### PR TITLE
fix(mixer): the BT.601 matrix decoded green from Cr with the wrong coefficient

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -192,8 +192,17 @@ struct image_kernel::impl
         const auto is_hd       = params.pix_desc.planes.at(0).height > 700;
         const auto color_space = is_hd ? params.pix_desc.color_space : core::color_space::bt601;
 
+        // Row order is R, G, B; columns are Y, Cb, Cr. Each row follows from the
+        // luma coefficients: Cr->R is 2(1-Kr), Cb->B is 2(1-Kb), and the two green terms
+        // are -2(1-Kb)Kb/Kg and -2(1-Kr)Kr/Kg.
+        //
+        // The BT.601 Cr->G term was -0.509 and should be -0.714136:
+        // -2(1-0.299)(0.299)/0.587. BT.709 and BT.2020 were both already correct, which
+        // is what made this hard to see -- only SD material was affected, and only in
+        // green. Measured on flat patches decoded as BT.601, green was out by up to 20
+        // LSB on saturated colour while red and blue were exact.
         const float color_matrices[3][9] = {
-            {1.0, 0.0, 1.402, 1.0, -0.344, -0.509, 1.0, 1.772, 0.0},                          // bt.601
+            {1.0, 0.0, 1.402, 1.0, -0.344136, -0.714136, 1.0, 1.772, 0.0},                    // bt.601
             {1.0, 0.0, 1.5748, 1.0, -0.1873, -0.4681, 1.0, 1.8556, 0.0},                      // bt.709
             {1.0, 0.0, 1.4746, 1.0, -0.16455312684366, -0.57135312684366, 1.0, 1.8814, 0.0}}; // bt.2020
         const auto color_matrix = color_matrices[static_cast<int>(color_space)];

--- a/src/accelerator/vulkan/image/fragment_shader.frag
+++ b/src/accelerator/vulkan/image/fragment_shader.frag
@@ -61,8 +61,12 @@ layout(push_constant) uniform ParamsBlock {
     uint flags;
 };
 
+// Each matrix follows from its luma coefficients: Cr->R is 2(1-Kr), Cb->B is 2(1-Kb),
+// and the green terms are -2(1-Kb)Kb/Kg and -2(1-Kr)Kr/Kg. BT.601's Cr->G was -0.509
+// and should be -0.714136 = -2(1-0.299)(0.299)/0.587. Kept in step with the OpenGL
+// mixer, which carried the same wrong literal.
 const mat3[3] color_matrices = mat3[3](
-                    mat3(1.0, 0.0, 1.402, 1.0, -0.344, -0.509, 1.0, 1.772, 0.0),
+                    mat3(1.0, 0.0, 1.402, 1.0, -0.344136, -0.714136, 1.0, 1.772, 0.0),
                     mat3(1.0, 0.0, 1.5748, 1.0, -0.1873, -0.4681, 1.0, 1.8556, 0.0),
                     mat3(1.0, 0.0, 1.4746, 1.0, -0.16455312684366, -0.57135312684366, 1.0, 1.8814, 0.0)
                 ); 


### PR DESCRIPTION
﻿Both mixers carry this table:

```cpp
const float color_matrices[3][9] = {
    {1.0, 0.0, 1.402,  1.0, -0.344,   -0.509,   1.0, 1.772,  0.0},   // bt.601
    {1.0, 0.0, 1.5748, 1.0, -0.1873,  -0.4681,  1.0, 1.8556, 0.0},   // bt.709
    {1.0, 0.0, 1.4746, 1.0, -0.164553, -0.571353, 1.0, 1.8814, 0.0}} // bt.2020
```

Rows are R, G, B; columns are Y, Cb, Cr. Every row follows from the luma coefficients:
Cr→R is `2(1-Kr)`, Cb→B is `2(1-Kb)`, and the two green terms are `-2(1-Kb)Kb/Kg` and
`-2(1-Kr)Kr/Kg`.

For BT.601 (Kr=0.299, Kg=0.587, Kb=0.114) the Cr→G term is
`-2(1-0.299)(0.299)/0.587 = -0.714136`. The table says **-0.509**.

BT.709 and BT.2020 both check out exactly against the same derivation. Only BT.601 is
wrong, and only in green — which is why it survived: red and blue are perfect, and no
grey, greyscale ramp or near-neutral test picture can show it. It needs saturated colour
through an SD/BT.601 path.

`-0.344` is also the Cb→G term rounded to three places where the rest of the table carries
more; it becomes `-0.344136`.

## How it was found

Not by reading the table — by measuring the decode. Four flat asymmetric patches are
encoded to YCbCr with a known matrix, tagged, played, captured, and compared against
closed-form predictions for **both** candidate matrices. Red and blue landed within 1 LSB
of the BT.601 prediction on every patch while green was out by up to 20:

| patch | predicted G | measured G | error |
| :--- | ---: | ---: | ---: |
| (13, 230, 115) | 230.3 | 210 | −20.3 |
| (230, 38, 153) | 37.9 | 56 | +18.1 |
| (191, 76, 26) | 76.2 | 89 | +12.8 |
| (51, 140, 204) | 140.8 | 130 | −10.8 |

The error tracks Cr, in both directions — negative Cr pulls green down, positive Cr pushes
it up — which is what identifies the Cr→G term specifically rather than anything else in
the path. Red and blue being exact rules out the luma scaling, the studio-swing offsets and
the capture.

After the fix the same patches sit at **0.41 LSB**, which is the 8-bit chroma quantisation
floor for this round trip.

**Both mixers, identical to the digit.** OpenGL and Vulkan carried the same literal and now
return the same numbers.

## Why the reach is wider than "SD files"

Both mixers force BT.601 whenever a source is 700 lines or fewer, whatever the file
declared:

```cpp
const auto is_hd       = params.pix_desc.planes.at(0).height > 700;
const auto color_space = is_hd ? params.pix_desc.color_space : core::color_space::bt601;
```

So any small YCbCr source was decoded through the wrong matrix, including material
explicitly tagged BT.709. That override is a separate problem with a separate fix
(`fix/sd-colorspace-override`), and the two are independent: this one is a wrong constant
and needs no design discussion.

The same `color_space` variable also selects `luma_coeff`, which
`ContrastSaturationBrightness` reads — so `MIXER SATURATION` on small sources was using
BT.601 weights too. That part is unaffected by this change; it is noted only because the
two share a variable.

## Measurement

The measurement reports which matrix was used rather than passing a tolerance: both candidate decodes are predicted in closed
form and the capture is matched against each, and on these patches the two predictions are
more than 5 LSB apart against a ~1.2 LSB round-trip floor. The reference is arithmetic, so
there is no golden image to drift.


