### PR TITLE
fix(osc): all channels but one lose state updates to a shared bundle slot

### DIFF
--- a/src/core/monitor/monitor.h
+++ b/src/core/monitor/monitor.h
@@ -108,6 +108,17 @@ class state
         data_ = other.data_;
         return *this;
     }
+    // The declared copy operations would otherwise suppress these, making every
+    // std::move of a state a silent copy that leaves the source populated.
+    state(state&& other) noexcept            = default;
+    state& operator=(state&& other) noexcept = default;
+
+    void merge(const state& other)
+    {
+        for (const auto& p : other.data_) {
+            data_[p.first] = p.second;
+        }
+    }
 
     template <typename T>
     state_proxy operator[](const T& key)

--- a/src/protocol/osc/client.cpp
+++ b/src/protocol/osc/client.cpp
@@ -191,7 +191,11 @@ struct client::impl : public spl::enable_shared_from_this<client::impl>
 
             // TODO: time_++ is a hack. Use proper channel time.
             bundle_time_ = time_++;
-            bundle_      = state;
+
+            // Each channel publishes from its own thread, so replacing the pending bundle
+            // drops what the others queued since the last send. Channels do not share
+            // addresses, so merging keeps all of them.
+            bundle_.merge(state);
         }
         cond_.notify_all();
     }


### PR DESCRIPTION
`osc::client::impl::send` keeps one pending bundle for the whole server and replaces it on every call:

```cpp
bundle_time_ = time_++;
bundle_      = state;
```

Every `video_channel` calls it from its own thread with a state containing only that channel. Channels tick in lockstep — same video mode, and in production a shared genlock — so their publishes collide inside every frame period and all but the last writer are discarded before the sender thread wakes. Channel 1 comes out best simply because it publishes first and finds the sender idle; the others overwrite each other while it is busy.

A client rendering a timecode from `file/time` therefore sees it advance smoothly on channel 1 and jump several frames at a time on every other channel. Reported against 2.5; `git log v2.5.x..master -- src/protocol/osc/` is empty apart from a lambda-capture cleanup, so master behaves the same.

### Fix

`send` merges into the pending bundle by address instead of replacing it. Channels do not share addresses, so all of them survive, and a channel that ticks twice before the sender drains supersedes only its own values — the right way to shed load if the sender ever falls behind. A bundle can now carry more than one channel, which the existing 2048-byte chunking already produced for a single busy channel.

`monitor::state` gains the move operations its declared copy operations were suppressing. Without them the sender's `bundle = std::move(bundle_)` silently copies and leaves `bundle_` populated — harmless while `send` replaced the slot, not harmless once it merges.

### Measurements

Windows, 1080p5000 channels, OSC to a loopback client, 15 s windows. Share of `file/time` updates that skipped at least one frame, four channels each looping a clip:

| | before | after |
|---|---|---|
| channel 1 | 20.2 % | 0.0 % |
| channel 2 | 45.1 % | 0.0 % |
| channel 3 | 58.5 % | 0.0 % |
| channel 4 | 31.5 % | 0.0 % |

Worst single skip was 10 frames. Share of ticks delivered, idle channels:

| channels | before | after |
|---|---|---|
| 1 | 100 % | 100 % |
| 4 | 54-82 % | 100 % on all four |
| 8 | 40-64 % | 100 % on all eight |
| 32 | 28-74 % | 100 % on all 32 |

Server CPU is unchanged (32 idle channels: 99.4 % of one core before, 99.2 % after — the channel threads dominate), and the datagram rate falls because one send now covers several channels: 761/s before, 723/s after while carrying nearly twice the data. The published address set is identical before and after, compared as a full inventory on a three-channel run including after a `STOP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
