### PR TITLE
fix(mixer): sample subsampled chroma at its co-sited position

### DIFF
--- a/src/accelerator/ogl/image/shader.frag
+++ b/src/accelerator/ogl/image/shader.frag
@@ -485,6 +485,19 @@ vec4 ycbcra_to_rgba(float Y, float Cb, float Cr, float A)
     return vec4(color_matrix * YCbCr / 255, A).bgra;
 }
 
+// Horizontal chroma in 4:2:2 and 4:2:0 is co-sited (ITU-R BT.601 / BT.709): chroma sample k
+// shares its position with luma 2k. Sampling a half-width plane at the luma coordinate lands
+// on chroma texel (x + 0.5) / 2, a quarter texel off centre; co-siting needs (x + 1) / 2, so
+// the horizontal coordinate gains half a luma pixel. The vertical coordinate is left alone:
+// 4:2:0 chroma is centred vertically, which sampling at the luma centre already gives. The
+// width ratio makes this a no-op for planes that are not subsampled.
+vec2 chroma_coords(sampler2D luma, sampler2D chroma, vec2 coords)
+{
+    float luma_width   = float(textureSize(luma, 0).x);
+    float chroma_width = float(textureSize(chroma, 0).x);
+    return vec2(coords.x + (luma_width / chroma_width - 1.0) * 0.5 / luma_width, coords.y);
+}
+
 vec4 get_sample(sampler2D sampler, vec2 coords)
 {
     return texture(sampler, coords);
@@ -506,16 +519,18 @@ vec4 get_rgba_color()
         return get_sample(plane[0], TexCoord.st / TexCoord.q).gbar * precision_factor[0];
     case 5:		//ycbcr,
         {
+            vec2  chroma = chroma_coords(plane[0], plane[1], TexCoord.st / TexCoord.q);
             float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float cb = get_sample(plane[1], chroma).r * precision_factor[1];
+            float cr = get_sample(plane[2], chroma).r * precision_factor[2];
             return ycbcra_to_rgba(y, cb, cr, 1.0);
         }
     case 6:		//ycbcra
         {
+            vec2  chroma = chroma_coords(plane[0], plane[1], TexCoord.st / TexCoord.q);
             float y  = get_sample(plane[0], TexCoord.st / TexCoord.q).r * precision_factor[0];
-            float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
-            float cr = get_sample(plane[2], TexCoord.st / TexCoord.q).r * precision_factor[2];
+            float cb = get_sample(plane[1], chroma).r * precision_factor[1];
+            float cr = get_sample(plane[2], chroma).r * precision_factor[2];
             float a  = get_sample(plane[3], TexCoord.st / TexCoord.q).r * precision_factor[3];
             return ycbcra_to_rgba(y, cb, cr, a);
         }
@@ -530,9 +545,10 @@ vec4 get_rgba_color()
         return vec4(get_sample(plane[0], TexCoord.st / TexCoord.q).rgb * precision_factor[0], 1.0);
 	case 10:	// uyvy
 		{
+			vec2 chroma = chroma_coords(plane[0], plane[1], TexCoord.st / TexCoord.q);
 			float y = get_sample(plane[0], TexCoord.st / TexCoord.q).g * precision_factor[0];
-			float cb = get_sample(plane[1], TexCoord.st / TexCoord.q).b * precision_factor[1];
-			float cr = get_sample(plane[1], TexCoord.st / TexCoord.q).r * precision_factor[1];
+			float cb = get_sample(plane[1], chroma).b * precision_factor[1];
+			float cr = get_sample(plane[1], chroma).r * precision_factor[1];
 			return ycbcra_to_rgba(y, cb, cr, 1.0);
 		}
     case 11:    // gbrp


### PR DESCRIPTION
Horizontal chroma in 4:2:2 and 4:2:0 is **co-sited** for the formats CasparCG plays — MPEG-2, H.264, ProRes, DNxHD, and anything tagged BT.601 or BT.709 (`AVCHROMA_LOC_LEFT`). Chroma sample `k` shares its position with luma `2k`, so luma `2k` reconstructs to `C[k]` and luma `2k+1` to `(C[k] + C[k+1]) / 2`.

The shader sampled the chroma planes at the luma coordinate. On a half-width plane that is chroma texel `(x + 0.5) / 2`, which `GL_LINEAR` resolves as `0.75/0.25` either side of a texel centre — for both parities. That is exactly the correct reconstruction for **centre**-sited chroma (`AVCHROMA_LOC_CENTER`: MPEG-1, JPEG), so the mixer has been applying the wrong siting convention rather than no convention at all. Co-siting needs `(x + 1) / 2`, so the horizontal coordinate gains half a luma pixel.

This is not a regression — the same pattern is present in the 2011 shader (`eaa18818a`) and was carried through every move and refactor since, including into the `uyvy` case added in 2020.

### Evidence

Model-free, and deliberately not a comparison against another implementation: with co-sited chroma, an **even** column adjacent to a chroma transition must carry the *unblended* chroma value. Sampling 946 such columns on a 1920x1080 `yuv422p10` ProRes frame captured through the IMAGE consumer:

|  | even columns carrying a blended value |
|---|---|
| before | **437 of 946 (46.2%)** |
| after | **0 of 946 (0.0%)** |

Pixel values across one green→magenta boundary (row 400), where 1063 is odd and 1064 even:

| x | before | after |
|---|---|---|
| 1062 | (0,190,0) | (0,190,0) |
| 1063 | (67,163,66) | (135,136,135) |
| 1064 | (121,28,122) | **(189,1,190)** |
| 1065 | (189,1,190) | (189,1,190) |

Before, the even column 1064 is a blend; after, it is the chroma sample exactly, and only the odd column interpolates.

Scope, comparing the two captures at **every** pixel: worst 89 LSB, 0.47% of pixels move by more than 3 LSB, 99.9% of those adjacent to a chroma edge. Flat areas are untouched, which is why this is easy to miss.

### Notes for review

- **This changes rendered output for every 4:2:2 and 4:2:0 source.**
- **Known limitation:** this hardcodes left/co-sited rather than following the source's signalled chroma location. Left is the correct default for the formats above, and is what the previous behaviour got wrong — but content that genuinely signals `AVCHROMA_LOC_CENTER` would now be reconstructed at the wrong position, where previously it was the only case that was right. Plumbing `AVFrame.chroma_location` through to a shader uniform would handle both; happy to extend this PR if that is preferred.
- **The vertical coordinate is deliberately unchanged.** 4:2:0 chroma is centred vertically between the two luma rows, and sampling at the luma centre is already the correct interpolation for that — offsetting it would introduce the error this removes.
- **No-op where it should be.** The width ratio makes the helper vanish for planes that are not subsampled, so 4:4:4 and packed RGB paths are bit-identical.
- `textureSize` is available at the shader's `#version 450`.
- Applies to the three cases that read a subsampled chroma plane: `ycbcr`, `ycbcra`, `uyvy`.

Built and measured on Windows, RelWithDebInfo, before and after on the same tree.
