### PR TITLE
build: copy CEF's DirectX Shader Compiler DLLs, so WebGPU can create a device

### DIFF
--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -277,6 +277,10 @@ if (ENABLE_HTML)
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/libcef.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/chrome_elf.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/d3dcompiler_47.dll")
+	# DirectX Shader Compiler, used by Dawn's D3D12 backend to compile WGSL for WebGPU.
+	# d3dcompiler_47.dll above serves ANGLE and does not cover it.
+	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/dxcompiler.dll")
+	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/dxil.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/libEGL.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/libGLESv2.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/vk_swiftshader.dll")

--- a/src/CMakeModules/Bootstrap_Windows.cmake
+++ b/src/CMakeModules/Bootstrap_Windows.cmake
@@ -277,8 +277,6 @@ if (ENABLE_HTML)
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/libcef.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/chrome_elf.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/d3dcompiler_47.dll")
-	# DirectX Shader Compiler, used by Dawn's D3D12 backend to compile WGSL for WebGPU.
-	# d3dcompiler_47.dll above serves ANGLE and does not cover it.
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/dxcompiler.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/dxil.dll")
 	casparcg_add_runtime_dependency("${CEF_BIN_PATH}/libEGL.dll")


### PR DESCRIPTION
### Problem

WebGPU cannot create a device in the HTML producer. `navigator.gpu` is present, `requestAdapter()` succeeds, and then:

```
requestDevice(): DynamicLib.Open: dxil.dll Windows Error: 87
    at EnsureDXCLibraries (third_party/dawn/src/dawn/native/d3d12/PlatformFunctionsD3D12.cpp:129)
```

Dawn's D3D12 backend compiles WGSL through the DirectX Shader Compiler. The CEF runtime dependency list in `Bootstrap_Windows.cmake` carries `d3dcompiler_47.dll`, which serves ANGLE (WebGL) and does not cover Dawn, so `dxcompiler.dll` and `dxil.dll` never reach the output folder.

### Fix

Two `casparcg_add_runtime_dependency` lines. Both files already ship inside the pinned CEF distribution — `cef_binary_142.0.17+g60aac24+chromium-142.0.7444.176_windows64_minimal` — so this adds no download and no new dependency, it only copies files that are already downloaded.

### Verification

Windows 10, NVIDIA Ampere, `<html><enable-gpu>true</enable-gpu>`:

- adapter acquired (`nvidia` / `ampere`), 18 features, `maxTextureDimension2D` 16384
- a compute shader round-tripped correctly through a storage buffer
- a WebGPU canvas composited into the channel and was captured through the IMAGE consumer, matching its clear colour within 1 LSB

As a third-party check, Vercel's `vgpu` 0.4.0 then runs unmodified — four asymmetric quadrant colours drawn via WGSL landed in the right positions, each within 1 LSB on every channel.

### Notes for reviewers

- Windows-only path; nothing changes on Linux or macOS.
- No behaviour change when `<html><enable-gpu>` is left at its default of `false` — the server passes `--disable-gpu` and no adapter is offered, exactly as before.
- The copy runs `POST_BUILD` on `casparcg_copy_dependencies`, so building only the `casparcg` target will not pick the new files up; a full build or that target does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)