### PR TITLE
fix(gl): rate-limit the OpenGL error log so a GL fault cannot fill the disk

### DIFF
--- a/src/common/gl/gl_check.cpp
+++ b/src/common/gl/gl_check.cpp
@@ -28,7 +28,44 @@
 
 #include <GL/glew.h>
 
+#include <chrono>
+#include <cstddef>
+#include <mutex>
+
 namespace caspar { namespace gl {
+
+// GL() wraps nearly every GL call, so one invalid context makes this log grow at the frame rate.
+static constexpr auto        error_log_window = std::chrono::seconds(1);
+static constexpr std::size_t error_log_burst  = 4;
+
+static std::mutex                            g_error_log_mutex;
+static std::chrono::steady_clock::time_point g_error_log_window_start;
+static bool                                  g_error_log_window_open = false;
+static std::size_t                           g_error_log_logged      = 0;
+static std::size_t                           g_error_log_suppressed  = 0;
+
+static bool claim_error_log_slot(std::size_t& suppressed_before)
+{
+    const auto now = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(g_error_log_mutex);
+
+    if (!g_error_log_window_open || now - g_error_log_window_start >= error_log_window) {
+        g_error_log_window_open  = true;
+        g_error_log_window_start = now;
+        g_error_log_logged       = 0;
+        suppressed_before        = g_error_log_suppressed;
+        g_error_log_suppressed   = 0;
+    }
+
+    if (g_error_log_logged < error_log_burst) {
+        ++g_error_log_logged;
+        return true;
+    }
+
+    ++g_error_log_suppressed;
+    return false;
+}
 
 void SMFL_GLCheckError(const std::string& /*unused*/, const char* func, const char* file, unsigned int line)
 {
@@ -36,8 +73,14 @@ void SMFL_GLCheckError(const std::string& /*unused*/, const char* func, const ch
     GLenum LastErrorCode = GL_NO_ERROR;
 
     for (GLenum ErrorCode = glGetError(); ErrorCode != GL_NO_ERROR; ErrorCode = glGetError()) {
-        std::string str(reinterpret_cast<const char*>(glewGetErrorString(ErrorCode)));
-        CASPAR_LOG(error) << "OpenGL Error: " << ErrorCode << L" " << str;
+        std::size_t suppressed = 0;
+        if (claim_error_log_slot(suppressed)) {
+            if (suppressed > 0) {
+                CASPAR_LOG(error) << "OpenGL Error: " << suppressed << " further errors were not logged.";
+            }
+            std::string str(reinterpret_cast<const char*>(glewGetErrorString(ErrorCode)));
+            CASPAR_LOG(error) << "OpenGL Error: " << ErrorCode << L" " << str;
+        }
         LastErrorCode = ErrorCode;
     }
 


### PR DESCRIPTION
`SMFL_GLCheckError()` logs every failing GL call unconditionally — no cap, no dedup, no rate
limit — and `GL()` wraps nearly every GL call in the codebase. Once a context is lost or
invalid, every call fails every frame, so the log grows at the rate the server renders.

Measured on a 1080i5000 production machine after a screen consumer failed to initialise and
left its channel's context dead: **6,498,290 `OpenGL Error: 1282` lines, 434 MB, in 5 min
30 s** — about 20,000 lines a second. Two control clients on the same box were killed by
Windows as unresponsive (`AppHangB1`) and the channel went off air. The graphics fault did not
require an outage; the logging is what turned it into one.

This is the guard @ronag asked for in #878 (*"We should probably also fix the error
tailspin"*) — the root cause there was fixed and the issue closed, the tailspin was not, and
it still carries `feedback/pull request wanted`. Same consequence reported in that thread from
an unrelated trigger: *"goes indeed into an opengl error tailspin which exhausts memory in no
time"*.

### The change

At most 4 lines per second, then a count of what was dropped — ~5 lines/s instead of 20,000,
still naming the error code. The lock is taken only once `glGetError()` has actually reported
an error, so the no-error path is unchanged, and the exception behaviour is untouched.

Counting verified directly: 100,000 errors in one window → 4 logged; 99,996 reported exactly
once on rollover; 8 threads × 20,000 concurrently → 4 grants total.

### What it does not change

The rate of the failing GL calls, or the exception thrown for each (#1757 covers part of that
cost on Windows). If a storm stops abruptly the final suppression count is not printed, since
it is reported on the first error after the window rolls over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
