### PR TITLE
fix(mixer): the sub-720 BT.601 rule overrode tagged metadata instead of filling in for it

### DIFF
--- a/src/accelerator/ogl/image/image_kernel.cpp
+++ b/src/accelerator/ogl/image/image_kernel.cpp
@@ -189,8 +189,7 @@ struct image_kernel::impl
             params.layer_key->bind(static_cast<int>(texture_id::layer_key));
         }
 
-        const auto is_hd       = params.pix_desc.planes.at(0).height > 700;
-        const auto color_space = is_hd ? params.pix_desc.color_space : core::color_space::bt601;
+        const auto color_space = core::decode_color_space(params.pix_desc);
 
         // Row order is R, G, B; columns are Y, Cb, Cr. Each row follows from the
         // luma coefficients: Cr->R is 2(1-Kr), Cb->B is 2(1-Kb), and the two green terms

--- a/src/accelerator/vulkan/image/image_kernel.cpp
+++ b/src/accelerator/vulkan/image/image_kernel.cpp
@@ -290,8 +290,7 @@ struct image_kernel::impl
             uniforms.precision_factor[n] = get_precision_factor(params.textures[n]->depth());
         }
 
-        const auto is_hd           = params.pix_desc.planes.at(0).height > 700;
-        const auto color_space     = is_hd ? params.pix_desc.color_space : core::color_space::bt601;
+        const auto color_space     = core::decode_color_space(params.pix_desc);
         uniforms.color_space_index = static_cast<uint32_t>(color_space);
 
         if (params.pix_desc.is_straight_alpha) {

--- a/src/core/frame/pixel_format.h
+++ b/src/core/frame/pixel_format.h
@@ -51,6 +51,10 @@ enum class color_space
     bt601,
     bt709,
     bt2020,
+
+    /// The source did not say; `decode_color_space` below resolves it. Must stay last,
+    /// because the value is a matrix index in both mixer shaders.
+    unknown,
 };
 
 struct pixel_format_desc final
@@ -79,7 +83,7 @@ struct pixel_format_desc final
 
     pixel_format_desc() = default;
 
-    explicit pixel_format_desc(pixel_format format, core::color_space color_space = core::color_space::bt709)
+    explicit pixel_format_desc(pixel_format format, core::color_space color_space = core::color_space::unknown)
         : format(format)
         , color_space(color_space)
     {
@@ -88,7 +92,18 @@ struct pixel_format_desc final
     pixel_format       format            = pixel_format::invalid;
     bool               is_straight_alpha = false;
     std::vector<plane> planes;
-    core::color_space  color_space = core::color_space::bt709;
+    core::color_space  color_space = core::color_space::unknown;
 };
+
+/// The matrix to decode this source's chroma with: whatever it declared, or the SD/HD
+/// convention when it declared nothing. Both mixers must pick the same one, so the
+/// convention lives here rather than once per backend.
+inline color_space decode_color_space(const pixel_format_desc& desc)
+{
+    if (desc.color_space != color_space::unknown) {
+        return desc.color_space;
+    }
+    return desc.planes.at(0).height > 700 ? color_space::bt709 : color_space::bt601;
+}
 
 }} // namespace caspar::core

--- a/src/core/frame/pixel_format.h
+++ b/src/core/frame/pixel_format.h
@@ -103,7 +103,16 @@ inline color_space decode_color_space(const pixel_format_desc& desc)
     if (desc.color_space != color_space::unknown) {
         return desc.color_space;
     }
-    return desc.planes.at(0).height > 700 ? color_space::bt709 : color_space::bt601;
+    // The sub-720 convention is about which matrix encoded the chroma, so it only applies
+    // to formats that have any. RGB is sRGB here, which is BT.709 primaries.
+    switch (desc.format) {
+        case pixel_format::ycbcr:
+        case pixel_format::ycbcra:
+        case pixel_format::uyvy:
+            return desc.planes.at(0).height > 700 ? color_space::bt709 : color_space::bt601;
+        default:
+            return color_space::bt709;
+    }
 }
 
 }} // namespace caspar::core

--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -395,11 +395,13 @@ core::color_space get_color_space(IDeckLinkVideoInputFrame* video)
                 return core::color_space::bt2020;
             } else if (color_space == bmdColorspaceRec601) {
                 return core::color_space::bt601;
+            } else if (color_space == bmdColorspaceRec709) {
+                return core::color_space::bt709;
             }
         }
     }
 
-    return core::color_space::bt709;
+    return core::color_space::unknown;
 }
 
 com_ptr<IDeckLinkDisplayMode> get_display_mode(const com_iface_ptr<IDeckLinkInput>& device,
@@ -686,7 +688,7 @@ class decklink_producer : public IDeckLinkInputCallback
 
             BMDTimeValue      in_video_pts = 0LL;
             BMDTimeValue      in_audio_pts = 0LL;
-            core::color_space color_space  = core::color_space::bt709;
+            core::color_space color_space  = core::color_space::unknown;
 
             if (video) {
                 const auto flags = video->GetFlags();

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -95,30 +95,6 @@ const AVCodec* get_decoder(AVCodecID codec_id)
 // TODO (fix) Handle ts discontinuities.
 // TODO (feat) Forward options.
 
-core::color_space get_color_space(const std::shared_ptr<AVFrame>& video)
-{
-    auto result = core::color_space::unknown;
-    if (video) {
-        switch (video->colorspace) {
-            case AVColorSpace::AVCOL_SPC_BT709:
-                result = core::color_space::bt709;
-                break;
-            case AVColorSpace::AVCOL_SPC_BT2020_NCL:
-                result = core::color_space::bt2020;
-                break;
-            case AVColorSpace::AVCOL_SPC_BT470BG:
-            case AVColorSpace::AVCOL_SPC_SMPTE170M:
-            case AVColorSpace::AVCOL_SPC_SMPTE240M:
-                result = core::color_space::bt601;
-                break;
-            default:
-                break;
-        }
-    }
-
-    return result;
-}
-
 class Decoder
 {
     Decoder(const Decoder&)            = delete;

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -97,9 +97,12 @@ const AVCodec* get_decoder(AVCodecID codec_id)
 
 core::color_space get_color_space(const std::shared_ptr<AVFrame>& video)
 {
-    auto result = core::color_space::bt709;
+    auto result = core::color_space::unknown;
     if (video) {
         switch (video->colorspace) {
+            case AVColorSpace::AVCOL_SPC_BT709:
+                result = core::color_space::bt709;
+                break;
             case AVColorSpace::AVCOL_SPC_BT2020_NCL:
                 result = core::color_space::bt2020;
                 break;

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -36,6 +36,30 @@ std::shared_ptr<AVPacket> alloc_packet()
     return packet;
 }
 
+core::color_space get_color_space(const std::shared_ptr<AVFrame>& video)
+{
+    auto result = core::color_space::unknown;
+    if (video) {
+        switch (video->colorspace) {
+            case AVColorSpace::AVCOL_SPC_BT709:
+                result = core::color_space::bt709;
+                break;
+            case AVColorSpace::AVCOL_SPC_BT2020_NCL:
+                result = core::color_space::bt2020;
+                break;
+            case AVColorSpace::AVCOL_SPC_BT470BG:
+            case AVColorSpace::AVCOL_SPC_SMPTE170M:
+            case AVColorSpace::AVCOL_SPC_SMPTE240M:
+                result = core::color_space::bt601;
+                break;
+            default:
+                break;
+        }
+    }
+
+    return result;
+}
+
 core::mutable_frame make_frame(void*                            tag,
                                core::frame_factory&             frame_factory,
                                std::shared_ptr<AVFrame>         video,

--- a/src/modules/ffmpeg/util/av_util.h
+++ b/src/modules/ffmpeg/util/av_util.h
@@ -29,12 +29,12 @@ core::pixel_format_desc pixel_format_desc(AVPixelFormat     pix_fmt,
                                           int               width,
                                           int               height,
                                           std::vector<int>& data_map,
-                                          core::color_space color_space = core::color_space::bt709);
+                                          core::color_space color_space = core::color_space::unknown);
 core::mutable_frame     make_frame(void*                    tag,
                                    core::frame_factory&     frame_factory,
                                    std::shared_ptr<AVFrame> video,
                                    std::shared_ptr<AVFrame> audio,
-                                   core::color_space        color_space = core::color_space::bt709,
+                                   core::color_space        color_space = core::color_space::unknown,
                                    core::frame_geometry::scale_mode     = core::frame_geometry::scale_mode::stretch,
                                    bool is_straight_alpha               = false);
 

--- a/src/modules/ffmpeg/util/av_util.h
+++ b/src/modules/ffmpeg/util/av_util.h
@@ -25,6 +25,8 @@ namespace caspar { namespace ffmpeg {
 std::shared_ptr<AVFrame>  alloc_frame();
 std::shared_ptr<AVPacket> alloc_packet();
 
+core::color_space get_color_space(const std::shared_ptr<AVFrame>& video);
+
 core::pixel_format_desc pixel_format_desc(AVPixelFormat     pix_fmt,
                                           int               width,
                                           int               height,

--- a/src/modules/image/producer/image_producer.cpp
+++ b/src/modules/image/producer/image_producer.cpp
@@ -57,7 +57,7 @@ struct image_producer : public core::frame_producer
             av_frame = convert_image_frame(av_frame, AV_PIX_FMT_BGRA);
 
         auto frame =
-            ffmpeg::make_frame(this, *frame_factory, av_frame, nullptr, core::color_space::bt709, scale_mode, true);
+            ffmpeg::make_frame(this, *frame_factory, av_frame, nullptr, ffmpeg::get_color_space(av_frame), scale_mode, true);
         frame_ = core::draw_frame(std::move(frame));
 
         state_["file/path"] = description_;
@@ -78,7 +78,7 @@ struct image_producer : public core::frame_producer
             av_frame = convert_image_frame(av_frame, AV_PIX_FMT_BGRA);
 
         auto frame =
-            ffmpeg::make_frame(this, *frame_factory, av_frame, nullptr, core::color_space::bt709, scale_mode, true);
+            ffmpeg::make_frame(this, *frame_factory, av_frame, nullptr, ffmpeg::get_color_space(av_frame), scale_mode, true);
         frame_ = core::draw_frame(std::move(frame));
 
         CASPAR_LOG(info) << print() << L" Initialized";


### PR DESCRIPTION
Both mixers resolved the YCbCr decode matrix as

```cpp
is_hd ? pix_desc.color_space : color_space::bt601
```

which applies the SD convention as an **override** rather than a fallback. A source that
explicitly declared BT.709 at 960x540 or 1024x640 was matrixed as BT.601 on any channel,
including 2160p. Nothing downstream can undo it: the matrix is applied at texture-fetch
time, before any colour management.

## Why it could not simply be written as a fallback

`color_space` had no way to say *not declared* — it defaulted to `bt709`, so a file tagged
BT.709 and a file that declared nothing were the same value.

Following review, that state is now an enum value rather than a separate boolean.
`unknown` is added last (the value is a matrix index in both mixer shaders), and one
function resolves it:

```cpp
inline color_space decode_color_space(const pixel_format_desc& desc)
{
    if (desc.color_space != color_space::unknown) {
        return desc.color_space;
    }
    return desc.planes.at(0).height > 700 ? color_space::bt709 : color_space::bt601;
}
```

A declared space is honoured at any size; an undeclared one gets BT.601 below 720 lines and
BT.709 above, as before. Both kernels become a single call, so the two backends cannot
diverge on the convention.

Producers that read metadata report `unknown` when there is none — ffmpeg from
`AVCOL_SPC_UNSPECIFIED`, the DeckLink producer when the card carries no colorspace flag. A
producer that never set a colour space also says `unknown`, and resolves to exactly what the
`bt709` default resolved to before, so untouched producers are unchanged.

## Two things that follow from putting the state in the enum

**The DeckLink producer had the same defect.** With a separate boolean it was never set
there, so an SD-SDI feed the card tags Rec2020 was still forced to BT.601. Distinguishing
"card said Rec709" from "card said nothing" is three lines in the same function, and it is
required rather than optional: without it, untagged SD-SDI would silently move from BT.601
to BT.709.

**The destination cannot enter into the decision**, because `decode_color_space` takes only
the source descriptor. What matrix a file was encoded with is a property of the file; keying
off the channel would trade one guess for another and would read untagged BT.601 material as
BT.709 on any non-broadcast raster — a regression for exactly the SD content the convention
exists to serve. Where the guess is wrong and the file cannot be re-tagged, the answer is an
explicit override, not a second heuristic.

## Measurements

Each case builds four saturated, asymmetric patches, encodes them to YCbCr with a known
matrix, and tags the file with an independently chosen colorspace (or none). Both candidate
decodes are then predicted in closed form and the capture is matched against each, so a case
reports **which matrix was used** rather than passing a tolerance — a wrong tolerance cannot
turn one answer into the other, because the two predictions are 10–20 LSB apart on these
patches. Greys are near-invariant between the two matrices, which is why the patches are
asymmetric.

| clip | channel | decoded as | worst residual |
| :--- | :--- | :--- | ---: |
| tagged BT.709, 640x480 | 1080p | **bt709** | 1.66 LSB |
| tagged SMPTE170M, 640x480 | 1080p | bt601 | 0.41 LSB |
| untagged, truly BT.601 | 1080p | bt601 | 0.41 LSB |
| untagged, truly BT.709 | 1080p | bt601 | 1.23 LSB |
| untagged, truly BT.709 | 1280x720 custom | bt601 | 1.23 LSB |
| untagged, truly BT.601 | 1280x720 custom | bt601 | 0.41 LSB |

The first row is the defect: it decoded as `bt601` before this change.

The fourth row is the convention's known cost — untagged BT.709 content below 720 lines is
read as BT.601 — and is unchanged by this PR.

The last two rows are a regression guard rather than a feature: they assert that the
channel raster does not influence the decode.

**6/6 on OpenGL and 6/6 on Vulkan**, with residuals equal to two decimals between the two
backends.
