### PR TITLE
chore(ci): normalize Debian package version suffixes

### DIFF
--- a/.github/workflows/linux-system.yml
+++ b/.github/workflows/linux-system.yml
@@ -80,7 +80,7 @@ jobs:
 
                   # Build a version number for this build
                   GH_REF="${GITHUB_REF##*/}"
-                  GH_REF=$(echo "$GH_REF" | sed 's/[\/]/_/g' | sed 's/ /_/g')
+                  GH_REF=$(echo "$GH_REF" | sed 's/[\/]/-/g' | sed 's/ /-/g' | sed 's/_/-/g')
 
                   VERSION_MAJOR=$(grep -oPi 'set\(CONFIG_VERSION_MAJOR \K\d+' src/CMakeLists.txt)
                   VERSION_MINOR=$(grep -oPi 'set\(CONFIG_VERSION_MINOR \K\d+' src/CMakeLists.txt)


### PR DESCRIPTION
Normalize `_`, `/`, and spaces in the ref-derived build suffix to `-` before creating Debian package versions.

Debian package versions cannot contain underscores. This keeps branch-based CI package builds valid without changing the build matrix or artifact behavior.

This makes it so either dashes or underscores can be used in branch names without causing issues for those CI jobs.