### PR TITLE
fix(screen): serialise GL context setup against teardown, and survive a failed setup

### DIFF
--- a/src/modules/screen/consumer/screen_consumer.cpp
+++ b/src/modules/screen/consumer/screen_consumer.cpp
@@ -47,8 +47,8 @@
 
 #include <tbb/concurrent_queue.h>
 
+#include <mutex>
 #include <thread>
-#include <tuple> // std::ignore
 #include <utility>
 #include <vector>
 
@@ -63,6 +63,9 @@
 #include <accelerator/ogl/util/shader.h>
 
 namespace caspar { namespace screen {
+
+// glewInit() rewrites a process-global table and needs a current context, so setup must not overlap a teardown.
+static std::mutex g_gl_lifetime_mutex;
 
 std::unique_ptr<accelerator::ogl::shader> get_shader()
 {
@@ -162,8 +165,8 @@ struct screen_consumer
     tbb::concurrent_bounded_queue<core::const_frame> frame_buffer_;
 
     std::unique_ptr<accelerator::ogl::shader> shader_;
-    GLuint                                    vao_;
-    GLuint                                    vbo_;
+    GLuint                                    vao_ = 0;
+    GLuint                                    vbo_ = 0;
 
     std::atomic<bool> is_running_{true};
     std::thread       thread_;
@@ -258,7 +261,9 @@ struct screen_consumer
         }
 
         thread_ = std::thread([this] {
+            bool gl_ready = false;
             try {
+                std::unique_lock<std::mutex> gl_lifetime_lock(g_gl_lifetime_mutex);
 #if SFML_VERSION_MAJOR >= 3
                 sf::VideoMode mode{sf::Vector2u(config_.sbs_key ? screen_width_ * 2 : screen_width_, screen_height_),
                                    sf::VideoMode::getDesktopMode().bitsPerPixel};
@@ -285,7 +290,10 @@ struct screen_consumer
 #endif
                 window_.setPosition(sf::Vector2i(screen_x_, screen_y_));
                 window_.setMouseCursorVisible(config_.interactive);
-                std::ignore = window_.setActive(true);
+                if (!window_.setActive(true)) {
+                    CASPAR_THROW_EXCEPTION(gl::ogl_exception()
+                                           << msg_info("Failed to make the OpenGL context current."));
+                }
 
                 if (config_.always_on_top) {
 #ifdef _MSC_VER
@@ -296,8 +304,11 @@ struct screen_consumer
 #endif
                 }
 
-                if (glewInit() != GLEW_OK) {
-                    CASPAR_THROW_EXCEPTION(gl::ogl_exception() << msg_info("Failed to initialize GLEW."));
+                if (const auto err = glewInit(); err != GLEW_OK) {
+                    CASPAR_THROW_EXCEPTION(gl::ogl_exception()
+                                           << msg_info(std::string("Failed to initialize GLEW (") +
+                                                       std::to_string(static_cast<int>(err)) + "): " +
+                                                       reinterpret_cast<const char*>(glewGetErrorString(err))));
                 }
 
                 if (!GLEW_VERSION_4_5 && (glewIsSupported("GL_ARB_sync GL_ARB_shader_objects GL_ARB_multitexture "
@@ -306,6 +317,8 @@ struct screen_consumer
                                                "Your graphics card does not meet the minimum hardware requirements "
                                                "since it does not support OpenGL 4.5 or higher."));
                 }
+
+                gl_ready = true;
 
                 GL(glGenVertexArrays(1, &vao_));
                 GL(glGenBuffers(1, &vbo_));
@@ -345,6 +358,8 @@ struct screen_consumer
                 glClear(GL_COLOR_BUFFER_BIT);
                 window_.display();
 
+                gl_lifetime_lock.unlock();
+
                 while (is_running_) {
                     tick();
                 }
@@ -355,13 +370,17 @@ struct screen_consumer
                 is_running_ = false;
             }
 
-            for (auto frame : frames_) {
-                strategy_->cleanup_frame(frame);
-            }
+            std::lock_guard<std::mutex> gl_lifetime_lock(g_gl_lifetime_mutex);
 
-            shader_.reset();
-            GL(glDeleteVertexArrays(1, &vao_));
-            GL(glDeleteBuffers(1, &vbo_));
+            if (gl_ready) {
+                for (auto frame : frames_) {
+                    strategy_->cleanup_frame(frame);
+                }
+
+                shader_.reset();
+                GL(glDeleteVertexArrays(1, &vao_));
+                GL(glDeleteBuffers(1, &vbo_));
+            }
 
             window_.close();
         });


### PR DESCRIPTION
Each screen consumer runs its GL setup on its own thread — create window, make the context
current, `glewInit()`, allocate GL objects — and the matching teardown (delete GL objects,
close window) at the end of that same thread body, i.e. on the thread of whichever consumer is
being destroyed. Nothing orders the two against each other, and both touch process-global
state:

- GLEW 2.2.0 has no `GLEW_MX`; there is one function-pointer table per process and
  `glewInit()` rewrites it.
- `glewInit()` needs a context current on the calling thread — it fails with
  `GLEW_ERROR_NO_GL_VERSION` if `glGetString(GL_VERSION)` returns null.
- SFML serialises its *own* context create/destroy under a global mutex (with the comment about
  drivers and "no operating system context or pixel format operations simultaneously").
  `glewInit()` and CasparCG's GL object setup/teardown sit outside it.

### What happened

On a 1080i5000 production channel, 46 ms after a screen consumer initialised and 1 ms before it
was torn down:

```
screen_consumer.cpp: Throw in caspar::screen::screen_consumer{ctor}
boost::wrapexcept<caspar::gl::ogl_exception>
[caspar::tag_msg_info] = Failed to initialize GLEW.
```

The channel's context was dead afterwards and every GL call returned `GL_INVALID_OPERATION`
(that flood is #1785). It also happened on an official Actions build, not only a locally built
one.

The trigger is a client replacing a preview consumer on a fill/key toggle, sending the remove
and the add in one write:

```
remove 1-20 SCREEN
ADD 1-20 SCREEN borderless key_only
```

Driving that in a loop against a fresh server and watching for the log to grow:

| pattern | cycles/run | runs | failed |
| :-- | --: | --: | :-- |
| `remove` + `ADD` in one write, mixed with bare `ADD` | 400 | 4 | **2** — at cycle 165 and 50 |
| `remove` + `ADD` in one write | 500 | 2 | **1** — at cycle 110 |
| bare `ADD` onto an occupied layer | 500 | 2 | 0 |
| `REMOVE`, wait 150 / 500 / 1500 ms, then `ADD` | 400 / 400 / 250 | 3 | 0 |

Every pattern genuinely churned consumers — the 500-cycle rows each logged 500 `Initialized`
and 499 `Uninitialized` — so the clean rows are not a no-op. Intermittent, as a race should be.

A client-side delay is not a fix: `REMOVE` returns `202 REMOVE OK` before the consumer is gone,
`INFO` does not list consumers, and measured `REMOVE` → `Uninitialized` reached 2075 ms on a
loaded machine.

### The change

A process-wide mutex spans the setup block and the teardown block. It is taken only on the
consumer's own render thread and released before the render loop, so it never overlaps
`thread_.join()` and cannot deadlock against the destructor. Consumer startup and shutdown no
longer overlap; neither is on the frame path.

Both racing parties here are screen consumers — the OpenGL device's own `glewInit()` runs once
at startup and is not covered. Happy to extend it to one shared lock if you prefer.

Three smaller things on the same failure path, fixed here too:

- Teardown ran unconditionally, so after a failed `glewInit()` it called
  `glDeleteVertexArrays`/`glDeleteBuffers` with `vao_`/`vbo_` uninitialised — and, had that been
  the process's first `glewInit()`, through null function pointers. Now skipped unless setup got
  far enough to own the objects, and both names are initialised.
- `window_.setActive(true)`'s result was discarded, so a failed activation surfaced as
  `glewInit()` failing rather than as itself.
- The GLEW error code was not reported, which is why we cannot say from the production log
  *which* of the two failure modes fired.

### Not established

- **Whether this closes it.** The loop above has not yet been re-run against a patched binary on
  the machine that reproduces; I will report back either way. Please read it as a race that is
  real and unserialised in the source rather than as a measured fix. What is checked is that it
  compiles clean, and that 300 cycles of the dangerous pattern plus a graceful shutdown behave
  identically to the same tree built without the patch.
- **Why bare `ADD` never reproduced** while `remove` + `ADD` in one write did, given both churn
  consumers identically. Something about handling the explicit `REMOVE` first widens the window,
  and that is probably the shortest route to a narrower fix.
- **Whether it needs a second GL-using device in the process.** It only reproduced with
  `<html><enable-gpu>true</enable-gpu>`, which opens a D3D11 interop device alongside the GL one;
  never in 1200 cycles with it off, never on 2.5.0 or 2.4. That is absence of reproduction, not
  proof of dependence.

Same class as #1763 (consumer teardown ordering, DeckLink consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
