### PR TITLE
Vulkan step 2: internal refactoring

### DIFF
--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -50,6 +50,7 @@ IF(ENABLE_VULKAN)
 		vulkan/util/pipeline.cpp
 		vulkan/util/renderpass.cpp
 		vulkan/util/texture.cpp
+		vulkan/util/transfer.cpp
 		vulkan/util/matrix.cpp
 		vulkan/util/transforms.cpp
 	)
@@ -68,6 +69,7 @@ IF(ENABLE_VULKAN)
 		vulkan/util/draw_params.h
 		vulkan/util/pipeline.h
 		vulkan/util/texture.h
+		vulkan/util/transfer.h
 		vulkan/util/matrix.h
 		vulkan/util/transforms.h
 		vulkan/util/uniform_block.h

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -44,6 +44,7 @@ IF(ENABLE_VULKAN)
 
 		vulkan/util/buffer.cpp
 		vulkan/util/command_context.cpp
+		vulkan/util/descriptor_pool.cpp
 		vulkan/util/device.cpp
 		vulkan/util/vulkan_queue.cpp
 		vulkan/util/pipeline.cpp
@@ -60,6 +61,7 @@ IF(ENABLE_VULKAN)
 		vulkan/util/buffer.h
 		vulkan/util/command_context.h
 		vulkan/util/completion_token.h
+		vulkan/util/descriptor_pool.h
 		vulkan/util/device.h
 		vulkan/util/vulkan_queue.h
 		vulkan/util/draw_params.h

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -43,6 +43,7 @@ IF(ENABLE_VULKAN)
 		vulkan/image/image_mixer.cpp
 
 		vulkan/util/buffer.cpp
+		vulkan/util/command_context.cpp
 		vulkan/util/device.cpp
 		vulkan/util/vulkan_queue.cpp
 		vulkan/util/pipeline.cpp
@@ -57,6 +58,8 @@ IF(ENABLE_VULKAN)
 		vulkan/image/image_mixer.h
 
 		vulkan/util/buffer.h
+		vulkan/util/command_context.h
+		vulkan/util/completion_token.h
 		vulkan/util/device.h
 		vulkan/util/vulkan_queue.h
 		vulkan/util/draw_params.h

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -58,6 +58,7 @@ IF(ENABLE_VULKAN)
 		vulkan/image/image_kernel.h
 		vulkan/image/image_mixer.h
 
+		vulkan/util/barrier.h
 		vulkan/util/buffer.h
 		vulkan/util/command_context.h
 		vulkan/util/completion_token.h

--- a/src/accelerator/CMakeLists.txt
+++ b/src/accelerator/CMakeLists.txt
@@ -44,6 +44,7 @@ IF(ENABLE_VULKAN)
 
 		vulkan/util/buffer.cpp
 		vulkan/util/device.cpp
+		vulkan/util/vulkan_queue.cpp
 		vulkan/util/pipeline.cpp
 		vulkan/util/renderpass.cpp
 		vulkan/util/texture.cpp
@@ -57,6 +58,7 @@ IF(ENABLE_VULKAN)
 
 		vulkan/util/buffer.h
 		vulkan/util/device.h
+		vulkan/util/vulkan_queue.h
 		vulkan/util/draw_params.h
 		vulkan/util/pipeline.h
 		vulkan/util/texture.h

--- a/src/accelerator/vulkan/image/image_kernel.cpp
+++ b/src/accelerator/vulkan/image/image_kernel.cpp
@@ -22,6 +22,7 @@
 #include "image_kernel.h"
 
 #include "../util/command_context.h"
+#include "../util/descriptor_pool.h"
 #include "../util/device.h"
 #include "../util/pipeline.h"
 #include "../util/renderpass.h"
@@ -100,8 +101,16 @@ struct image_kernel::impl
         // command_context timeline.
         completion_token token;
 
+        // Per-slot descriptor sets, recycled on the same completion as the vertex
+        // buffer: create_renderpass waits the token before this slot is reused, so
+        // allocate() can safely reset the pool.
+        descriptor_pool desc_pool_;
+
         explicit frame_data(image_kernel::impl* parent)
             : parent(parent)
+            , desc_pool_(parent->vulkan_->getVkDevice(),
+                         parent->pipeline_->descriptor_set_layout(),
+                         parent->pipeline_->descriptor_pool_sizes())
         {
         }
 
@@ -111,7 +120,11 @@ struct image_kernel::impl
         }
         virtual draw_data create_draw_data(const draw_params& params) { return parent->draw(params); }
         virtual std::shared_ptr<class pipeline> get_pipeline() { return parent->pipeline_; }
-        virtual void                            record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
+        virtual std::vector<vk::DescriptorSet>  allocate_descriptor_sets(uint32_t count)
+        {
+            return desc_pool_.allocate(count);
+        }
+        virtual void record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
         {
             token = parent->cmd_ctx_.record_and_submit(record);
         }

--- a/src/accelerator/vulkan/image/image_kernel.cpp
+++ b/src/accelerator/vulkan/image/image_kernel.cpp
@@ -21,6 +21,7 @@
 
 #include "image_kernel.h"
 
+#include "../util/command_context.h"
 #include "../util/device.h"
 #include "../util/pipeline.h"
 #include "../util/renderpass.h"
@@ -92,8 +93,11 @@ struct image_kernel::impl
         vk::DeviceMemory memory = nullptr;
         size_t           size   = 0;
 
-        vk::CommandBuffer cmd_buffer = nullptr;
-        vk::Fence         fence      = nullptr;
+        // Set by the last submit that used this slot; create_renderpass waits on
+        // it before reusing the slot (keeps its vertex buffer alive until the GPU
+        // is done). Replaces the per-frame VkFence — same completion info, off the
+        // command_context timeline.
+        completion_token token;
 
         explicit frame_data(image_kernel::impl* parent)
             : parent(parent)
@@ -106,13 +110,9 @@ struct image_kernel::impl
         }
         virtual draw_data create_draw_data(const draw_params& params) { return parent->draw(params); }
         virtual std::shared_ptr<class pipeline> get_pipeline() { return parent->vulkan_->get_pipeline(parent->depth_); }
-        virtual vk::CommandBuffer               get_command_buffer() { return cmd_buffer; }
-        virtual void                            submit()
+        virtual void                            record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
         {
-            fence = parent->vulkan_->getVkDevice().createFence({});
-            vk::SubmitInfo submitInfo{};
-            submitInfo.setCommandBuffers(cmd_buffer);
-            parent->vulkan_->submit(submitInfo, fence);
+            token = parent->cmd_ctx_.record_and_submit(record);
         }
         virtual std::shared_ptr<class texture>
         create_attachment(uint32_t width, uint32_t height, uint32_t components_count)
@@ -121,50 +121,47 @@ struct image_kernel::impl
         }
     };
 
-    frame_data frames_[frame_buffer_size];
-    uint32_t   current_frame_index_ = 0;
+    // Private to this kernel's (channel's) thread: command buffers are recorded
+    // lock-free here; only the queue submit serializes (vulkan_queue's mutex).
+    command_context cmd_ctx_;
+    frame_data      frames_[frame_buffer_size];
+    uint32_t        current_frame_index_ = 0;
 
     explicit impl(const spl::shared_ptr<device>& vulkan, common::bit_depth depth)
         : vulkan_(vulkan)
         , depth_(depth)
+        , cmd_ctx_(vulkan->getVkDevice(), vulkan->queue())
         , frames_{frame_data{this}, frame_data{this}, frame_data{this}}
     {
-        auto cmd_buffers = vulkan_->allocateCommandBuffers(frame_buffer_size);
-        for (uint32_t i = 0; i < frame_buffer_size; ++i) {
-            frames_[i].cmd_buffer = cmd_buffers[i];
-        }
     }
 
     ~impl()
     {
         auto vk_device = vulkan_->getVkDevice();
 
+        // command_context's dtor requires the device idle (it does not waitIdle);
+        // the in-flight slots may still reference these vertex buffers.
+        vk_device.waitIdle();
+
         for (auto& frame : frames_) {
             if (frame.buffer) {
                 vk_device.unmapMemory(frame.memory);
                 vk_device.destroyBuffer(frame.buffer);
                 vk_device.freeMemory(frame.memory);
-                if (frame.fence) {
-                    vk_device.destroyFence(frame.fence);
-                }
             }
         }
     }
 
     spl::shared_ptr<renderpass> create_renderpass(uint32_t width, uint32_t height)
     {
-        auto  device = vulkan_->getVkDevice();
-        auto& ctx    = frames_[(++current_frame_index_) % frame_buffer_size];
-        if (ctx.fence) {
-            auto result = device.waitForFences(ctx.fence, true, 1000000000); // wait up to one second
-            if (result == vk::Result::eTimeout) {
-                CASPAR_LOG(warning) << L"[Vulkan image_kernel] Timeout waiting for fence";
-            }
-            device.destroyFence(ctx.fence);
-            ctx.fence = nullptr;
+        auto& ctx = frames_[(++current_frame_index_) % frame_buffer_size];
+
+        // Wait until the previous use of this slot has completed on the GPU before
+        // reusing its vertex buffer (bounds in-flight frames to frame_buffer_size).
+        if (ctx.token && !cmd_ctx_.wait(ctx.token)) {
+            CASPAR_LOG(warning) << L"[Vulkan image_kernel] Timeout waiting for frame completion";
         }
 
-        ctx.cmd_buffer.reset({});
         return spl::make_shared<renderpass>(&ctx, width, height);
     }
 

--- a/src/accelerator/vulkan/image/image_kernel.cpp
+++ b/src/accelerator/vulkan/image/image_kernel.cpp
@@ -21,6 +21,7 @@
 
 #include "image_kernel.h"
 
+#include "../util/barrier.h"
 #include "../util/command_context.h"
 #include "../util/descriptor_pool.h"
 #include "../util/device.h"
@@ -36,8 +37,12 @@
 #include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
+#include <tbb/concurrent_queue.h>
+#include <tbb/concurrent_unordered_map.h>
+
 #include <array>
 #include <cmath>
+#include <memory>
 
 namespace caspar::accelerator::vulkan {
 
@@ -86,6 +91,12 @@ struct image_kernel::impl
     common::bit_depth         depth_;
     std::shared_ptr<pipeline> pipeline_;
 
+    // Output/intermediate render targets, recycled per (width,height). Kept in a
+    // shared_ptr so a recycled texture's deleter can outlive this kernel without a
+    // dangling pool (concurrent_unordered_map keeps element references stable).
+    using attachment_queue_t = tbb::concurrent_bounded_queue<std::shared_ptr<texture>>;
+    std::shared_ptr<tbb::concurrent_unordered_map<size_t, attachment_queue_t>> attachment_pools_;
+
     struct frame_data : public frame_context
     {
         image_kernel::impl* parent = nullptr;
@@ -131,7 +142,7 @@ struct image_kernel::impl
         virtual std::shared_ptr<class texture>
         create_attachment(uint32_t width, uint32_t height, uint32_t components_count)
         {
-            return parent->vulkan_->create_attachment(width, height, parent->depth_, components_count);
+            return parent->create_attachment(width, height, components_count);
         }
     };
 
@@ -147,6 +158,7 @@ struct image_kernel::impl
         , pipeline_(std::make_shared<pipeline>(vulkan->getVkDevice(),
                                                depth == common::bit_depth::bit8 ? vk::Format::eR8G8B8A8Unorm
                                                                                 : vk::Format::eR16G16B16A16Unorm))
+        , attachment_pools_(std::make_shared<tbb::concurrent_unordered_map<size_t, attachment_queue_t>>())
         , cmd_ctx_(vulkan->getVkDevice(), vulkan->queue())
         , frames_{frame_data{this}, frame_data{this}, frame_data{this}}
     {
@@ -229,6 +241,72 @@ struct image_kernel::impl
         memcpy(vb.data, data, size);
 
         return vb.buffer;
+    }
+
+    std::shared_ptr<texture> create_attachment(uint32_t width, uint32_t height, uint32_t components_count)
+    {
+        CASPAR_VERIFY(width > 0 && height > 0);
+
+        auto format = depth_ == common::bit_depth::bit8 ? vk::Format::eR8G8B8A8Unorm : vk::Format::eR16G16B16A16Unorm;
+        auto vk_device = vulkan_->getVkDevice();
+
+        auto pool   = &(*attachment_pools_)[(width << 16 & 0xFFFF0000) | (height & 0x0000FFFF)];
+        auto extent = vk::Extent3D{width, height, 1};
+
+        std::shared_ptr<texture> tex;
+        if (!pool->try_pop(tex)) {
+            vk::ImageCreateInfo imageInfo{};
+            imageInfo.imageType     = vk::ImageType::e2D;
+            imageInfo.format        = format;
+            imageInfo.extent        = extent;
+            imageInfo.mipLevels     = 1;
+            imageInfo.arrayLayers   = 1;
+            imageInfo.initialLayout = vk::ImageLayout::eUndefined;
+            imageInfo.samples       = vk::SampleCountFlagBits::e1;
+            imageInfo.tiling        = vk::ImageTiling::eOptimal;
+            imageInfo.usage         = vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eInputAttachment |
+                              vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferDst |
+                              vk::ImageUsageFlagBits::eSampled;
+            imageInfo.sharingMode = vk::SharingMode::eExclusive;
+            auto image            = vk_device.createImage(imageInfo);
+
+            auto memReq = vk_device.getImageMemoryRequirements(image);
+
+            vk::MemoryAllocateInfo allocInfo{};
+            allocInfo.allocationSize = memReq.size;
+            allocInfo.memoryTypeIndex =
+                findDedicatedMemoryType(memReq.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal);
+
+            auto imageMemory = vk_device.allocateMemory(allocInfo);
+            vk_device.bindImageMemory(image, imageMemory, 0);
+            auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
+
+            vk::ImageViewCreateInfo createInfo(
+                {}, image, vk::ImageViewType::e2D, format, vk::ComponentMapping(), range);
+
+            auto imageView = vk_device.createImageView(createInfo);
+
+            tex = std::make_shared<texture>(
+                width, height, components_count, depth_, image, imageMemory, imageView, vk_device);
+        }
+
+        cmd_ctx_.record_and_submit([&](vk::CommandBuffer cmd) {
+            transitionImageLayout(
+                tex->id(),
+                vk::ImageLayout::eUndefined,
+                vk::AccessFlagBits2::eNone,
+                vk::PipelineStageFlagBits2::eTopOfPipe,
+                vk::ImageLayout::eRenderingLocalRead,
+                vk::AccessFlagBits2::eColorAttachmentWrite | vk::AccessFlagBits2::eInputAttachmentRead,
+                vk::PipelineStageFlagBits2::eColorAttachmentOutput | vk::PipelineStageFlagBits2::eFragmentShader,
+                cmd);
+        });
+
+        tex->set_depth(depth_);
+
+        auto ptr = tex.get();
+        return std::shared_ptr<texture>(
+            ptr, [tex = std::move(tex), pool, pools = attachment_pools_](texture*) mutable { pool->push(tex); });
     }
 
     std::pair<std::vector<core::frame_geometry::coord>, uniform_block> draw(const draw_params& params)

--- a/src/accelerator/vulkan/image/image_kernel.cpp
+++ b/src/accelerator/vulkan/image/image_kernel.cpp
@@ -81,8 +81,9 @@ static const uint32_t frame_buffer_size = 3;
 
 struct image_kernel::impl
 {
-    spl::shared_ptr<device> vulkan_;
-    common::bit_depth       depth_;
+    spl::shared_ptr<device>   vulkan_;
+    common::bit_depth         depth_;
+    std::shared_ptr<pipeline> pipeline_;
 
     struct frame_data : public frame_context
     {
@@ -109,7 +110,7 @@ struct image_kernel::impl
             return parent->upload_vertex_buffer(*this, (void*)src.data(), src.size() * sizeof(float));
         }
         virtual draw_data create_draw_data(const draw_params& params) { return parent->draw(params); }
-        virtual std::shared_ptr<class pipeline> get_pipeline() { return parent->vulkan_->get_pipeline(parent->depth_); }
+        virtual std::shared_ptr<class pipeline> get_pipeline() { return parent->pipeline_; }
         virtual void                            record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
         {
             token = parent->cmd_ctx_.record_and_submit(record);
@@ -130,6 +131,9 @@ struct image_kernel::impl
     explicit impl(const spl::shared_ptr<device>& vulkan, common::bit_depth depth)
         : vulkan_(vulkan)
         , depth_(depth)
+        , pipeline_(std::make_shared<pipeline>(vulkan->getVkDevice(),
+                                               depth == common::bit_depth::bit8 ? vk::Format::eR8G8B8A8Unorm
+                                                                                : vk::Format::eR16G16B16A16Unorm))
         , cmd_ctx_(vulkan->getVkDevice(), vulkan->queue())
         , frames_{frame_data{this}, frame_data{this}, frame_data{this}}
     {

--- a/src/accelerator/vulkan/image/image_mixer.cpp
+++ b/src/accelerator/vulkan/image/image_mixer.cpp
@@ -26,6 +26,7 @@
 #include "../util/device.h"
 #include "../util/renderpass.h"
 #include "../util/texture.h"
+#include "../util/transfer.h"
 
 #ifdef WIN32
 #include "../../d3d/d3d_texture2d.h"
@@ -105,7 +106,7 @@ class image_renderer
 
         pass->commit();
 
-        auto readback = vulkan_->copy_async(target);
+        auto readback = vulkan_->transfer().copy_async(target);
 
         return std::async(std::launch::deferred,
                           [readback = std::move(readback)]() mutable
@@ -318,11 +319,11 @@ struct image_mixer::impl
             item.textures = *textures_ptr;
         } else {
             for (int n = 0; n < static_cast<int>(item.pix_desc.planes.size()); ++n) {
-                item.textures.emplace_back(vulkan_->copy_async(frame.image_data(n),
-                                                               item.pix_desc.planes[n].width,
-                                                               item.pix_desc.planes[n].height,
-                                                               item.pix_desc.planes[n].stride,
-                                                               item.pix_desc.planes[n].depth));
+                item.textures.emplace_back(vulkan_->transfer().copy_async(frame.image_data(n),
+                                                                          item.pix_desc.planes[n].width,
+                                                                          item.pix_desc.planes[n].height,
+                                                                          item.pix_desc.planes[n].stride,
+                                                                          item.pix_desc.planes[n].depth));
             }
         }
 
@@ -367,11 +368,12 @@ struct image_mixer::impl
                                        }
                                        std::vector<future_texture> textures;
                                        for (int n = 0; n < static_cast<int>(desc.planes.size()); ++n) {
-                                           textures.emplace_back(self->vulkan_->copy_async(image_data[n],
-                                                                                           desc.planes[n].width,
-                                                                                           desc.planes[n].height,
-                                                                                           desc.planes[n].stride,
-                                                                                           desc.planes[n].depth));
+                                           textures.emplace_back(
+                                               self->vulkan_->transfer().copy_async(image_data[n],
+                                                                                    desc.planes[n].width,
+                                                                                    desc.planes[n].height,
+                                                                                    desc.planes[n].stride,
+                                                                                    desc.planes[n].depth));
                                        }
                                        return std::make_shared<decltype(textures)>(std::move(textures));
                                    });

--- a/src/accelerator/vulkan/image/image_mixer.cpp
+++ b/src/accelerator/vulkan/image/image_mixer.cpp
@@ -97,24 +97,21 @@ class image_renderer
                 {array<const std::uint8_t>(buffer.data(), format_desc.size, true), nullptr});
         }
 
-        auto f = std::move(vulkan_->dispatch_async(
-            [this, format_desc, layers = std::move(layers)]() mutable
-            -> std::tuple<std::future<array<const std::uint8_t>>, std::shared_ptr<core::texture>> {
-                auto pass   = kernel_.create_renderpass(format_desc.square_width, format_desc.square_height);
-                auto target = pass->default_attachment();
-                draw(target, std::move(layers), format_desc, pass);
+        // Record + submit synchronously on the caller's (mixer) thread; the only
+        // CPU wait is the readback future's .get() downstream (it consumes bytes).
+        auto pass   = kernel_.create_renderpass(format_desc.square_width, format_desc.square_height);
+        auto target = pass->default_attachment();
+        draw(target, std::move(layers), format_desc, pass);
 
-                pass->commit();
+        pass->commit();
 
-                return {vulkan_->copy_async(target), nullptr};
-            }));
+        auto readback = vulkan_->copy_async(target);
 
-        return std::async(
-            std::launch::deferred,
-            [f = std::move(f)]() mutable -> std::tuple<array<const std::uint8_t>, std::shared_ptr<core::texture>> {
-                auto tuple = std::move(f.get());
-                return {std::move(std::get<0>(tuple).get()), std::move(std::get<1>(tuple))};
-            });
+        return std::async(std::launch::deferred,
+                          [readback = std::move(readback)]() mutable
+                              -> std::tuple<array<const std::uint8_t>, std::shared_ptr<core::texture>> {
+                              return {std::move(readback.get()), nullptr};
+                          });
     }
 
     common::bit_depth depth() const { return depth_; }
@@ -419,7 +416,6 @@ image_mixer::create_frame(const void* tag, const core::pixel_format_desc& desc, 
 {
     return impl_->create_frame(tag, desc, depth);
 }
-
 
 #ifdef WIN32
 core::const_frame image_mixer::import_d3d_texture(const void*                                tag,

--- a/src/accelerator/vulkan/util/barrier.h
+++ b/src/accelerator/vulkan/util/barrier.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+// Record a single-subresource image layout transition (color, mip 0, layer 0)
+// with explicit src/dst access + stage masks. Shared by the transfer paths
+// (upload/readback) and the renderer's attachment initialization.
+inline void transitionImageLayout(const vk::Image&        image,
+                                  vk::ImageLayout         oldLayout,
+                                  vk::AccessFlags2        srcAccessMask,
+                                  vk::PipelineStageFlags2 srcStage,
+                                  vk::ImageLayout         newLayout,
+                                  vk::AccessFlags2        dstAccessMask,
+                                  vk::PipelineStageFlags2 dstStage,
+                                  vk::CommandBuffer       cmdBuffer)
+{
+    auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
+
+    vk::ImageMemoryBarrier2 barrier{};
+    barrier.oldLayout = oldLayout, barrier.newLayout = newLayout, barrier.srcQueueFamilyIndex = vk::QueueFamilyIgnored,
+    barrier.dstQueueFamilyIndex = vk::QueueFamilyIgnored, barrier.image = image, barrier.subresourceRange = range;
+
+    barrier.srcAccessMask = srcAccessMask;
+    barrier.srcStageMask  = srcStage;
+
+    barrier.dstAccessMask = dstAccessMask;
+    barrier.dstStageMask  = dstStage;
+
+    vk::DependencyInfo dep_info;
+    dep_info.setImageMemoryBarriers(barrier);
+
+    cmdBuffer.pipelineBarrier2(dep_info);
+}
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/command_context.cpp
+++ b/src/accelerator/vulkan/util/command_context.cpp
@@ -72,6 +72,8 @@ vk::CommandBuffer command_context::acquire_command_buffer()
 
 completion_token command_context::record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
 {
+    std::lock_guard<std::mutex> lock(mutex_);
+
     auto cmd = acquire_command_buffer();
 
     cmd.begin(vk::CommandBufferBeginInfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit});

--- a/src/accelerator/vulkan/util/command_context.cpp
+++ b/src/accelerator/vulkan/util/command_context.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#include "command_context.h"
+
+#include "vulkan_queue.h"
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+command_context::command_context(vk::Device device, std::shared_ptr<vulkan_queue> queue)
+    : device_(device)
+    , queue_(std::move(queue))
+{
+    vk::CommandPoolCreateInfo pool_info;
+    pool_info.flags            = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
+    pool_info.queueFamilyIndex = queue_->family_index();
+    pool_                      = device_.createCommandPool(pool_info);
+
+    vk::SemaphoreTypeCreateInfo timeline_info{};
+    timeline_info.semaphoreType = vk::SemaphoreType::eTimeline;
+    timeline_info.initialValue  = 0;
+    vk::SemaphoreCreateInfo semaphore_info{};
+    semaphore_info.pNext = &timeline_info;
+    timeline_            = device_.createSemaphore(semaphore_info);
+}
+
+command_context::~command_context()
+{
+    inflight_.clear();
+    device_.destroySemaphore(timeline_);
+    device_.destroyCommandPool(pool_);
+}
+
+vk::CommandBuffer command_context::acquire_command_buffer()
+{
+    if (inflight_.size() > 1) {
+        auto completed = device_.getSemaphoreCounterValue(timeline_);
+
+        // try to reuse the oldest existing command buffer
+        if (inflight_.front().value <= completed) {
+            auto cmd = inflight_.front().cmd;
+            cmd.reset();
+            inflight_.pop_front();
+            return cmd;
+        }
+    }
+
+    vk::CommandBufferAllocateInfo alloc_info{};
+    alloc_info.commandPool        = pool_;
+    alloc_info.level              = vk::CommandBufferLevel::ePrimary;
+    alloc_info.commandBufferCount = 1;
+    return device_.allocateCommandBuffers(alloc_info)[0];
+}
+
+completion_token command_context::record_and_submit(const std::function<void(vk::CommandBuffer)>& record)
+{
+    auto cmd = acquire_command_buffer();
+
+    cmd.begin(vk::CommandBufferBeginInfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
+    record(cmd);
+    cmd.end();
+
+    auto signal_value = ++value_;
+
+    vk::TimelineSemaphoreSubmitInfo timeline_submit{};
+    timeline_submit.setSignalSemaphoreValues(signal_value);
+
+    vk::SubmitInfo submit_info{};
+    submit_info.setCommandBuffers(cmd);
+    submit_info.setSignalSemaphores(timeline_);
+    submit_info.pNext = &timeline_submit;
+    queue_->submit(submit_info);
+
+    inflight_.push_back({cmd, signal_value});
+
+    return completion_token{timeline_, signal_value};
+}
+
+bool command_context::wait(const completion_token& token, uint64_t timeout_ns) const
+{
+    if (!token)
+        return true;
+
+    vk::SemaphoreWaitInfo wait_info{};
+    wait_info.setSemaphores(token.timeline);
+    wait_info.setValues(token.value);
+    return device_.waitSemaphores(wait_info, timeout_ns) == vk::Result::eSuccess;
+}
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/command_context.h
+++ b/src/accelerator/vulkan/util/command_context.h
@@ -26,6 +26,7 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
 
 #include <vulkan/vulkan.hpp>
 
@@ -39,8 +40,13 @@ class vulkan_queue;
 // timeline drives both buffer reclamation (reuse a buffer once the GPU passed
 // its value) and the readback wait().
 //
-// Single-threaded for now: not internally synchronized. The owner must ensure
-// the device is idle before destruction (the dtor does not waitIdle).
+// Internally synchronized for the record path: one context is shared by every
+// channel's transfer ops, so record_and_submit holds a mutex guarding the pool,
+// the inflight ring and the timeline value. wait() is deliberately left
+// lock-free — it only reads the semaphore via a self-contained completion_token,
+// touching no mutable state, so a host readback can block without serializing
+// other submitters. The owner must ensure the device is idle before destruction
+// (the dtor does not waitIdle).
 class command_context final
 {
   public:
@@ -74,6 +80,7 @@ class command_context final
     vk::Semaphore                       timeline_;
     uint64_t                            value_ = 0;
     std::deque<inflight_command_buffer> inflight_;
+    std::mutex                          mutex_;
 };
 
 }}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/command_context.h
+++ b/src/accelerator/vulkan/util/command_context.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include "completion_token.h"
+
+#include <deque>
+#include <functional>
+#include <memory>
+
+#include <vulkan/vulkan.hpp>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+class vulkan_queue;
+
+// A command pool + timeline semaphore + a deque of recycled one-time command
+// buffers, bound to one vulkan_queue: record a one-time command buffer, submit
+// it on the queue signalling the timeline, and return a completion_token. The
+// timeline drives both buffer reclamation (reuse a buffer once the GPU passed
+// its value) and the readback wait().
+//
+// Single-threaded for now: not internally synchronized. The owner must ensure
+// the device is idle before destruction (the dtor does not waitIdle).
+class command_context final
+{
+  public:
+    command_context(vk::Device device, std::shared_ptr<vulkan_queue> queue);
+    ~command_context();
+
+    command_context(const command_context&)            = delete;
+    command_context& operator=(const command_context&) = delete;
+
+    // Reuse-or-allocate a one-time command buffer, begin/record(fn)/end, and
+    // submit it on the bound queue signalling this context's timeline.
+    completion_token record_and_submit(const std::function<void(vk::CommandBuffer)>& record);
+
+    // Block until the token's value is reached (or timeout). True on success;
+    // an empty token is already complete.
+    bool wait(const completion_token& token, uint64_t timeout_ns = 1'000'000'000) const;
+
+  private:
+    struct inflight_command_buffer
+    {
+        vk::CommandBuffer cmd;
+        uint64_t          value;
+    };
+
+    // Reuse the oldest retired command buffer, or allocate a fresh one.
+    vk::CommandBuffer acquire_command_buffer();
+
+    vk::Device                          device_;
+    std::shared_ptr<vulkan_queue>       queue_;
+    vk::CommandPool                     pool_;
+    vk::Semaphore                       timeline_;
+    uint64_t                            value_ = 0;
+    std::deque<inflight_command_buffer> inflight_;
+};
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/completion_token.h
+++ b/src/accelerator/vulkan/util/completion_token.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <vulkan/vulkan.hpp>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+// Handle to a submitted batch: a value on a command_context's timeline
+// semaphore. wait() on it to observe completion. A default-constructed token is
+// "nothing submitted" and is treated as already complete.
+struct completion_token
+{
+    vk::Semaphore timeline{};
+    uint64_t      value = 0;
+
+    explicit operator bool() const { return timeline && value > 0; }
+};
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/descriptor_pool.cpp
+++ b/src/accelerator/vulkan/util/descriptor_pool.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#include "descriptor_pool.h"
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+descriptor_pool::descriptor_pool(vk::Device                                 device,
+                                 vk::DescriptorSetLayout                    layout,
+                                 const std::vector<vk::DescriptorPoolSize>& sizes_per_set)
+    : device_(device)
+    , layout_(layout)
+    , sizes_per_set_(sizes_per_set)
+{
+}
+
+descriptor_pool::~descriptor_pool() { destroy(); }
+
+void descriptor_pool::destroy()
+{
+    if (pool_) {
+        device_.destroyDescriptorPool(pool_);
+        pool_ = nullptr;
+    }
+    capacity_ = 0;
+}
+
+vk::DescriptorPool descriptor_pool::create_pool(uint32_t max_sets) const
+{
+    auto sizes = sizes_per_set_;
+    for (auto& size : sizes)
+        size.descriptorCount *= max_sets;
+
+    vk::DescriptorPoolCreateInfo info{};
+    info.maxSets = max_sets;
+    info.setPoolSizes(sizes);
+    return device_.createDescriptorPool(info);
+}
+
+std::vector<vk::DescriptorSet> descriptor_pool::allocate(uint32_t count)
+{
+    if (count == 0)
+        return {};
+
+    if (count > capacity_) {
+        // Grow to the new high-water mark; the old pool's sets are from an
+        // already-completed frame (slot token waited), so it is safe to drop.
+        destroy();
+        pool_     = create_pool(count);
+        capacity_ = count;
+    } else {
+        device_.resetDescriptorPool(pool_);
+    }
+
+    std::vector<vk::DescriptorSetLayout> layouts(count, layout_);
+    vk::DescriptorSetAllocateInfo        info{};
+    info.descriptorPool = pool_;
+    info.setSetLayouts(layouts);
+    return device_.allocateDescriptorSets(info);
+}
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/descriptor_pool.h
+++ b/src/accelerator/vulkan/util/descriptor_pool.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include <vector>
+
+#include <vulkan/vulkan.hpp>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+// A resettable VkDescriptorPool sized to one frame's exact need. Owned per
+// render-frame slot (alongside that slot's vertex buffer); since the slot's
+// completion_token is waited before reuse (image_kernel::create_renderpass), a
+// reset here can never recycle a set still read by an in-flight submission.
+//
+// allocate(count) frees the previous frame's sets and hands back exactly `count`
+// fresh ones. The underlying VkDescriptorPool grows monotonically to the largest
+// count ever requested (high-water mark) and is reused (reset, not recreated) on
+// every smaller frame, so steady state is allocation-free churn. Not internally
+// synchronized: one instance lives on its kernel's (channel's) thread.
+class descriptor_pool final
+{
+  public:
+    descriptor_pool(vk::Device                                 device,
+                    vk::DescriptorSetLayout                    layout,
+                    const std::vector<vk::DescriptorPoolSize>& sizes_per_set);
+    ~descriptor_pool();
+
+    descriptor_pool(const descriptor_pool&)            = delete;
+    descriptor_pool& operator=(const descriptor_pool&) = delete;
+
+    // Reset the pool (freeing the previous frame's sets) and allocate `count`
+    // fresh sets of the bound layout. count == 0 returns empty without touching
+    // the pool.
+    std::vector<vk::DescriptorSet> allocate(uint32_t count);
+
+  private:
+    vk::DescriptorPool create_pool(uint32_t max_sets) const;
+    void               destroy();
+
+    vk::Device                          device_;
+    vk::DescriptorSetLayout             layout_;
+    std::vector<vk::DescriptorPoolSize> sizes_per_set_;
+    vk::DescriptorPool                  pool_     = nullptr;
+    uint32_t                            capacity_ = 0;
+};
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -25,6 +25,7 @@
 #include "buffer.h"
 #include "pipeline.h"
 #include "texture.h"
+#include "vulkan_queue.h"
 
 #include <common/array.h>
 #include <common/assert.h>
@@ -56,6 +57,7 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #include <array>
 #include <deque>
 #include <future>
+#include <memory>
 #include <thread>
 
 namespace caspar { namespace accelerator { namespace vulkan {
@@ -127,7 +129,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
     vk::PhysicalDeviceMemoryProperties _memoryProperties;
     vk::PhysicalDevice                 _physical_device;
     vk::Device                         _device;
-    vk::Queue                          _queue;
+    std::unique_ptr<vulkan_queue>      _queue;
     vk::CommandPool                    _command_pool;
     VmaAllocator                       _allocator;
 
@@ -223,12 +225,13 @@ struct device::impl : public std::enable_shared_from_this<impl>
         auto vkb_device = device_res.value();
         _device         = vk::Device(vkb_device.device);
         VULKAN_HPP_DEFAULT_DISPATCHER.init(_device);
-        _queue            = vk::Queue(vkb_device.get_queue(vkb::QueueType::graphics).value());
-        auto queue_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
+        auto graphics_queue  = vk::Queue(vkb_device.get_queue(vkb::QueueType::graphics).value());
+        auto graphics_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
+        _queue               = std::make_unique<vulkan_queue>(graphics_queue, graphics_family);
 
         vk::CommandPoolCreateInfo pool_info;
         pool_info.flags            = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
-        pool_info.queueFamilyIndex = queue_family;
+        pool_info.queueFamilyIndex = _queue->family_index();
 
         _command_pool = _device.createCommandPool(pool_info);
 
@@ -382,7 +385,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         submitInfo.setCommandBuffers(cmd_buffer);
         submitInfo.setSignalSemaphores(_semaphore);
         submitInfo.pNext = &timelineInfo;
-        _queue.submit(submitInfo);
+        _queue->submit(submitInfo);
 
         _transfer_cmd_buffers.push_back({cmd_buffer, signal_value});
 
@@ -394,7 +397,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         return _device.allocateCommandBuffers(
             vk::CommandBufferAllocateInfo(_command_pool, vk::CommandBufferLevel::ePrimary, count));
     }
-    void submit(const vk::SubmitInfo& submitInfo, vk::Fence fence) { _queue.submit(submitInfo, fence); }
+    void submit(const vk::SubmitInfo& submitInfo, vk::Fence fence) { _queue->submit(submitInfo, fence); }
 
     std::shared_ptr<texture>
     create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count)

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -33,7 +33,7 @@
 #include <common/assert.h>
 #include <common/env.h>
 #include <common/except.h>
-#include <common/os/thread.h>
+#include <common/future.h>
 
 #include <VkBootstrap.h>
 #include <vulkan/vulkan.hpp>
@@ -48,9 +48,6 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #include <vk_mem_alloc.h>
 #pragma warning(pop)
 
-#include <boost/asio/deadline_timer.hpp>
-#include <boost/asio/dispatch.hpp>
-#include <boost/asio/spawn.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <tbb/concurrent_queue.h>
@@ -60,11 +57,8 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #include <deque>
 #include <future>
 #include <memory>
-#include <thread>
 
 namespace caspar { namespace accelerator { namespace vulkan {
-
-using namespace boost::asio;
 
 inline VKAPI_ATTR VkBool32 VKAPI_CALL default_debug_callback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
                                                              VkDebugUtilsMessageTypeFlagsEXT        messageType,
@@ -138,12 +132,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
     std::unique_ptr<command_context> cmd_ctx_;
 
-    io_context                             io_context_;
-    decltype(make_work_guard(io_context_)) work_;
-    std::thread                            thread_;
-
     impl()
-        : work_(make_work_guard(io_context_))
     {
         CASPAR_LOG(info) << L"Initializing Vulkan Device.";
 
@@ -243,18 +232,10 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
         _pipelines[0] = std::make_shared<pipeline>(_device, vk::Format::eR8G8B8A8Unorm);
         _pipelines[1] = std::make_shared<pipeline>(_device, vk::Format::eR16G16B16A16Unorm);
-
-        thread_ = std::thread([&] {
-            set_thread_name(L"Vulkan Device");
-            io_context_.run();
-        });
     }
 
     ~impl()
     {
-        work_.reset();
-        thread_.join();
-
         _device.waitIdle();
 
         for (auto& pool : host_pools_)
@@ -276,45 +257,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
         _device.destroy();
         vkb::destroy_instance(_vkb_instance);
-    }
-
-    template <typename Func>
-    auto spawn_async(Func&& func)
-    {
-        using result_type = decltype(func(std::declval<yield_context>()));
-        using task_type   = std::packaged_task<result_type(yield_context)>;
-
-        auto task   = task_type(std::forward<Func>(func));
-        auto future = task.get_future();
-        boost::asio::spawn(io_context_,
-                           std::move(task)
-#if BOOST_VERSION >= 108000
-                               ,
-                           [](std::exception_ptr e) {
-                               if (e)
-                                   std::rethrow_exception(e);
-                           }
-#endif
-        );
-        return future;
-    }
-
-    template <typename Func>
-    auto dispatch_async(Func&& func)
-    {
-        using result_type = decltype(func());
-        using task_type   = std::packaged_task<result_type()>;
-
-        auto task   = task_type(std::forward<Func>(func));
-        auto future = task.get_future();
-        boost::asio::dispatch(io_context_, std::move(task));
-        return future;
-    }
-
-    template <typename Func>
-    auto dispatch_sync(Func&& func) -> decltype(func())
-    {
-        return dispatch_async(std::forward<Func>(func)).get();
     }
 
     std::wstring version() { return version_; }
@@ -486,95 +428,93 @@ struct device::impl : public std::enable_shared_from_this<impl>
         return array<uint8_t>(ptr, buf->size(), std::move(buf));
     }
 
+    // Upload (host→device). Records + submits synchronously on the caller's
+    // thread (serialized through cmd_ctx_'s record mutex and the queue mutex), and
+    // returns a ready future: no host readback, so no CPU wait — GPU consumers of
+    // the texture are ordered by the memory barriers, not by the CPU.
     std::future<std::shared_ptr<texture>>
     copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth)
     {
-        return dispatch_async([this, source, width, height, stride, depth]() {
-            std::shared_ptr<buffer> buf;
+        std::shared_ptr<buffer> buf;
 
-            auto tmp = source.storage<std::shared_ptr<buffer>>();
-            if (tmp) {
-                buf = *tmp;
-            } else {
-                buf = create_buffer(static_cast<int>(source.size()), true);
-                std::memcpy(buf->data(), source.data(), source.size());
-            }
+        auto tmp = source.storage<std::shared_ptr<buffer>>();
+        if (tmp) {
+            buf = *tmp;
+        } else {
+            buf = create_buffer(static_cast<int>(source.size()), true);
+            std::memcpy(buf->data(), source.data(), source.size());
+        }
 
-            auto tex = create_texture(width, height, stride, depth, false);
+        auto tex = create_texture(width, height, stride, depth, false);
 
-            vk::BufferImageCopy region(0,
-                                       0,
-                                       0,
-                                       vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1),
-                                       vk::Offset3D(0, 0, 0),
-                                       vk::Extent3D(width, height, 1));
+        vk::BufferImageCopy region(0,
+                                   0,
+                                   0,
+                                   vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1),
+                                   vk::Offset3D(0, 0, 0),
+                                   vk::Extent3D(width, height, 1));
 
-            cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
-                transitionImageLayout(tex->id(),
-                                      vk::ImageLayout::eUndefined,
-                                      vk::AccessFlagBits2::eNone,
-                                      vk::PipelineStageFlagBits2::eTopOfPipe,
+        cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+            transitionImageLayout(tex->id(),
+                                  vk::ImageLayout::eUndefined,
+                                  vk::AccessFlagBits2::eNone,
+                                  vk::PipelineStageFlagBits2::eTopOfPipe,
 
-                                      vk::ImageLayout::eTransferDstOptimal,
-                                      vk::AccessFlagBits2::eTransferWrite,
-                                      vk::PipelineStageFlagBits2::eTransfer,
-                                      cmd);
+                                  vk::ImageLayout::eTransferDstOptimal,
+                                  vk::AccessFlagBits2::eTransferWrite,
+                                  vk::PipelineStageFlagBits2::eTransfer,
+                                  cmd);
 
-                cmd.copyBufferToImage(buf->id(), tex->id(), vk::ImageLayout::eTransferDstOptimal, region);
+            cmd.copyBufferToImage(buf->id(), tex->id(), vk::ImageLayout::eTransferDstOptimal, region);
 
-                transitionImageLayout(tex->id(),
-                                      vk::ImageLayout::eTransferDstOptimal,
-                                      vk::AccessFlagBits2::eTransferWrite,
-                                      vk::PipelineStageFlagBits2::eTransfer,
+            transitionImageLayout(tex->id(),
+                                  vk::ImageLayout::eTransferDstOptimal,
+                                  vk::AccessFlagBits2::eTransferWrite,
+                                  vk::PipelineStageFlagBits2::eTransfer,
 
-                                      vk::ImageLayout::eShaderReadOnlyOptimal,
-                                      vk::AccessFlagBits2::eShaderRead,
-                                      vk::PipelineStageFlagBits2::eFragmentShader,
-                                      cmd);
-            });
-
-            // No need to wait here, GPU-GPU deps (the usage of this texture on the device) are enforced by the memory
-            // barriers
-            return tex;
+                                  vk::ImageLayout::eShaderReadOnlyOptimal,
+                                  vk::AccessFlagBits2::eShaderRead,
+                                  vk::PipelineStageFlagBits2::eFragmentShader,
+                                  cmd);
         });
+
+        return make_ready_future(std::move(tex));
     }
 
+    // Readback (device→host). Records + submits synchronously on the caller's
+    // thread; the returned deferred future blocks at .get() on cmd_ctx_->wait —
+    // the one legitimate CPU wait, because the caller is consuming bytes.
     std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source)
     {
-        auto f = dispatch_async([this, source]() -> std::pair<std::shared_ptr<buffer>, completion_token> {
-            auto buf = create_buffer(source->size(), false);
+        auto buf = create_buffer(source->size(), false);
 
-            vk::CopyImageToBufferInfo2 copyInfo{};
-            copyInfo.dstBuffer      = buf->id();
-            copyInfo.srcImage       = source->id();
-            copyInfo.srcImageLayout = vk::ImageLayout::eTransferSrcOptimal;
+        vk::CopyImageToBufferInfo2 copyInfo{};
+        copyInfo.dstBuffer      = buf->id();
+        copyInfo.srcImage       = source->id();
+        copyInfo.srcImageLayout = vk::ImageLayout::eTransferSrcOptimal;
 
-            vk::BufferImageCopy2 region{};
-            region.bufferOffset     = 0;
-            region.imageSubresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
-            region.imageOffset      = vk::Offset3D{0, 0, 0};
-            region.imageExtent =
-                vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
-            copyInfo.setRegions(region);
+        vk::BufferImageCopy2 region{};
+        region.bufferOffset     = 0;
+        region.imageSubresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
+        region.imageOffset      = vk::Offset3D{0, 0, 0};
+        region.imageExtent =
+            vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
+        copyInfo.setRegions(region);
 
-            auto token = cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
-                transitionImageLayout(source->id(),
-                                      vk::ImageLayout::eRenderingLocalRead,
-                                      vk::AccessFlagBits2::eColorAttachmentWrite,
-                                      vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+        auto token = cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+            transitionImageLayout(source->id(),
+                                  vk::ImageLayout::eRenderingLocalRead,
+                                  vk::AccessFlagBits2::eColorAttachmentWrite,
+                                  vk::PipelineStageFlagBits2::eColorAttachmentOutput,
 
-                                      vk::ImageLayout::eTransferSrcOptimal,
-                                      vk::AccessFlagBits2::eHostRead,
-                                      vk::PipelineStageFlagBits2::eHost,
-                                      cmd);
-                cmd.copyImageToBuffer2(copyInfo);
-            });
-
-            return {buf, token};
+                                  vk::ImageLayout::eTransferSrcOptimal,
+                                  vk::AccessFlagBits2::eHostRead,
+                                  vk::PipelineStageFlagBits2::eHost,
+                                  cmd);
+            cmd.copyImageToBuffer2(copyInfo);
         });
 
-        return std::async(std::launch::deferred, [this, f = std::move(f)]() mutable {
-            auto [buf, token] = f.get();
+        return std::async(std::launch::deferred, [this, buf = std::move(buf), token]() mutable {
             if (!cmd_ctx_->wait(token)) {
                 CASPAR_LOG(warning) << L"[Vulkan] Timeout waiting for readback semaphore";
             }
@@ -673,28 +613,28 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
     std::future<void> gc()
     {
-        return spawn_async([this](yield_context yield) {
-            CASPAR_LOG(info) << " vulkan: Running GC.";
+        CASPAR_LOG(info) << " vulkan: Running GC.";
 
-            try {
-                for (auto& depth_pools : device_pools_) {
-                    for (auto& pools : depth_pools) {
-                        for (auto& pool : pools)
-                            pool.second.clear();
-                    }
-                }
-                for (auto& pools : host_pools_) {
+        try {
+            for (auto& depth_pools : device_pools_) {
+                for (auto& pools : depth_pools) {
                     for (auto& pool : pools)
                         pool.second.clear();
                 }
-                for (auto& pools : attachment_pools_) {
-                    for (auto& pool : pools)
-                        pool.second.clear();
-                }
-            } catch (...) {
-                CASPAR_LOG_CURRENT_EXCEPTION();
             }
-        });
+            for (auto& pools : host_pools_) {
+                for (auto& pool : pools)
+                    pool.second.clear();
+            }
+            for (auto& pools : attachment_pools_) {
+                for (auto& pool : pools)
+                    pool.second.clear();
+            }
+        } catch (...) {
+            CASPAR_LOG_CURRENT_EXCEPTION();
+        }
+
+        return make_ready_future();
     }
 };
 
@@ -732,7 +672,6 @@ std::future<array<const uint8_t>> device::copy_async(const std::shared_ptr<textu
 {
     return impl_->copy_async(source);
 }
-void device::dispatch(std::function<void()> func) { boost::asio::dispatch(impl_->io_context_, std::move(func)); }
 std::wstring                 device::version() const { return impl_->version(); }
 boost::property_tree::wptree device::info() const { return impl_->info(); }
 std::future<void>            device::gc() { return impl_->gc(); }

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -25,7 +25,6 @@
 #include "buffer.h"
 #include "command_context.h"
 #include "completion_token.h"
-#include "pipeline.h"
 #include "texture.h"
 #include "vulkan_queue.h"
 
@@ -128,8 +127,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
     std::shared_ptr<vulkan_queue>      _queue;
     VmaAllocator                       _allocator;
 
-    std::array<std::shared_ptr<pipeline>, 2> _pipelines;
-
     std::unique_ptr<command_context> cmd_ctx_;
 
     impl()
@@ -229,9 +226,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         vmaCreateAllocator(&allocatorCreateInfo, &_allocator);
 
         _memoryProperties = _physical_device.getMemoryProperties();
-
-        _pipelines[0] = std::make_shared<pipeline>(_device, vk::Format::eR8G8B8A8Unorm);
-        _pipelines[1] = std::make_shared<pipeline>(_device, vk::Format::eR16G16B16A16Unorm);
     }
 
     ~impl()
@@ -251,9 +245,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         cmd_ctx_.reset();
 
         vmaDestroyAllocator(_allocator);
-        for (auto& pipeline : _pipelines) {
-            pipeline.reset();
-        }
 
         _device.destroy();
         vkb::destroy_instance(_vkb_instance);
@@ -647,10 +638,6 @@ device::~device() {}
 vk::PhysicalDeviceMemoryProperties device::getMemoryProperties() { return impl_->_memoryProperties; }
 vk::Device                         device::getVkDevice() const { return impl_->_device; }
 std::shared_ptr<vulkan_queue>      device::queue() { return impl_->_queue; }
-std::shared_ptr<pipeline>          device::get_pipeline(common::bit_depth depth)
-{
-    return impl_->_pipelines[depth == common::bit_depth::bit8 ? 0 : 1];
-}
 
 std::shared_ptr<texture>
 device::create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count)

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -22,6 +22,7 @@
 #include "device.h"
 
 #include "../image/image_kernel.h"
+#include "barrier.h"
 #include "buffer.h"
 #include "command_context.h"
 #include "completion_token.h"
@@ -81,39 +82,11 @@ inline VKAPI_ATTR VkBool32 VKAPI_CALL default_debug_callback(VkDebugUtilsMessage
                      // driver)
 }
 
-void transitionImageLayout(const vk::Image&        image,
-                           vk::ImageLayout         oldLayout,
-                           vk::AccessFlags2        srcAccessMask,
-                           vk::PipelineStageFlags2 srcStage,
-                           vk::ImageLayout         newLayout,
-                           vk::AccessFlags2        dstAccessMask,
-                           vk::PipelineStageFlags2 dstStage,
-                           vk::CommandBuffer       cmdBuffer)
-{
-    auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
-
-    vk::ImageMemoryBarrier2 barrier{};
-    barrier.oldLayout = oldLayout, barrier.newLayout = newLayout, barrier.srcQueueFamilyIndex = vk::QueueFamilyIgnored,
-    barrier.dstQueueFamilyIndex = vk::QueueFamilyIgnored, barrier.image = image, barrier.subresourceRange = range;
-
-    barrier.srcAccessMask = srcAccessMask;
-    barrier.srcStageMask  = srcStage;
-
-    barrier.dstAccessMask = dstAccessMask;
-    barrier.dstStageMask  = dstStage;
-
-    vk::DependencyInfo dep_info;
-    dep_info.setImageMemoryBarriers(barrier);
-
-    cmdBuffer.pipelineBarrier2(dep_info);
-}
-
 struct device::impl : public std::enable_shared_from_this<impl>
 {
     using texture_queue_t = tbb::concurrent_bounded_queue<std::shared_ptr<texture>>;
     using buffer_queue_t  = tbb::concurrent_bounded_queue<std::shared_ptr<buffer>>;
 
-    std::array<tbb::concurrent_unordered_map<size_t, texture_queue_t>, 2>                attachment_pools_;
     std::array<std::array<tbb::concurrent_unordered_map<size_t, texture_queue_t>, 4>, 2> device_pools_;
     std::array<tbb::concurrent_unordered_map<size_t, buffer_queue_t>, 2>                 host_pools_;
 
@@ -127,7 +100,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
     std::shared_ptr<vulkan_queue>      _queue;
     VmaAllocator                       _allocator;
 
-    std::unique_ptr<command_context> cmd_ctx_;
+    std::unique_ptr<command_context> transfer_ctx_;
 
     impl()
     {
@@ -209,7 +182,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         auto graphics_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
         _queue               = std::make_shared<vulkan_queue>(graphics_queue, graphics_family);
 
-        cmd_ctx_ = std::make_unique<command_context>(_device, _queue);
+        transfer_ctx_ = std::make_unique<command_context>(_device, _queue);
 
         VmaVulkanFunctions vulkanFunctions    = {};
         vulkanFunctions.vkGetInstanceProcAddr = _vkb_instance.fp_vkGetInstanceProcAddr;
@@ -235,14 +208,11 @@ struct device::impl : public std::enable_shared_from_this<impl>
         for (auto& pool : host_pools_)
             pool.clear();
 
-        for (auto& pool : attachment_pools_)
-            pool.clear();
-
         for (auto& pools : device_pools_)
             for (auto& pool : pools)
                 pool.clear();
 
-        cmd_ctx_.reset();
+        transfer_ctx_.reset();
 
         vmaDestroyAllocator(_allocator);
 
@@ -261,74 +231,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
             }
         }
         throw std::runtime_error("Failed to find suitable memory type");
-    }
-
-    std::shared_ptr<texture>
-    create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count)
-    {
-        CASPAR_VERIFY(width > 0 && height > 0);
-
-        auto depth_pool_index = depth == common::bit_depth::bit8 ? 0 : 1;
-        auto format = depth == common::bit_depth::bit8 ? vk::Format::eR8G8B8A8Unorm : vk::Format::eR16G16B16A16Unorm;
-
-        // TODO (perf) Shared pool.
-        auto pool   = &attachment_pools_[depth_pool_index][(width << 16 & 0xFFFF0000) | (height & 0x0000FFFF)];
-        auto extent = vk::Extent3D{static_cast<uint32_t>(width), static_cast<uint32_t>(height), 1};
-
-        std::shared_ptr<texture> tex;
-        if (!pool->try_pop(tex)) {
-            vk::ImageCreateInfo imageInfo{};
-            imageInfo.imageType     = vk::ImageType::e2D;
-            imageInfo.format        = format;
-            imageInfo.extent        = extent;
-            imageInfo.mipLevels     = 1;
-            imageInfo.arrayLayers   = 1;
-            imageInfo.initialLayout = vk::ImageLayout::eUndefined;
-            imageInfo.samples       = vk::SampleCountFlagBits::e1;
-            imageInfo.tiling        = vk::ImageTiling::eOptimal;
-            imageInfo.usage         = vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eInputAttachment |
-                              vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferDst |
-                              vk::ImageUsageFlagBits::eSampled;
-            imageInfo.sharingMode = vk::SharingMode::eExclusive;
-            auto image            = _device.createImage(imageInfo);
-
-            auto memReq = _device.getImageMemoryRequirements(image);
-
-            vk::MemoryAllocateInfo allocInfo{};
-            allocInfo.allocationSize = memReq.size;
-            allocInfo.memoryTypeIndex =
-                findDedicatedMemoryType(memReq.memoryTypeBits, vk::MemoryPropertyFlagBits::eDeviceLocal);
-
-            auto imageMemory = _device.allocateMemory(allocInfo);
-            _device.bindImageMemory(image, imageMemory, 0);
-            auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
-
-            vk::ImageViewCreateInfo createInfo(
-                {}, image, vk::ImageViewType::e2D, format, vk::ComponentMapping(), range);
-
-            auto imageView = _device.createImageView(createInfo);
-
-            tex = std::make_shared<texture>(
-                width, height, components_count, depth, image, imageMemory, imageView, _device);
-        }
-
-        cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
-            transitionImageLayout(
-                tex->id(),
-                vk::ImageLayout::eUndefined,
-                vk::AccessFlagBits2::eNone,
-                vk::PipelineStageFlagBits2::eTopOfPipe,
-                vk::ImageLayout::eRenderingLocalRead,
-                vk::AccessFlagBits2::eColorAttachmentWrite | vk::AccessFlagBits2::eInputAttachmentRead,
-                vk::PipelineStageFlagBits2::eColorAttachmentOutput | vk::PipelineStageFlagBits2::eFragmentShader,
-                cmd);
-        });
-
-        tex->set_depth(depth);
-
-        auto ptr = tex.get();
-        return std::shared_ptr<texture>(
-            ptr, [tex = std::move(tex), pool, self = shared_from_this()](texture*) mutable { pool->push(tex); });
     }
 
     std::shared_ptr<texture> create_texture(int width, int height, int stride, common::bit_depth depth, bool clear)
@@ -420,7 +322,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
     }
 
     // Upload (host→device). Records + submits synchronously on the caller's
-    // thread (serialized through cmd_ctx_'s record mutex and the queue mutex), and
+    // thread (serialized through transfer_ctx_'s record mutex and the queue mutex), and
     // returns a ready future: no host readback, so no CPU wait — GPU consumers of
     // the texture are ordered by the memory barriers, not by the CPU.
     std::future<std::shared_ptr<texture>>
@@ -445,7 +347,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
                                    vk::Offset3D(0, 0, 0),
                                    vk::Extent3D(width, height, 1));
 
-        cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+        transfer_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
             transitionImageLayout(tex->id(),
                                   vk::ImageLayout::eUndefined,
                                   vk::AccessFlagBits2::eNone,
@@ -473,7 +375,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
     }
 
     // Readback (device→host). Records + submits synchronously on the caller's
-    // thread; the returned deferred future blocks at .get() on cmd_ctx_->wait —
+    // thread; the returned deferred future blocks at .get() on transfer_ctx_->wait —
     // the one legitimate CPU wait, because the caller is consuming bytes.
     std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source)
     {
@@ -492,7 +394,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
             vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
         copyInfo.setRegions(region);
 
-        auto token = cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+        auto token = transfer_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
             transitionImageLayout(source->id(),
                                   vk::ImageLayout::eRenderingLocalRead,
                                   vk::AccessFlagBits2::eColorAttachmentWrite,
@@ -506,7 +408,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         });
 
         return std::async(std::launch::deferred, [this, buf = std::move(buf), token]() mutable {
-            if (!cmd_ctx_->wait(token)) {
+            if (!transfer_ctx_->wait(token)) {
                 CASPAR_LOG(warning) << L"[Vulkan] Timeout waiting for readback semaphore";
             }
 
@@ -617,10 +519,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
                 for (auto& pool : pools)
                     pool.second.clear();
             }
-            for (auto& pools : attachment_pools_) {
-                for (auto& pool : pools)
-                    pool.second.clear();
-            }
         } catch (...) {
             CASPAR_LOG_CURRENT_EXCEPTION();
         }
@@ -638,12 +536,6 @@ device::~device() {}
 vk::PhysicalDeviceMemoryProperties device::getMemoryProperties() { return impl_->_memoryProperties; }
 vk::Device                         device::getVkDevice() const { return impl_->_device; }
 std::shared_ptr<vulkan_queue>      device::queue() { return impl_->_queue; }
-
-std::shared_ptr<texture>
-device::create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count)
-{
-    return impl_->create_attachment(width, height, depth, components_count);
-}
 
 std::shared_ptr<texture> device::create_texture(int width, int height, int stride, common::bit_depth depth)
 {

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -132,7 +132,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
     vk::PhysicalDevice                 _physical_device;
     vk::Device                         _device;
     std::shared_ptr<vulkan_queue>      _queue;
-    vk::CommandPool                    _command_pool;
     VmaAllocator                       _allocator;
 
     std::array<std::shared_ptr<pipeline>, 2> _pipelines;
@@ -224,12 +223,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         auto graphics_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
         _queue               = std::make_shared<vulkan_queue>(graphics_queue, graphics_family);
 
-        vk::CommandPoolCreateInfo pool_info;
-        pool_info.flags            = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
-        pool_info.queueFamilyIndex = _queue->family_index();
-
-        _command_pool = _device.createCommandPool(pool_info);
-
         cmd_ctx_ = std::make_unique<command_context>(_device, _queue);
 
         VmaVulkanFunctions vulkanFunctions    = {};
@@ -276,7 +269,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
         cmd_ctx_.reset();
 
-        _device.destroyCommandPool(_command_pool);
         vmaDestroyAllocator(_allocator);
         for (auto& pipeline : _pipelines) {
             pipeline.reset();
@@ -337,13 +329,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         }
         throw std::runtime_error("Failed to find suitable memory type");
     }
-
-    std::vector<vk::CommandBuffer> allocateCommandBuffers(uint32_t count)
-    {
-        return _device.allocateCommandBuffers(
-            vk::CommandBufferAllocateInfo(_command_pool, vk::CommandBufferLevel::ePrimary, count));
-    }
-    void submit(const vk::SubmitInfo& submitInfo, vk::Fence fence) { _queue->submit(submitInfo, fence); }
 
     std::shared_ptr<texture>
     create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count)
@@ -720,13 +705,9 @@ device::device()
 device::~device() {}
 
 vk::PhysicalDeviceMemoryProperties device::getMemoryProperties() { return impl_->_memoryProperties; }
-std::vector<vk::CommandBuffer>     device::allocateCommandBuffers(uint32_t count)
-{
-    return impl_->allocateCommandBuffers(count);
-}
-void       device::submit(const vk::SubmitInfo& submitInfo, vk::Fence fence) { impl_->submit(submitInfo, fence); }
-vk::Device device::getVkDevice() const { return impl_->_device; }
-std::shared_ptr<pipeline> device::get_pipeline(common::bit_depth depth)
+vk::Device                         device::getVkDevice() const { return impl_->_device; }
+std::shared_ptr<vulkan_queue>      device::queue() { return impl_->_queue; }
+std::shared_ptr<pipeline>          device::get_pipeline(common::bit_depth depth)
 {
     return impl_->_pipelines[depth == common::bit_depth::bit8 ? 0 : 1];
 }

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -23,6 +23,8 @@
 
 #include "../image/image_kernel.h"
 #include "buffer.h"
+#include "command_context.h"
+#include "completion_token.h"
 #include "pipeline.h"
 #include "texture.h"
 #include "vulkan_queue.h"
@@ -129,20 +131,13 @@ struct device::impl : public std::enable_shared_from_this<impl>
     vk::PhysicalDeviceMemoryProperties _memoryProperties;
     vk::PhysicalDevice                 _physical_device;
     vk::Device                         _device;
-    std::unique_ptr<vulkan_queue>      _queue;
+    std::shared_ptr<vulkan_queue>      _queue;
     vk::CommandPool                    _command_pool;
     VmaAllocator                       _allocator;
 
     std::array<std::shared_ptr<pipeline>, 2> _pipelines;
 
-    struct inflight_command_buffer
-    {
-        vk::CommandBuffer cmd;
-        uint64_t          semaphore_value;
-    };
-    std::deque<inflight_command_buffer> _transfer_cmd_buffers;
-    vk::Semaphore                       _semaphore;
-    uint64_t                            _semaphore_value{0};
+    std::unique_ptr<command_context> cmd_ctx_;
 
     io_context                             io_context_;
     decltype(make_work_guard(io_context_)) work_;
@@ -227,7 +222,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
         VULKAN_HPP_DEFAULT_DISPATCHER.init(_device);
         auto graphics_queue  = vk::Queue(vkb_device.get_queue(vkb::QueueType::graphics).value());
         auto graphics_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
-        _queue               = std::make_unique<vulkan_queue>(graphics_queue, graphics_family);
+        _queue               = std::make_shared<vulkan_queue>(graphics_queue, graphics_family);
 
         vk::CommandPoolCreateInfo pool_info;
         pool_info.flags            = vk::CommandPoolCreateFlagBits::eResetCommandBuffer;
@@ -235,12 +230,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
         _command_pool = _device.createCommandPool(pool_info);
 
-        vk::SemaphoreTypeCreateInfo timeline_info{};
-        timeline_info.semaphoreType = vk::SemaphoreType::eTimeline;
-        timeline_info.initialValue  = 0;
-        vk::SemaphoreCreateInfo semaphore_info{};
-        semaphore_info.pNext = &timeline_info;
-        _semaphore           = _device.createSemaphore(semaphore_info);
+        cmd_ctx_ = std::make_unique<command_context>(_device, _queue);
 
         VmaVulkanFunctions vulkanFunctions    = {};
         vulkanFunctions.vkGetInstanceProcAddr = _vkb_instance.fp_vkGetInstanceProcAddr;
@@ -284,8 +274,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
             for (auto& pool : pools)
                 pool.clear();
 
-        _transfer_cmd_buffers.clear();
-        _device.destroySemaphore(_semaphore);
+        cmd_ctx_.reset();
 
         _device.destroyCommandPool(_command_pool);
         vmaDestroyAllocator(_allocator);
@@ -349,49 +338,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         throw std::runtime_error("Failed to find suitable memory type");
     }
 
-    uint64_t submitSingleTimeCommands(std::function<void(const vk::CommandBuffer&)> func)
-    {
-        vk::CommandBuffer cmd_buffer = nullptr;
-        if (_transfer_cmd_buffers.size() > 1) {
-            auto completed = _device.getSemaphoreCounterValue(_semaphore);
-
-            // try to reuse the oldest existing command buffer
-            if (_transfer_cmd_buffers.front().semaphore_value <= completed) {
-                cmd_buffer = _transfer_cmd_buffers.front().cmd;
-                cmd_buffer.reset();
-                _transfer_cmd_buffers.pop_front();
-            }
-        }
-
-        if (!cmd_buffer) {
-            // create a new command buffer
-            vk::CommandBufferAllocateInfo allocInfo{};
-            allocInfo.commandPool        = _command_pool;
-            allocInfo.level              = vk::CommandBufferLevel::ePrimary;
-            allocInfo.commandBufferCount = 1;
-
-            cmd_buffer = _device.allocateCommandBuffers(allocInfo)[0];
-        }
-
-        cmd_buffer.begin(vk::CommandBufferBeginInfo{vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
-        func(cmd_buffer);
-        cmd_buffer.end();
-
-        auto                            signal_value = ++_semaphore_value;
-        vk::TimelineSemaphoreSubmitInfo timelineInfo{};
-        timelineInfo.setSignalSemaphoreValues(signal_value);
-
-        vk::SubmitInfo submitInfo{};
-        submitInfo.setCommandBuffers(cmd_buffer);
-        submitInfo.setSignalSemaphores(_semaphore);
-        submitInfo.pNext = &timelineInfo;
-        _queue->submit(submitInfo);
-
-        _transfer_cmd_buffers.push_back({cmd_buffer, signal_value});
-
-        return signal_value;
-    }
-
     std::vector<vk::CommandBuffer> allocateCommandBuffers(uint32_t count)
     {
         return _device.allocateCommandBuffers(
@@ -448,7 +394,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
                 width, height, components_count, depth, image, imageMemory, imageView, _device);
         }
 
-        submitSingleTimeCommands([&](vk::CommandBuffer cmd) {
+        cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
             transitionImageLayout(
                 tex->id(),
                 vk::ImageLayout::eUndefined,
@@ -578,7 +524,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
                                        vk::Offset3D(0, 0, 0),
                                        vk::Extent3D(width, height, 1));
 
-            submitSingleTimeCommands([&](vk::CommandBuffer cmd) {
+            cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
                 transitionImageLayout(tex->id(),
                                       vk::ImageLayout::eUndefined,
                                       vk::AccessFlagBits2::eNone,
@@ -610,7 +556,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
 
     std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source)
     {
-        auto f = dispatch_async([this, source]() -> std::pair<std::shared_ptr<buffer>, uint64_t> {
+        auto f = dispatch_async([this, source]() -> std::pair<std::shared_ptr<buffer>, completion_token> {
             auto buf = create_buffer(source->size(), false);
 
             vk::CopyImageToBufferInfo2 copyInfo{};
@@ -626,7 +572,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
                 vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
             copyInfo.setRegions(region);
 
-            auto signal_value = submitSingleTimeCommands([&](vk::CommandBuffer cmd) {
+            auto token = cmd_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
                 transitionImageLayout(source->id(),
                                       vk::ImageLayout::eRenderingLocalRead,
                                       vk::AccessFlagBits2::eColorAttachmentWrite,
@@ -639,16 +585,12 @@ struct device::impl : public std::enable_shared_from_this<impl>
                 cmd.copyImageToBuffer2(copyInfo);
             });
 
-            return {buf, signal_value};
+            return {buf, token};
         });
 
         return std::async(std::launch::deferred, [this, f = std::move(f)]() mutable {
-            auto [buf, signal_value] = f.get();
-            vk::SemaphoreWaitInfo waitInfo{};
-            waitInfo.setSemaphores(_semaphore);
-            waitInfo.setValues(signal_value);
-            auto res = _device.waitSemaphores(waitInfo, 1000000000);
-            if (res != vk::Result::eSuccess) {
+            auto [buf, token] = f.get();
+            if (!cmd_ctx_->wait(token)) {
                 CASPAR_LOG(warning) << L"[Vulkan] Timeout waiting for readback semaphore";
             }
 

--- a/src/accelerator/vulkan/util/device.cpp
+++ b/src/accelerator/vulkan/util/device.cpp
@@ -22,11 +22,9 @@
 #include "device.h"
 
 #include "../image/image_kernel.h"
-#include "barrier.h"
 #include "buffer.h"
-#include "command_context.h"
-#include "completion_token.h"
 #include "texture.h"
+#include "transfer.h"
 #include "vulkan_queue.h"
 
 #include <common/array.h>
@@ -100,7 +98,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
     std::shared_ptr<vulkan_queue>      _queue;
     VmaAllocator                       _allocator;
 
-    std::unique_ptr<command_context> transfer_ctx_;
+    std::unique_ptr<class transfer> transfer_;
 
     impl()
     {
@@ -182,8 +180,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         auto graphics_family = vkb_device.get_queue_index(vkb::QueueType::graphics).value();
         _queue               = std::make_shared<vulkan_queue>(graphics_queue, graphics_family);
 
-        transfer_ctx_ = std::make_unique<command_context>(_device, _queue);
-
         VmaVulkanFunctions vulkanFunctions    = {};
         vulkanFunctions.vkGetInstanceProcAddr = _vkb_instance.fp_vkGetInstanceProcAddr;
         vulkanFunctions.vkGetDeviceProcAddr   = vkb_device.fp_vkGetDeviceProcAddr;
@@ -212,7 +208,7 @@ struct device::impl : public std::enable_shared_from_this<impl>
             for (auto& pool : pools)
                 pool.clear();
 
-        transfer_ctx_.reset();
+        transfer_.reset();
 
         vmaDestroyAllocator(_allocator);
 
@@ -319,103 +315,6 @@ struct device::impl : public std::enable_shared_from_this<impl>
         auto buf = create_buffer(size, true);
         auto ptr = reinterpret_cast<uint8_t*>(buf->data());
         return array<uint8_t>(ptr, buf->size(), std::move(buf));
-    }
-
-    // Upload (host→device). Records + submits synchronously on the caller's
-    // thread (serialized through transfer_ctx_'s record mutex and the queue mutex), and
-    // returns a ready future: no host readback, so no CPU wait — GPU consumers of
-    // the texture are ordered by the memory barriers, not by the CPU.
-    std::future<std::shared_ptr<texture>>
-    copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth)
-    {
-        std::shared_ptr<buffer> buf;
-
-        auto tmp = source.storage<std::shared_ptr<buffer>>();
-        if (tmp) {
-            buf = *tmp;
-        } else {
-            buf = create_buffer(static_cast<int>(source.size()), true);
-            std::memcpy(buf->data(), source.data(), source.size());
-        }
-
-        auto tex = create_texture(width, height, stride, depth, false);
-
-        vk::BufferImageCopy region(0,
-                                   0,
-                                   0,
-                                   vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1),
-                                   vk::Offset3D(0, 0, 0),
-                                   vk::Extent3D(width, height, 1));
-
-        transfer_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
-            transitionImageLayout(tex->id(),
-                                  vk::ImageLayout::eUndefined,
-                                  vk::AccessFlagBits2::eNone,
-                                  vk::PipelineStageFlagBits2::eTopOfPipe,
-
-                                  vk::ImageLayout::eTransferDstOptimal,
-                                  vk::AccessFlagBits2::eTransferWrite,
-                                  vk::PipelineStageFlagBits2::eTransfer,
-                                  cmd);
-
-            cmd.copyBufferToImage(buf->id(), tex->id(), vk::ImageLayout::eTransferDstOptimal, region);
-
-            transitionImageLayout(tex->id(),
-                                  vk::ImageLayout::eTransferDstOptimal,
-                                  vk::AccessFlagBits2::eTransferWrite,
-                                  vk::PipelineStageFlagBits2::eTransfer,
-
-                                  vk::ImageLayout::eShaderReadOnlyOptimal,
-                                  vk::AccessFlagBits2::eShaderRead,
-                                  vk::PipelineStageFlagBits2::eFragmentShader,
-                                  cmd);
-        });
-
-        return make_ready_future(std::move(tex));
-    }
-
-    // Readback (device→host). Records + submits synchronously on the caller's
-    // thread; the returned deferred future blocks at .get() on transfer_ctx_->wait —
-    // the one legitimate CPU wait, because the caller is consuming bytes.
-    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source)
-    {
-        auto buf = create_buffer(source->size(), false);
-
-        vk::CopyImageToBufferInfo2 copyInfo{};
-        copyInfo.dstBuffer      = buf->id();
-        copyInfo.srcImage       = source->id();
-        copyInfo.srcImageLayout = vk::ImageLayout::eTransferSrcOptimal;
-
-        vk::BufferImageCopy2 region{};
-        region.bufferOffset     = 0;
-        region.imageSubresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
-        region.imageOffset      = vk::Offset3D{0, 0, 0};
-        region.imageExtent =
-            vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
-        copyInfo.setRegions(region);
-
-        auto token = transfer_ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
-            transitionImageLayout(source->id(),
-                                  vk::ImageLayout::eRenderingLocalRead,
-                                  vk::AccessFlagBits2::eColorAttachmentWrite,
-                                  vk::PipelineStageFlagBits2::eColorAttachmentOutput,
-
-                                  vk::ImageLayout::eTransferSrcOptimal,
-                                  vk::AccessFlagBits2::eHostRead,
-                                  vk::PipelineStageFlagBits2::eHost,
-                                  cmd);
-            cmd.copyImageToBuffer2(copyInfo);
-        });
-
-        return std::async(std::launch::deferred, [this, buf = std::move(buf), token]() mutable {
-            if (!transfer_ctx_->wait(token)) {
-                CASPAR_LOG(warning) << L"[Vulkan] Timeout waiting for readback semaphore";
-            }
-
-            auto ptr  = reinterpret_cast<uint8_t*>(buf->data());
-            auto size = buf->size();
-            return array<const uint8_t>(ptr, size, std::move(buf));
-        });
     }
 
     boost::property_tree::wptree info() const
@@ -530,27 +429,23 @@ struct device::impl : public std::enable_shared_from_this<impl>
 device::device()
     : impl_(new impl())
 {
+    // Created after impl_ is set so the transfer service can build its
+    // command_context off this fully-constructed device's queue.
+    impl_->transfer_ = std::make_unique<class transfer>(*this);
 }
 device::~device() {}
 
 vk::PhysicalDeviceMemoryProperties device::getMemoryProperties() { return impl_->_memoryProperties; }
 vk::Device                         device::getVkDevice() const { return impl_->_device; }
 std::shared_ptr<vulkan_queue>      device::queue() { return impl_->_queue; }
+class transfer&                    device::transfer() { return *impl_->transfer_; }
 
 std::shared_ptr<texture> device::create_texture(int width, int height, int stride, common::bit_depth depth)
 {
     return impl_->create_texture(width, height, stride, depth, true);
 }
-array<uint8_t> device::create_array(int size) { return impl_->create_array(size); }
-std::future<std::shared_ptr<texture>>
-device::copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth)
-{
-    return impl_->copy_async(source, width, height, stride, depth);
-}
-std::future<array<const uint8_t>> device::copy_async(const std::shared_ptr<texture>& source)
-{
-    return impl_->copy_async(source);
-}
+std::shared_ptr<buffer>      device::create_buffer(int size, bool write) { return impl_->create_buffer(size, write); }
+array<uint8_t>               device::create_array(int size) { return impl_->create_array(size); }
 std::wstring                 device::version() const { return impl_->version(); }
 boost::property_tree::wptree device::info() const { return impl_->info(); }
 std::future<void>            device::gc() { return impl_->gc(); }

--- a/src/accelerator/vulkan/util/device.h
+++ b/src/accelerator/vulkan/util/device.h
@@ -26,7 +26,6 @@
 #include <common/bit_depth.h>
 #include <core/frame/geometry.h>
 
-#include <functional>
 #include <future>
 
 #include <vulkan/vulkan.hpp>
@@ -66,23 +65,6 @@ class device final
     std::future<std::shared_ptr<class texture>>
     copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth);
     std::future<array<const uint8_t>> copy_async(const std::shared_ptr<class texture>& source);
-    template <typename Func>
-    auto dispatch_async(Func&& func)
-    {
-        using result_type = decltype(func());
-        using task_type   = std::packaged_task<result_type()>;
-
-        auto task   = std::make_shared<task_type>(std::forward<Func>(func));
-        auto future = task->get_future();
-        dispatch([=] { (*task)(); });
-        return future;
-    }
-
-    template <typename Func>
-    auto dispatch_sync(Func&& func)
-    {
-        return dispatch_async(std::forward<Func>(func)).get();
-    }
 
     std::wstring version() const;
 
@@ -90,7 +72,6 @@ class device final
     std::future<void>            gc();
 
   private:
-    void dispatch(std::function<void()> func);
     struct impl;
     std::shared_ptr<impl> impl_;
 };

--- a/src/accelerator/vulkan/util/device.h
+++ b/src/accelerator/vulkan/util/device.h
@@ -53,8 +53,6 @@ class device final
     vk::Device                         getVkDevice() const;
     std::shared_ptr<vulkan_queue>      queue();
 
-    std::shared_ptr<class texture>
-    create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count);
     std::shared_ptr<class texture> create_texture(int width, int height, int stride, common::bit_depth depth);
     array<uint8_t>                 create_array(int size);
 

--- a/src/accelerator/vulkan/util/device.h
+++ b/src/accelerator/vulkan/util/device.h
@@ -36,6 +36,7 @@ struct draw_params;
 
 class image_kernel;
 class vulkan_queue;
+class transfer;
 
 class device final
     : public std::enable_shared_from_this<device>
@@ -52,13 +53,11 @@ class device final
     vk::PhysicalDeviceMemoryProperties getMemoryProperties();
     vk::Device                         getVkDevice() const;
     std::shared_ptr<vulkan_queue>      queue();
+    class transfer&                    transfer();
 
     std::shared_ptr<class texture> create_texture(int width, int height, int stride, common::bit_depth depth);
+    std::shared_ptr<class buffer>  create_buffer(int size, bool write);
     array<uint8_t>                 create_array(int size);
-
-    std::future<std::shared_ptr<class texture>>
-    copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth);
-    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<class texture>& source);
 
     std::wstring version() const;
 

--- a/src/accelerator/vulkan/util/device.h
+++ b/src/accelerator/vulkan/util/device.h
@@ -36,6 +36,7 @@ namespace caspar { namespace accelerator { namespace vulkan {
 struct draw_params;
 
 class image_kernel;
+class vulkan_queue;
 
 class device final
     : public std::enable_shared_from_this<device>
@@ -54,9 +55,8 @@ class device final
     upload_vertex_buffer(const std::vector<core::frame_geometry::coord>& coords);
 
     vk::PhysicalDeviceMemoryProperties getMemoryProperties();
-    std::vector<vk::CommandBuffer>     allocateCommandBuffers(uint32_t count);
-    void                               submit(const vk::SubmitInfo& submitInfo, vk::Fence fence);
     vk::Device                         getVkDevice() const;
+    std::shared_ptr<vulkan_queue>      queue();
 
     std::shared_ptr<class texture>
     create_attachment(int width, int height, common::bit_depth depth, uint32_t components_count);

--- a/src/accelerator/vulkan/util/device.h
+++ b/src/accelerator/vulkan/util/device.h
@@ -49,10 +49,6 @@ class device final
 
     device& operator=(const device&) = delete;
 
-    std::shared_ptr<class pipeline> get_pipeline(common::bit_depth depth);
-    std::pair<vk::Buffer, vk::DeviceMemory>
-    upload_vertex_buffer(const std::vector<core::frame_geometry::coord>& coords);
-
     vk::PhysicalDeviceMemoryProperties getMemoryProperties();
     vk::Device                         getVkDevice() const;
     std::shared_ptr<vulkan_queue>      queue();

--- a/src/accelerator/vulkan/util/pipeline.cpp
+++ b/src/accelerator/vulkan/util/pipeline.cpp
@@ -67,7 +67,6 @@ std::array<vk::VertexInputAttributeDescription, 2> get_attribute_descriptions(ui
     return attributeDescriptions;
 }
 
-const int DescriptorPoolSize = 64;
 const int BindlessTextureCount = 8;
 
 struct pipeline::impl
@@ -75,16 +74,12 @@ struct pipeline::impl
     vk::Device device_;
     vk::Format format_;
 
-    vk::Sampler                    textureSampler_;
-    vk::Sampler                    keySampler_;
-    vk::DescriptorSetLayout        descriptorSetLayout_;
-    vk::DescriptorPool             descriptorPool_;
-    std::vector<vk::DescriptorSet> descriptorSets_;
+    vk::Sampler             textureSampler_;
+    vk::Sampler             keySampler_;
+    vk::DescriptorSetLayout descriptorSetLayout_;
 
     vk::PipelineLayout pipelineLayout_;
     vk::Pipeline       pipeline_;
-
-    size_t currentDescriptorSet_ = 0;
 
     impl(const impl&)            = delete;
     impl& operator=(const impl&) = delete;
@@ -106,36 +101,25 @@ struct pipeline::impl
         backgroundLayoutBinding.stageFlags      = vk::ShaderStageFlagBits::eFragment;
 
         vk::DescriptorSetLayoutCreateInfo layoutInfo{};
-        std::array bindings{texturesLayoutBinding, backgroundLayoutBinding};
+        std::array                        bindings{texturesLayoutBinding, backgroundLayoutBinding};
         layoutInfo.setBindings(bindings);
 
-        std::array<vk::DescriptorBindingFlags, 2> bindingFlags{vk::DescriptorBindingFlagBits::ePartiallyBound,
-                                                                vk::DescriptorBindingFlags{}};
+        std::array<vk::DescriptorBindingFlags, 2>     bindingFlags{vk::DescriptorBindingFlagBits::ePartiallyBound,
+                                                               vk::DescriptorBindingFlags{}};
         vk::DescriptorSetLayoutBindingFlagsCreateInfo bindingFlagsInfo;
         bindingFlagsInfo.setBindingFlags(bindingFlags);
         layoutInfo.pNext = &bindingFlagsInfo;
 
         descriptorSetLayout_ = device_.createDescriptorSetLayout(layoutInfo);
+    }
 
-        // Create descriptor pool
-        vk::DescriptorPoolSize samplerPoolSize(vk::DescriptorType::eCombinedImageSampler, BindlessTextureCount * DescriptorPoolSize);
-        vk::DescriptorPoolSize inputAttachmentPoolSize(vk::DescriptorType::eInputAttachment, 1 * DescriptorPoolSize);
-
-        std::array poolSizes{samplerPoolSize, inputAttachmentPoolSize};
-
-        vk::DescriptorPoolCreateInfo poolInfo{};
-        poolInfo.maxSets = DescriptorPoolSize;
-
-        poolInfo.setPoolSizes(poolSizes);
-        descriptorPool_ = device_.createDescriptorPool(poolInfo);
-
-        // Allocate descriptor sets
-        std::vector<vk::DescriptorSetLayout> layouts(DescriptorPoolSize, descriptorSetLayout_);
-        vk::DescriptorSetAllocateInfo        allocInfo;
-        allocInfo.descriptorPool = descriptorPool_;
-        allocInfo.setSetLayouts(layouts);
-
-        descriptorSets_ = device_.allocateDescriptorSets(allocInfo);
+    // Per-set descriptor counts a pool must provide to allocate this pipeline's
+    // layout: the bindless texture array (binding 0) plus one input attachment
+    // (binding 1).
+    std::vector<vk::DescriptorPoolSize> descriptor_pool_sizes() const
+    {
+        return {{vk::DescriptorType::eCombinedImageSampler, BindlessTextureCount},
+                {vk::DescriptorType::eInputAttachment, 1}};
     }
 
     void setup_sampler()
@@ -264,16 +248,13 @@ struct pipeline::impl
         }
     }
 
-    vk::DescriptorSet acquire_descriptor_set(const std::array<vk::ImageView, 7>& textures)
+    void write_descriptor_set(vk::DescriptorSet descriptorSet, const std::array<vk::ImageView, 7>& textures)
     {
         // C++ textures array layout:
         //   [0] = background attachment, [1..4] = planes, [5] = local_key, [6] = layer_key
 
         // Shader bindless textures[N] layout:
         //   [0..3] = planes, [4] = local_key, [5] = layer_key
-
-        auto descriptorSet    = descriptorSets_[currentDescriptorSet_];
-        currentDescriptorSet_ = (currentDescriptorSet_ + 1) % DescriptorPoolSize;
 
         // Bind planes, local_key, and layer_key to the bindless texture array
         std::array<vk::DescriptorImageInfo, 6> textureInfos;
@@ -301,27 +282,25 @@ struct pipeline::impl
         backgroundInfo.imageView   = textures[0];
 
         vk::WriteDescriptorSet backgroundWrite{};
-        backgroundWrite.dstSet                    = descriptorSet;
-        backgroundWrite.dstBinding                = 1;
-        backgroundWrite.dstArrayElement           = 0;
-        backgroundWrite.descriptorType            = vk::DescriptorType::eInputAttachment;
+        backgroundWrite.dstSet          = descriptorSet;
+        backgroundWrite.dstBinding      = 1;
+        backgroundWrite.dstArrayElement = 0;
+        backgroundWrite.descriptorType  = vk::DescriptorType::eInputAttachment;
         backgroundWrite.setImageInfo(backgroundInfo);
 
-
-        vk::WriteDescriptorSet descriptorWrites[]{ backgroundWrite, texturesWrite };
+        vk::WriteDescriptorSet descriptorWrites[]{backgroundWrite, texturesWrite};
         device_.updateDescriptorSets(descriptorWrites, nullptr);
-
-        return descriptorSet;
     }
 
     void draw(vk::CommandBuffer                   commandBuffer,
+              vk::DescriptorSet                   descriptorSet,
               vk::Buffer                          vertexBuffer,
               uint32_t                            coords_count,
               uint32_t                            vertex_buffer_offset,
               const uniform_block&                params,
               const std::array<vk::ImageView, 7>& textures)
     {
-        auto descriptorSet = acquire_descriptor_set(textures);
+        write_descriptor_set(descriptorSet, textures);
         commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline_);
         commandBuffer.bindVertexBuffers(0, vertexBuffer, {vertex_buffer_offset});
         commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, pipelineLayout_, 0, descriptorSet, nullptr);
@@ -332,7 +311,6 @@ struct pipeline::impl
 
     ~impl()
     {
-        device_.destroyDescriptorPool(descriptorPool_);
         device_.destroyDescriptorSetLayout(descriptorSetLayout_);
         device_.destroySampler(textureSampler_);
         device_.destroySampler(keySampler_);
@@ -349,15 +327,20 @@ pipeline::pipeline(vk::Device device, vk::Format format)
 pipeline::~pipeline() {}
 
 void pipeline::draw(vk::CommandBuffer                   commandBuffer,
+                    vk::DescriptorSet                   descriptorSet,
                     vk::Buffer                          vertexBuffer,
                     uint32_t                            coords_count,
                     uint32_t                            vertex_buffer_offset,
                     const uniform_block&                params,
                     const std::array<vk::ImageView, 7>& textures)
 {
-    impl_->draw(commandBuffer, vertexBuffer, coords_count, vertex_buffer_offset, params, textures);
+    impl_->draw(commandBuffer, descriptorSet, vertexBuffer, coords_count, vertex_buffer_offset, params, textures);
 }
 
 vk::Pipeline pipeline::id() const { return impl_->pipeline_; }
+
+vk::DescriptorSetLayout pipeline::descriptor_set_layout() const { return impl_->descriptorSetLayout_; }
+
+std::vector<vk::DescriptorPoolSize> pipeline::descriptor_pool_sizes() const { return impl_->descriptor_pool_sizes(); }
 
 }}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/pipeline.h
+++ b/src/accelerator/vulkan/util/pipeline.h
@@ -22,6 +22,9 @@
 #pragma once
 
 #include "uniform_block.h"
+
+#include <vector>
+
 #include <vulkan/vulkan.hpp>
 namespace caspar { namespace accelerator { namespace vulkan {
 
@@ -47,13 +50,23 @@ class pipeline final
     pipeline(vk::Device device, vk::Format format);
     ~pipeline();
 
+    // Write `descriptorSet` (allocated by the caller for this draw) with the
+    // given textures, then bind and draw. The set must outlive GPU execution;
+    // its lifetime is owned by the caller's per-frame descriptor_pool.
     void         draw(vk::CommandBuffer                   commandBuffer,
+                      vk::DescriptorSet                   descriptorSet,
                       vk::Buffer                          vertexBuffer,
                       uint32_t                            coords_count,
                       uint32_t                            vertex_buffer_offset,
                       const uniform_block&                params,
                       const std::array<vk::ImageView, 7>& textures);
     vk::Pipeline id() const;
+
+    // The layout every per-draw descriptor set is allocated against, and the
+    // per-set descriptor counts a pool must provide for it. Together they let a
+    // descriptor_pool size itself for this pipeline.
+    vk::DescriptorSetLayout             descriptor_set_layout() const;
+    std::vector<vk::DescriptorPoolSize> descriptor_pool_sizes() const;
 
   private:
     struct impl;

--- a/src/accelerator/vulkan/util/renderpass.cpp
+++ b/src/accelerator/vulkan/util/renderpass.cpp
@@ -77,11 +77,10 @@ void renderpass::draw(const draw_params& params)
         return;
     }
 
-    std::array<vk::ImageView, 7> textures = {attachment->view(),
-                                             nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    std::array<vk::ImageView, 7> textures = {attachment->view(), nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
     for (int n = 0; n < params.textures.size(); ++n) {
-        textures[1+n] = params.textures[n]->view();
+        textures[1 + n] = params.textures[n]->view();
     }
     if (params.local_key) {
         textures[5] = params.local_key->view();
@@ -104,115 +103,112 @@ void renderpass::commit()
 {
     auto vertex_buffer = upload_vertex_buffers();
 
-    auto cmd_buffer = _ctx->get_command_buffer();
-    cmd_buffer.begin(vk::CommandBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+    _ctx->record_and_submit([&](vk::CommandBuffer cmd_buffer) {
+        vk::ClearValue clearColor{vk::ClearColorValue(std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f})};
 
-    vk::ClearValue clearColor{vk::ClearColorValue(std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f})};
+        // Viewport and scissor
+        vk::Viewport viewport{0.0f, 0.0f, static_cast<float>(_width), static_cast<float>(_height), 0.0f, 1.0f};
 
-    // Viewport and scissor
-    vk::Viewport viewport{0.0f, 0.0f, static_cast<float>(_width), static_cast<float>(_height), 0.0f, 1.0f};
+        vk::Extent2D extent = {_width, _height};
+        vk::Rect2D   scissor{{0, 0}, extent};
 
-    vk::Extent2D extent = {_width, _height};
-    vk::Rect2D   scissor{{0, 0}, extent};
+        if (layers_.empty()) {
+            // No layers, just clear the default attachment
+            vk::RenderingAttachmentInfo attachment_info{};
+            attachment_info.imageView   = _default_attachment->view();
+            attachment_info.imageLayout = vk::ImageLayout::eRenderingLocalRead;
+            attachment_info.loadOp      = vk::AttachmentLoadOp::eClear;
+            attachment_info.storeOp     = vk::AttachmentStoreOp::eStore;
 
-    if (layers_.empty()) {
-        // No layers, just clear the default attachment
-        vk::RenderingAttachmentInfo attachment_info{};
-        attachment_info.imageView   = _default_attachment->view();
-        attachment_info.imageLayout = vk::ImageLayout::eRenderingLocalRead;
-        attachment_info.loadOp      = vk::AttachmentLoadOp::eClear;
-        attachment_info.storeOp     = vk::AttachmentStoreOp::eStore;
+            vk::RenderingInfo rendering_info{};
+            rendering_info.renderArea = scissor;
+            rendering_info.layerCount = 1;
+            rendering_info.setColorAttachments(attachment_info);
 
-        vk::RenderingInfo rendering_info{};
-        rendering_info.renderArea = scissor;
-        rendering_info.layerCount = 1;
-        rendering_info.setColorAttachments(attachment_info);
+            cmd_buffer.beginRendering(rendering_info);
+            cmd_buffer.setViewport(0, viewport);
+            cmd_buffer.setScissor(0, scissor);
+        } else {
+            // create a renderpass for each layer
+            bool                     default_cleared = false;
+            std::shared_ptr<texture> previous_attachment;
+            for (auto& layer : layers_) {
+                if (layer.attachment != previous_attachment) {
+                    // We need to start a new render pass
 
-        cmd_buffer.beginRendering(rendering_info);
-        cmd_buffer.setViewport(0, viewport);
-        cmd_buffer.setScissor(0, scissor);
-    } else {
-        // create a renderpass for each layer
-        bool                     default_cleared = false;
-        std::shared_ptr<texture> previous_attachment;
-        for (auto& layer : layers_) {
-            if (layer.attachment != previous_attachment) {
-                // We need to start a new render pass
+                    if (previous_attachment) {
+                        // If this is not the first pass, end the previous render pass
+                        cmd_buffer.endRendering();
 
-                if (previous_attachment) {
-                    // If this is not the first pass, end the previous render pass
-                    cmd_buffer.endRendering();
+                        if (previous_attachment != _default_attachment) {
+                            // If we're done with a non-default attachment, we need to transition it to a shader read
+                            // layout
+                            vk::ImageMemoryBarrier2 memoryBarrier{};
+                            auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
+                            memoryBarrier.subresourceRange = range;
+                            memoryBarrier.srcStageMask     = vk::PipelineStageFlagBits2::eColorAttachmentOutput;
+                            memoryBarrier.srcAccessMask    = vk::AccessFlagBits2::eColorAttachmentWrite;
+                            memoryBarrier.dstStageMask     = vk::PipelineStageFlagBits2::eFragmentShader;
+                            memoryBarrier.dstAccessMask    = vk::AccessFlagBits2::eInputAttachmentRead;
+                            memoryBarrier.oldLayout        = vk::ImageLayout::eRenderingLocalRead;
+                            memoryBarrier.newLayout        = vk::ImageLayout::eShaderReadOnlyOptimal;
+                            memoryBarrier.image            = previous_attachment->id();
 
-                    if (previous_attachment != _default_attachment) {
-                        // If we're done with a non-default attachment, we need to transition it to a shader read layout
-                        vk::ImageMemoryBarrier2 memoryBarrier{};
-                        auto range = vk::ImageSubresourceRange(vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1);
-                        memoryBarrier.subresourceRange = range;
-                        memoryBarrier.srcStageMask     = vk::PipelineStageFlagBits2::eColorAttachmentOutput;
-                        memoryBarrier.srcAccessMask    = vk::AccessFlagBits2::eColorAttachmentWrite;
-                        memoryBarrier.dstStageMask     = vk::PipelineStageFlagBits2::eFragmentShader;
-                        memoryBarrier.dstAccessMask    = vk::AccessFlagBits2::eInputAttachmentRead;
-                        memoryBarrier.oldLayout        = vk::ImageLayout::eRenderingLocalRead;
-                        memoryBarrier.newLayout        = vk::ImageLayout::eShaderReadOnlyOptimal;
-                        memoryBarrier.image            = previous_attachment->id();
-
-                        vk::DependencyInfo dependencyInfo{};
-                        dependencyInfo.setImageMemoryBarriers(memoryBarrier);
-                        cmd_buffer.pipelineBarrier2(dependencyInfo);
+                            vk::DependencyInfo dependencyInfo{};
+                            dependencyInfo.setImageMemoryBarriers(memoryBarrier);
+                            cmd_buffer.pipelineBarrier2(dependencyInfo);
+                        }
                     }
+
+                    // We only want to clear the default attachment once
+                    bool do_clear = (layer.attachment != _default_attachment) || !default_cleared;
+
+                    vk::RenderingAttachmentInfo attachment_info{};
+                    attachment_info.imageView   = layer.attachment->view();
+                    attachment_info.imageLayout = vk::ImageLayout::eRenderingLocalRead;
+                    attachment_info.loadOp      = do_clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad;
+                    attachment_info.storeOp     = vk::AttachmentStoreOp::eStore;
+
+                    if (layer.attachment == _default_attachment) {
+                        default_cleared = true;
+                    }
+
+                    previous_attachment = layer.attachment;
+
+                    vk::RenderingInfo rendering_info{};
+                    rendering_info.renderArea = scissor;
+                    rendering_info.layerCount = 1;
+                    rendering_info.setColorAttachments(attachment_info);
+
+                    cmd_buffer.beginRendering(rendering_info);
+                    cmd_buffer.setViewport(0, viewport);
+                    cmd_buffer.setScissor(0, scissor);
+                } else {
+                    // We are continuing in the same render pass, so we need a barrier to ensure the attachment is ready
+                    vk::MemoryBarrier2 memoryBarrier{};
+                    memoryBarrier.srcStageMask  = vk::PipelineStageFlagBits2::eColorAttachmentOutput;
+                    memoryBarrier.srcAccessMask = vk::AccessFlagBits2::eColorAttachmentWrite;
+                    memoryBarrier.dstStageMask  = vk::PipelineStageFlagBits2::eFragmentShader;
+                    memoryBarrier.dstAccessMask = vk::AccessFlagBits2::eInputAttachmentRead;
+
+                    vk::DependencyInfo dependencyInfo{};
+                    dependencyInfo.dependencyFlags    = vk::DependencyFlagBits::eByRegion;
+                    dependencyInfo.memoryBarrierCount = 1;
+                    dependencyInfo.pMemoryBarriers    = &memoryBarrier;
+                    cmd_buffer.pipelineBarrier2(dependencyInfo);
                 }
 
-                // We only want to clear the default attachment once
-                bool do_clear = (layer.attachment != _default_attachment) || !default_cleared;
-
-                vk::RenderingAttachmentInfo attachment_info{};
-                attachment_info.imageView   = layer.attachment->view();
-                attachment_info.imageLayout = vk::ImageLayout::eRenderingLocalRead;
-                attachment_info.loadOp      = do_clear ? vk::AttachmentLoadOp::eClear : vk::AttachmentLoadOp::eLoad;
-                attachment_info.storeOp     = vk::AttachmentStoreOp::eStore;
-
-                if (layer.attachment == _default_attachment) {
-                    default_cleared = true;
-                }
-
-                previous_attachment = layer.attachment;
-
-                vk::RenderingInfo rendering_info{};
-                rendering_info.renderArea = scissor;
-                rendering_info.layerCount = 1;
-                rendering_info.setColorAttachments(attachment_info);
-
-                cmd_buffer.beginRendering(rendering_info);
-                cmd_buffer.setViewport(0, viewport);
-                cmd_buffer.setScissor(0, scissor);
-            } else {
-                // We are continuing in the same render pass, so we need a barrier to ensure the attachment is ready
-                vk::MemoryBarrier2 memoryBarrier{};
-                memoryBarrier.srcStageMask  = vk::PipelineStageFlagBits2::eColorAttachmentOutput;
-                memoryBarrier.srcAccessMask = vk::AccessFlagBits2::eColorAttachmentWrite;
-                memoryBarrier.dstStageMask  = vk::PipelineStageFlagBits2::eFragmentShader;
-                memoryBarrier.dstAccessMask = vk::AccessFlagBits2::eInputAttachmentRead;
-
-                vk::DependencyInfo dependencyInfo{};
-                dependencyInfo.dependencyFlags    = vk::DependencyFlagBits::eByRegion;
-                dependencyInfo.memoryBarrierCount = 1;
-                dependencyInfo.pMemoryBarriers    = &memoryBarrier;
-                cmd_buffer.pipelineBarrier2(dependencyInfo);
+                _pipeline->draw(cmd_buffer,
+                                vertex_buffer,
+                                static_cast<uint32_t>(layer.coords.size()),
+                                layer.vertex_buffer_offset,
+                                layer.uniforms,
+                                layer.textures);
             }
-
-            _pipeline->draw(cmd_buffer,
-                            vertex_buffer,
-                            static_cast<uint32_t>(layer.coords.size()),
-                            layer.vertex_buffer_offset,
-                            layer.uniforms,
-                            layer.textures);
         }
-    }
 
-    cmd_buffer.endRendering();
-    cmd_buffer.end();
-
-    _ctx->submit();
+        cmd_buffer.endRendering();
+    });
 }
 
 }}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/renderpass.cpp
+++ b/src/accelerator/vulkan/util/renderpass.cpp
@@ -103,6 +103,9 @@ void renderpass::commit()
 {
     auto vertex_buffer = upload_vertex_buffers();
 
+    // One descriptor set per layer (= per draw), sized to this exact frame.
+    auto descriptor_sets = _ctx->allocate_descriptor_sets(static_cast<uint32_t>(layers_.size()));
+
     _ctx->record_and_submit([&](vk::CommandBuffer cmd_buffer) {
         vk::ClearValue clearColor{vk::ClearColorValue(std::array<float, 4>{0.0f, 0.0f, 0.0f, 0.0f})};
 
@@ -132,6 +135,7 @@ void renderpass::commit()
             // create a renderpass for each layer
             bool                     default_cleared = false;
             std::shared_ptr<texture> previous_attachment;
+            size_t                   draw_index = 0;
             for (auto& layer : layers_) {
                 if (layer.attachment != previous_attachment) {
                     // We need to start a new render pass
@@ -199,6 +203,7 @@ void renderpass::commit()
                 }
 
                 _pipeline->draw(cmd_buffer,
+                                descriptor_sets[draw_index++],
                                 vertex_buffer,
                                 static_cast<uint32_t>(layer.coords.size()),
                                 layer.vertex_buffer_offset,

--- a/src/accelerator/vulkan/util/renderpass.h
+++ b/src/accelerator/vulkan/util/renderpass.h
@@ -40,6 +40,9 @@ struct frame_context
     virtual vk::Buffer                      upload_vertex_data(const std::vector<float>& data) = 0;
     virtual draw_data                       create_draw_data(const draw_params& params)        = 0;
     virtual std::shared_ptr<class pipeline> get_pipeline()                                     = 0;
+    // Allocate `count` fresh descriptor sets (one per layer) for this frame from
+    // the frame slot's descriptor_pool; valid until the slot is reused.
+    virtual std::vector<vk::DescriptorSet> allocate_descriptor_sets(uint32_t count) = 0;
     // Record the renderpass body into a fresh command buffer and submit it; the
     // buffer's begin/end and the submit are owned by the implementation (a
     // command_context). The recorded function must not begin/end the buffer.

--- a/src/accelerator/vulkan/util/renderpass.h
+++ b/src/accelerator/vulkan/util/renderpass.h
@@ -23,6 +23,7 @@
 
 #include <common/bit_depth.h>
 #include <common/memory.h>
+#include <functional>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <vector>
@@ -39,8 +40,10 @@ struct frame_context
     virtual vk::Buffer                      upload_vertex_data(const std::vector<float>& data) = 0;
     virtual draw_data                       create_draw_data(const draw_params& params)        = 0;
     virtual std::shared_ptr<class pipeline> get_pipeline()                                     = 0;
-    virtual vk::CommandBuffer               get_command_buffer()                               = 0;
-    virtual void                            submit()                                           = 0;
+    // Record the renderpass body into a fresh command buffer and submit it; the
+    // buffer's begin/end and the submit are owned by the implementation (a
+    // command_context). The recorded function must not begin/end the buffer.
+    virtual void record_and_submit(const std::function<void(vk::CommandBuffer)>& record) = 0;
     virtual std::shared_ptr<class texture>
     create_attachment(uint32_t width, uint32_t height, uint32_t components_count) = 0;
 };

--- a/src/accelerator/vulkan/util/transfer.cpp
+++ b/src/accelerator/vulkan/util/transfer.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#include "transfer.h"
+
+#include "barrier.h"
+#include "buffer.h"
+#include "command_context.h"
+#include "device.h"
+#include "texture.h"
+
+#include <common/future.h>
+#include <common/log.h>
+
+#include <cstring>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+transfer::transfer(device& device)
+    : device_(device)
+    , ctx_(std::make_unique<command_context>(device.getVkDevice(), device.queue()))
+{
+}
+
+transfer::~transfer() {}
+
+std::future<std::shared_ptr<texture>>
+transfer::copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth)
+{
+    std::shared_ptr<buffer> buf;
+
+    auto tmp = source.storage<std::shared_ptr<buffer>>();
+    if (tmp) {
+        buf = *tmp;
+    } else {
+        buf = device_.create_buffer(static_cast<int>(source.size()), true);
+        std::memcpy(buf->data(), source.data(), source.size());
+    }
+
+    auto tex = device_.create_texture(width, height, stride, depth);
+
+    vk::BufferImageCopy region(0,
+                               0,
+                               0,
+                               vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1),
+                               vk::Offset3D(0, 0, 0),
+                               vk::Extent3D(width, height, 1));
+
+    ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+        transitionImageLayout(tex->id(),
+                              vk::ImageLayout::eUndefined,
+                              vk::AccessFlagBits2::eNone,
+                              vk::PipelineStageFlagBits2::eTopOfPipe,
+
+                              vk::ImageLayout::eTransferDstOptimal,
+                              vk::AccessFlagBits2::eTransferWrite,
+                              vk::PipelineStageFlagBits2::eTransfer,
+                              cmd);
+
+        cmd.copyBufferToImage(buf->id(), tex->id(), vk::ImageLayout::eTransferDstOptimal, region);
+
+        transitionImageLayout(tex->id(),
+                              vk::ImageLayout::eTransferDstOptimal,
+                              vk::AccessFlagBits2::eTransferWrite,
+                              vk::PipelineStageFlagBits2::eTransfer,
+
+                              vk::ImageLayout::eShaderReadOnlyOptimal,
+                              vk::AccessFlagBits2::eShaderRead,
+                              vk::PipelineStageFlagBits2::eFragmentShader,
+                              cmd);
+    });
+
+    return make_ready_future(std::move(tex));
+}
+
+std::future<array<const uint8_t>> transfer::copy_async(const std::shared_ptr<texture>& source)
+{
+    auto buf = device_.create_buffer(source->size(), false);
+
+    vk::CopyImageToBufferInfo2 copyInfo{};
+    copyInfo.dstBuffer      = buf->id();
+    copyInfo.srcImage       = source->id();
+    copyInfo.srcImageLayout = vk::ImageLayout::eTransferSrcOptimal;
+
+    vk::BufferImageCopy2 region{};
+    region.bufferOffset     = 0;
+    region.imageSubresource = vk::ImageSubresourceLayers(vk::ImageAspectFlagBits::eColor, 0, 0, 1);
+    region.imageOffset      = vk::Offset3D{0, 0, 0};
+    region.imageExtent =
+        vk::Extent3D{static_cast<uint32_t>(source->width()), static_cast<uint32_t>(source->height()), 1};
+    copyInfo.setRegions(region);
+
+    auto token = ctx_->record_and_submit([&](vk::CommandBuffer cmd) {
+        transitionImageLayout(source->id(),
+                              vk::ImageLayout::eRenderingLocalRead,
+                              vk::AccessFlagBits2::eColorAttachmentWrite,
+                              vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+
+                              vk::ImageLayout::eTransferSrcOptimal,
+                              vk::AccessFlagBits2::eHostRead,
+                              vk::PipelineStageFlagBits2::eHost,
+                              cmd);
+        cmd.copyImageToBuffer2(copyInfo);
+    });
+
+    return std::async(std::launch::deferred, [this, buf = std::move(buf), token]() mutable {
+        if (!ctx_->wait(token)) {
+            CASPAR_LOG(warning) << L"[Vulkan] Timeout waiting for readback semaphore";
+        }
+
+        auto ptr  = reinterpret_cast<uint8_t*>(buf->data());
+        auto size = buf->size();
+        return array<const uint8_t>(ptr, size, std::move(buf));
+    });
+}
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/transfer.h
+++ b/src/accelerator/vulkan/util/transfer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include <common/array.h>
+#include <common/bit_depth.h>
+
+#include <future>
+#include <memory>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+class device;
+class texture;
+class command_context;
+
+// The shared host<->device copy service: one instance per device, used by every
+// channel's image_mixer for plane uploads (h->d) and the final frame readback
+// (d->h). It records onto its own command_context — whose record mutex serializes
+// the many channel threads hitting it — and submits on the device's shared queue;
+// allocation of the staging buffers and destination textures is delegated back to
+// the device's pools. The CPU blocks only on readback (.get()), never on upload.
+class transfer final
+{
+  public:
+    explicit transfer(device& device);
+    ~transfer();
+
+    transfer(const transfer&)            = delete;
+    transfer& operator=(const transfer&) = delete;
+
+    // Upload (h->d). Records + submits synchronously on the caller's thread and
+    // returns a ready future: no host readback, so no CPU wait — GPU consumers of
+    // the texture are ordered by the memory barriers, not by the CPU.
+    std::future<std::shared_ptr<texture>>
+    copy_async(const array<const uint8_t>& source, int width, int height, int stride, common::bit_depth depth);
+
+    // Readback (d->h). Records + submits synchronously; the returned deferred
+    // future blocks at .get() on the completion wait — the one legitimate CPU
+    // wait, because the caller is consuming bytes.
+    std::future<array<const uint8_t>> copy_async(const std::shared_ptr<texture>& source);
+
+  private:
+    device&                          device_;
+    std::unique_ptr<command_context> ctx_;
+};
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/vulkan_queue.cpp
+++ b/src/accelerator/vulkan/util/vulkan_queue.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#include "vulkan_queue.h"
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+vulkan_queue::vulkan_queue(vk::Queue queue, uint32_t family_index)
+    : queue_(queue)
+    , family_index_(family_index)
+{
+}
+
+void vulkan_queue::submit(const vk::ArrayProxy<const vk::SubmitInfo>& submits, vk::Fence fence)
+{
+    queue_.submit(submits, fence);
+}
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/vulkan_queue.cpp
+++ b/src/accelerator/vulkan/util/vulkan_queue.cpp
@@ -31,6 +31,7 @@ vulkan_queue::vulkan_queue(vk::Queue queue, uint32_t family_index)
 
 void vulkan_queue::submit(const vk::ArrayProxy<const vk::SubmitInfo>& submits, vk::Fence fence)
 {
+    std::lock_guard<std::mutex> lock(mutex_);
     queue_.submit(submits, fence);
 }
 

--- a/src/accelerator/vulkan/util/vulkan_queue.h
+++ b/src/accelerator/vulkan/util/vulkan_queue.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Niklas Andersson, niklas@niklaspandersson.se
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <vulkan/vulkan.hpp>
+
+namespace caspar { namespace accelerator { namespace vulkan {
+
+// A single VkQueue together with the family it was created from. Mirrors
+// vk::Queue::submit so call sites stop passing raw handles around. Single
+// queue, single thread for now: no internal synchronization.
+class vulkan_queue final
+{
+  public:
+    vulkan_queue(vk::Queue queue, uint32_t family_index);
+
+    vulkan_queue(const vulkan_queue&)            = delete;
+    vulkan_queue& operator=(const vulkan_queue&) = delete;
+
+    void submit(const vk::ArrayProxy<const vk::SubmitInfo>& submits, vk::Fence fence = {});
+
+    uint32_t family_index() const { return family_index_; }
+
+    // The raw queue handle, for submitters that need vkQueueSubmit2 (binary +
+    // timeline semaphore mix) or vkQueuePresentKHR, which submit() does not wrap.
+    vk::Queue vk_queue() const { return queue_; }
+
+  private:
+    vk::Queue queue_;
+    uint32_t  family_index_;
+};
+
+}}} // namespace caspar::accelerator::vulkan

--- a/src/accelerator/vulkan/util/vulkan_queue.h
+++ b/src/accelerator/vulkan/util/vulkan_queue.h
@@ -22,14 +22,21 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 
 #include <vulkan/vulkan.hpp>
 
 namespace caspar { namespace accelerator { namespace vulkan {
 
 // A single VkQueue together with the family it was created from. Mirrors
-// vk::Queue::submit so call sites stop passing raw handles around. Single
-// queue, single thread for now: no internal synchronization.
+// vk::Queue::submit so call sites stop passing raw handles around.
+//
+// Internally synchronized: vkQueueSubmit requires external synchronization of
+// the VkQueue, and this one queue is shared by every submitter (the transfer
+// command_context and the render ring, across all channel threads). submit()
+// holds a mutex so those submits serialize. This is the queue's own lock; the
+// transfer command_context guards its own pool/ring with a separate lock (see
+// command_context).
 class vulkan_queue final
 {
   public:
@@ -44,11 +51,17 @@ class vulkan_queue final
 
     // The raw queue handle, for submitters that need vkQueueSubmit2 (binary +
     // timeline semaphore mix) or vkQueuePresentKHR, which submit() does not wrap.
+    // Such callers must hold scoped_lock() to honour the queue's external sync.
     vk::Queue vk_queue() const { return queue_; }
 
+    // Hold this while submitting through vk_queue() directly, so those submits
+    // serialize against the ones going through submit().
+    std::unique_lock<std::mutex> scoped_lock() { return std::unique_lock<std::mutex>(mutex_); }
+
   private:
-    vk::Queue queue_;
-    uint32_t  family_index_;
+    vk::Queue  queue_;
+    uint32_t   family_index_;
+    std::mutex mutex_;
 };
 
 }}} // namespace caspar::accelerator::vulkan


### PR DESCRIPTION
This is the first in a series of Vulkan related PRs intended to make the Vulkan accelerator genuinely useful and the preferred accelerator. All of which are complete, but needs separate PRs

The phases are roughly the following:
1. (this pr): vulkan accelerator Internal improvements and restructuring (no code changes outside of the vulkan namespace)
    The intent of this work is to move away from the old opengl abstractions to a structure more native to vulkan, and also to more cleanly separate the various internal components
2. The next PR is a single commit that gives consumers the option to indicate whether they need a copy of the frame on the host or not, allowing image mixers to completely skip the gpu-to-host copy if no consumers ever read the frame on host
3. Adds a Vulkan native screen consumer implementation that consumes GPU frames
4. macOS support
5. FFmpeg hardware decoding using Vulkan video, nvdec (where available) and/or videotoolbox (on macos) with zero host roundtrips. Including plumbing for exposing the vulkan accelerator to other modules and for producer to generate frames that resides the gpu