### PR TITLE
fix(amcp): reply when a deferred command fails, instead of nothing at all

### DIFF
--- a/src/protocol/amcp/AMCPCommandQueue.cpp
+++ b/src/protocol/amcp/AMCPCommandQueue.cpp
@@ -39,6 +39,40 @@ AMCPCommandQueue::AMCPCommandQueue(const std::wstring&                          
 
 AMCPCommandQueue::~AMCPCommandQueue() {}
 
+/// Maps the exception currently being handled onto an AMCP failure reply. Call from inside
+/// a catch block.
+///
+/// This mapping used to be written out inline, once, around `cmd->Execute(...)` — which is
+/// only half the places a command can fail. A command whose future is deferred, as CALL's
+/// is, does its work when the reply lambda calls `res.get()`, long after that try block has
+/// been left, and an exception there reached nobody: no reply, no log, and a client waiting
+/// forever for an answer to a command it had already been told nothing about. One mapping,
+/// used by both paths, is what stops them diverging again.
+void send_failure_reply(const std::shared_ptr<AMCPCommand>& cmd, bool reply_without_req_id)
+{
+    try {
+        throw;
+    } catch (file_not_found&) {
+        CASPAR_LOG(error) << " File not found.";
+        cmd->SendReply(L"404 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    } catch (expected_user_error&) {
+        cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    } catch (user_error&) {
+        CASPAR_LOG(error) << " Check syntax.";
+        cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    } catch (std::out_of_range&) {
+        CASPAR_LOG(error) << L"Missing parameter. Check syntax.";
+        cmd->SendReply(L"402 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    } catch (boost::bad_lexical_cast&) {
+        CASPAR_LOG(error) << L"Invalid parameter. Check syntax.";
+        cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    } catch (...) {
+        CASPAR_LOG_CURRENT_EXCEPTION();
+        CASPAR_LOG(error) << "Failed to execute command: " << cmd->name();
+        cmd->SendReply(L"501 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+    }
+}
+
 std::future<bool> exec_cmd(std::shared_ptr<AMCPCommand>                         cmd,
                            const spl::shared_ptr<std::vector<channel_context>>& channels,
                            bool                                                 reply_without_req_id)
@@ -52,32 +86,22 @@ std::future<bool> exec_cmd(std::shared_ptr<AMCPCommand>                         
 
             auto res = cmd->Execute(channels).share();
             return std::async(std::launch::async, [cmd, res, reply_without_req_id, timer, name]() -> bool {
-                cmd->SendReply(res.get(), reply_without_req_id);
+                try {
+                    cmd->SendReply(res.get(), reply_without_req_id);
+                } catch (...) {
+                    // Where a deferred command — CALL — actually fails. Without this the
+                    // reply never goes out at all.
+                    send_failure_reply(cmd, reply_without_req_id);
+                    return false;
+                }
 
                 CASPAR_LOG(debug) << "Executed command (" << timer.elapsed() << "s): " << name;
                 return true;
             });
 
-        } catch (file_not_found&) {
-            CASPAR_LOG(error) << " File not found.";
-            cmd->SendReply(L"404 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
-        } catch (expected_user_error&) {
-            cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
-        } catch (user_error&) {
-            CASPAR_LOG(error) << " Check syntax.";
-            cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
-        } catch (std::out_of_range&) {
-            CASPAR_LOG(error) << L"Missing parameter. Check syntax.";
-            cmd->SendReply(L"402 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
-        } catch (boost::bad_lexical_cast&) {
-            CASPAR_LOG(error) << L"Invalid parameter. Check syntax.";
-            cmd->SendReply(L"403 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
         } catch (...) {
-            CASPAR_LOG_CURRENT_EXCEPTION();
-            CASPAR_LOG(error) << "Failed to execute command: " << cmd->name();
-            cmd->SendReply(L"501 " + cmd->name() + L" FAILED\r\n", reply_without_req_id);
+            send_failure_reply(cmd, reply_without_req_id);
         }
-
     } catch (...) {
         CASPAR_LOG_CURRENT_EXCEPTION();
     }


### PR DESCRIPTION
An exception thrown out of `core::frame_producer::call()` produces **no AMCP reply of any kind**. The connection stays open and the server stays healthy, so the client just blocks on a read that never completes — a typo in a `CALL` hangs it until its own timeout, if it has one. Every other AMCP failure answers something a client can be written against.

### Cause

The exception-to-reply-code mapping in `exec_cmd` wraps `cmd->Execute(channels)`:

```cpp
auto res = cmd->Execute(channels).share();
return std::async(std::launch::async, [cmd, res, …]() -> bool {
    cmd->SendReply(res.get(), reply_without_req_id);   // ← the work happens HERE
    …
});
} catch (file_not_found&) { … 404 … }
  catch (user_error&)     { … 403 … }
  catch (...)             { … 501 … }
```

`CALL`'s future is deferred — `stage::call` returns a deferred future and `call_command` wraps that in a second one, with a `// TODO: because of std::async deferred timed waiting does not work` already noting it. So nothing runs until `res.get()`, which happens inside the async lambda, *after* the `try` block has been left. The exception is stored in the `std::future<bool>` that lambda returns, nobody reads it, and it is discarded — no reply, and no log line either.

Commands whose futures are ready fail inside the `try` and answer correctly, which is why this went unnoticed: it is specifically the deferred commands that hang.

### The change

Lift the mapping into `send_failure_reply()` and call it from both places. The catch bodies are unchanged — moved, not rewritten. One mapping used by both paths is the point rather than a tidy-up alongside it, since the duplication is what let them diverge.

### Measured

One server, one connection, FFmpeg producer playing a file:

| command | before | after |
| :--- | :--- | :--- |
| `CALL 1-10 REWIND` (producer throws) | **no reply, forever** | `501 CALL FAILED` |
| `CALL 1-10 SEEK notanumber` | **no reply, forever** | `403 CALL FAILED` |
| `CALL 1-10 LOOP` | `201 CALL OK` / `1` | unchanged |
| `CALL 1-99 LOOP` (empty layer) | `202 CALL OK` | unchanged |
| `PLAY 1-11 "no_such_file"` | `404 PLAY FAILED` | unchanged |
| `MIXER 1-10 OPACITY notanumber` | `501 MIXER OPACITY FAILED` | unchanged |
| `CALL` (no parameters) | `400 ERROR` | unchanged |
| `VERSION` | `201 VERSION OK` | unchanged |

`VERSION` issued straight after a hung command always answered normally, so only the reply to the failing command was lost — the connection itself was never in trouble.

The non-deferred failure codes are in the table because the mapping moved, so they are worth showing unchanged rather than asserted to be. Note `MIXER … OPACITY notanumber` answers `501`, before and after: that parse is `std::stod`, which throws `std::invalid_argument`, and that is not in the catch chain. Whether it should be `403` is a separate question from this one, so it is left alone here.

### Scope

Only the failure path changes. Producers keep throwing, which is the established pattern — `ffmpeg_producer` throws for an unknown command, and the base class throws `not_implemented` for producers implementing none — so nothing needs rewriting to return sentinels. `501` for the unknown-command case is what the existing `catch (...)` already chose; whether an unknown `CALL` deserves `403` instead is a question about which exception producers should throw, and is deliberately not answered here.
