### PR TITLE
fix(ffmpeg-consumer): constrain the audio sink to the encoder's channel layouts

### DIFF
--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -225,6 +225,35 @@ struct Stream
 
         } else if (codec->type == AVMEDIA_TYPE_AUDIO) {
             sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
+
+            // -ac has to be applied to the graph here, and is consumed rather than left in the
+            // dict: it is not an AVCodecContext option, so passing it on to avcodec_open2 did
+            // nothing and the encoder still saw the channel's 16 channels.
+            const auto requested_channels = [&]() -> int {
+                for (const auto* key : {"ac", "channels"}) {
+                    for (auto* map : {&stream_options, &options}) {
+                        const auto it = map->find(key);
+                        if (it != map->end()) {
+                            const auto value = std::move(it->second);
+                            map->erase(it);
+                            try {
+                                const auto n = std::stoi(value);
+                                if (n <= 0 || n > AV_NUM_DATA_POINTERS * 16) {
+                                    CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
+                                                           << boost::errinfo_errno(EINVAL)
+                                                           << msg_info_t("channel count out of range: " + value));
+                                }
+                                return n;
+                            } catch (const std::logic_error&) {
+                                CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
+                                                       << boost::errinfo_errno(EINVAL)
+                                                       << msg_info_t("invalid channel count: " + value));
+                            }
+                        }
+                    }
+                }
+                return 0;
+            }();
             // TODO codec->profiles
 
 #if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
@@ -254,25 +283,47 @@ struct Stream
                                 AV_OPT_TYPE_INT,
                                 sample_rates));
 
-            const void* ch_layouts;
-            int         nb_ch_layouts = 0;
-            FF(avcodec_get_supported_config(
-                nullptr, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0, &ch_layouts, &nb_ch_layouts));
+            // An explicit -ac takes precedence: it is a request, not a guess, so it can be
+            // honoured even where the encoder publishes no list to constrain against.
+            if (requested_channels > 0) {
+                AVChannelLayout want{};
+                av_channel_layout_default(&want, requested_channels);
+                const auto ret_layout = av_opt_set_array(sink,
+                                                         "channel_layouts",
+                                                         AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                                         0,
+                                                         1,
+                                                         AV_OPT_TYPE_CHLAYOUT,
+                                                         &want);
+                av_channel_layout_uninit(&want);
+                FF(ret_layout);
+            } else {
+                const void* ch_layouts;
+                int         nb_ch_layouts = 0;
+                FF(avcodec_get_supported_config(
+                    nullptr, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0, &ch_layouts, &nb_ch_layouts));
 
-            // A null list means no restriction, and the sink must then be left alone: an empty
-            // array would say "no layout is supported". PCM takes the 16 channels unchanged.
-            if (ch_layouts != nullptr) {
-                FF(av_opt_set_array(sink,
-                                    "channel_layouts",
-                                    AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                    0,
-                                    nb_ch_layouts,
-                                    AV_OPT_TYPE_CHLAYOUT,
-                                    ch_layouts));
+                // A null list means no restriction, and the sink must then be left alone: an
+                // empty array would say "no layout is supported". PCM takes the 16 channels
+                // unchanged.
+                if (ch_layouts != nullptr && nb_ch_layouts > 0) {
+                    FF(av_opt_set_array(sink,
+                                        "channel_layouts",
+                                        AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                        0,
+                                        nb_ch_layouts,
+                                        AV_OPT_TYPE_CHLAYOUT,
+                                        ch_layouts));
+                }
             }
 #else
             FF(av_opt_set_int_list(sink, "sample_fmts", codec->sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
             FF(av_opt_set_int_list(sink, "sample_rates", codec->supported_samplerates, 0, AV_OPT_SEARCH_CHILDREN));
+            if (requested_channels > 0) {
+                const int64_t layouts[] = {
+                    static_cast<int64_t>(get_channel_layout_mask_for_channels(requested_channels)), 0};
+                FF(av_opt_set_int_list(sink, "channel_layouts", layouts, 0, AV_OPT_SEARCH_CHILDREN));
+            }
 
             // TODO: need to translate codec->ch_layouts into something that can be passed via
             // av_opt_set_*. Unconstrained here; the FFmpeg 8 path above constrains the sink.

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -253,13 +253,31 @@ struct Stream
                                 nb_sample_rates,
                                 AV_OPT_TYPE_INT,
                                 sample_rates));
+
+            const void* ch_layouts;
+            int         nb_ch_layouts = 0;
+            FF(avcodec_get_supported_config(
+                nullptr, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0, &ch_layouts, &nb_ch_layouts));
+
+            // A null list means no restriction, and the sink must then be left alone: an empty
+            // array would say "no layout is supported". PCM takes the 16 channels unchanged.
+            if (ch_layouts != nullptr) {
+                FF(av_opt_set_array(sink,
+                                    "channel_layouts",
+                                    AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                    0,
+                                    nb_ch_layouts,
+                                    AV_OPT_TYPE_CHLAYOUT,
+                                    ch_layouts));
+            }
 #else
             FF(av_opt_set_int_list(sink, "sample_fmts", codec->sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
             FF(av_opt_set_int_list(sink, "sample_rates", codec->supported_samplerates, 0, AV_OPT_SEARCH_CHILDREN));
-#endif
 
-            // TODO: need to translate codec->ch_layouts into something that can be passed via av_opt_set_*
+            // TODO: need to translate codec->ch_layouts into something that can be passed via
+            // av_opt_set_*. Unconstrained here; the FFmpeg 8 path above constrains the sink.
             // FF(av_opt_set_chlayout(sink, "ch_layouts", codec->ch_layouts, AV_OPT_SEARCH_CHILDREN));
+#endif
 
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()


### PR DESCRIPTION
CasparCG channels always carry 16 audio channels, and the audio filtergraph's sink is never constrained to what the encoder accepts — there was a `TODO` saying exactly that. So the graph never downmixes and 16 channels reach the encoder unchanged. Any encoder that publishes a supported-layout list without a 16-channel entry then fails to open: `ADD` answers `202 ADD OK` because the consumer is created before it initialises, `avcodec_open2` returns `EINVAL`, and no file is written.

Two commits:

1. **Constrain the sink** with the layouts the encoder publishes, and let libavfilter insert the conversion. A null list means "no restriction" and must be left alone rather than treated as "nothing supported" — that is what keeps PCM writing all 16 channels.
2. **Apply `-ac` to the graph.** `-ac` is not an `AVCodecContext` option, so passing it on to `avcodec_open2` did nothing at all and the encoder still saw 16 channels; the only way to ask for a different count was the per-stream `filter` option. This also covers what (1) cannot, below.

### Measured

On a 16-channel channel, before → after:

| command | before | after |
| :--- | :--- | :--- |
| `ADD 1 FILE out.mp4 -codec:a ac3` | no file | ac3, 5.1(side), 727 KB |
| `ADD 1 FILE out.mp4 -codec:a mp2` | no file | mp2, stereo, 467 KB |
| `ADD 1 FILE out.mp4 -ac 2` | no file | aac, 2 ch, 19 KB |
| `ADD 1 FILE out.mp4 -ac 6` | no file | aac, 6 ch, 22 KB |
| `ADD 1 FILE out.wav` | 16 ch | 16 ch, unchanged |

The last row is the one the change must not alter, and does not. A 1 kHz tone on channel 0 with silence on channel 1 stays on channel 0 through the downmix, so programme audio is not weighted away by the conversion.

Each file was probed after the server had stopped, so the container is finalised — an unfinalised MP4 is a 48-byte file that any "was something written" check would pass. The gate is the audio stream's codec and channel count, not the file size.

### Why `-ac` is the right lever for AAC, and what is still open

A null capability list is ambiguous. `avcodec_get_supported_config(…, AV_CODEC_CONFIG_CHANNEL_LAYOUT, …)` returns null both for encoders that genuinely accept anything and for encoders that enforce a restriction internally without publishing it:

| encoder | published layouts |
| :--- | :--- |
| `pcm_s16le` | null — truly unrestricted |
| `aac` | null — but rejects 16 channels in its own `init` |
| `libopus` | null |
| `ac3` | 16 layouts |
| `mp2` | mono, stereo |

So commit (1) alone cannot fix AAC: there is nothing published to constrain the sink with. Commit (2) fixes it *when the caller says what they want*, which is a different thing from picking a layout for them — and it needs no rebuild of the graph after a failed `avcodec_open2`, because the layout is decided before the sink is configured.

**Still unfixed, deliberately:** `ADD 1 FILE out.mp4` with no `-ac`. That would mean choosing a channel count for a 16-channel channel when the encoder will not say what it accepts, and `ffmpeg` itself fails the same way on `-f lavfi -i anullsrc=channel_layout=16c -c:a aac`, so there is no upstream behaviour to copy. Defaulting it to stereo is a policy decision rather than a bug fix, and I would rather you made it than have it slipped in here. Happy to add it if you want it.

`-af` is still ignored; only `filter` and now `-ac` are read.
