### PR TITLE
Add new channels library and use it in `ffmpeg::Decoder`

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -41,6 +41,7 @@ set(HEADERS
 		array.h
 		assert.h
 		base64.h
+		channel.h
 		endian.h
 		enum_class.h
 		env.h

--- a/src/common/channel.h
+++ b/src/common/channel.h
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2025 Jacob Lifshay <programmerjake@gmail.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// use boost's types to support thread interruption
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <string>
+
+#ifdef CASPARCG_DEBUG_CHANNEL
+#include <sstream>
+
+#include "common/log.h"
+#endif
+
+namespace caspar {
+template <typename T>
+class Sender;
+
+template <typename T>
+class Receiver;
+
+struct channel_capacity_is_hint_t final
+{
+};
+
+inline constexpr channel_capacity_is_hint_t channel_capacity_is_hint{};
+
+template <typename T>
+std::pair<Sender<T>, Receiver<T>> channel(std::size_t capacity, std::string debug_name = {});
+
+template <typename T>
+std::pair<Sender<T>, Receiver<T>>
+channel(std::size_t capacity, channel_capacity_is_hint_t, std::string debug_name = {});
+
+template <typename T>
+class Receiver final
+{
+    template <typename>
+    friend class Sender;
+
+    template <typename T2>
+    friend std::pair<Sender<T2>, Receiver<T2>> channel(std::size_t capacity, std::string debug_name);
+
+    template <typename T2>
+    friend std::pair<Sender<T2>, Receiver<T2>>
+    channel(std::size_t capacity, channel_capacity_is_hint_t, std::string debug_name);
+
+  public:
+    Receiver() noexcept
+        : state_()
+    {
+    }
+    Receiver(const Receiver&)                = delete;
+    Receiver(Receiver&&) noexcept            = default;
+    Receiver& operator=(const Receiver&)     = delete;
+    Receiver& operator=(Receiver&&) noexcept = default;
+
+    bool closed() const
+    {
+        if (!state_)
+            return true;
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->queue_.empty() && state_->sender_destroyed_;
+    }
+    bool empty() const
+    {
+        if (!state_)
+            return true;
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->queue_.empty();
+    }
+    std::size_t capacity() const
+    {
+        if (!state_)
+            return 0;
+        return state_->capacity_;
+    }
+
+    struct TryReceiveResult final
+    {
+        std::optional<T> value;
+        bool             closed;
+    };
+    TryReceiveResult try_receive()
+    {
+        if (!state_)
+            return {std::nullopt, true};
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->try_receive_locked();
+    }
+    /// not named `receive` since that would imply throwing an exception when closed
+    std::optional<T> try_receive_blocking()
+    {
+        if (!state_)
+            return std::nullopt;
+        auto lock = boost::unique_lock(state_->lock_);
+
+        TryReceiveResult try_receive_result{std::nullopt, true};
+        state_->cond_.wait(lock, [&]() {
+            try_receive_result = state_->try_receive_locked();
+            return try_receive_result.value || try_receive_result.closed;
+        });
+        return std::move(try_receive_result.value);
+    }
+
+  private:
+    struct TrySendResult final
+    {
+        std::optional<T> unsent;
+        bool             closed;
+    };
+    struct State final
+    {
+        // use boost's types to support thread interruption
+        boost::mutex              lock_;
+        boost::condition_variable cond_;
+        std::queue<T>             queue_;
+        const std::size_t         capacity_;
+        const bool                capacity_is_hint_;
+#ifdef CASPARCG_DEBUG_CHANNEL
+        const std::string debug_name_;
+#endif
+        bool sender_destroyed_   = false;
+        bool receiver_destroyed_ = false;
+
+        TryReceiveResult try_receive_locked()
+        {
+            if (queue_.empty()) {
+#ifdef CASPARCG_DEBUG_CHANNEL
+                CASPAR_LOG(trace) << "channel state: " << debug_name_
+                                  << ": try_receive_locked: empty, sender_destroyed_ == " << sender_destroyed_;
+#endif
+                return {std::nullopt, sender_destroyed_};
+            }
+            TryReceiveResult retval{std::move(queue_.front()), false};
+            queue_.pop();
+            cond_.notify_all();
+#ifdef CASPARCG_DEBUG_CHANNEL
+            CASPAR_LOG(trace) << "channel state: " << debug_name_ << ": try_receive_locked: received value";
+#endif
+            return retval;
+        }
+
+        TrySendResult try_send_locked(T&& v)
+        {
+            if ((queue_.size() >= capacity_ && !capacity_is_hint_) || receiver_destroyed_) {
+#ifdef CASPARCG_DEBUG_CHANNEL
+                CASPAR_LOG(trace) << "channel state: " << debug_name_
+                                  << ": try_send_locked: full, receiver_destroyed_ == " << receiver_destroyed_;
+#endif
+                return {std::move(v), receiver_destroyed_};
+            }
+            queue_.push(std::move(v));
+            cond_.notify_all();
+#ifdef CASPARCG_DEBUG_CHANNEL
+            CASPAR_LOG(trace) << "channel state: " << debug_name_ << ": try_send_locked: sent value";
+#endif
+            return {std::nullopt, false};
+        }
+
+#ifdef CASPARCG_DEBUG_CHANNEL
+        static std::string make_default_debug_name(const void* p)
+        {
+            std::ostringstream os;
+            os << p;
+            return std::move(os).str();
+        }
+#endif
+
+        explicit State(std::size_t capacity, bool capacity_is_hint, std::string debug_name)
+            : capacity_(capacity)
+            , capacity_is_hint_(capacity_is_hint)
+#ifdef CASPARCG_DEBUG_CHANNEL
+            , debug_name_(debug_name.empty() ? make_default_debug_name(this) : std::move(debug_name))
+#endif
+        {
+        }
+        template <bool is_sender>
+        struct Deleter final
+        {
+            void operator()(State* state) noexcept
+            {
+                if (!state)
+                    return;
+                {
+                    auto lock = boost::unique_lock(state->lock_);
+                    if (is_sender) {
+#ifdef CASPARCG_DEBUG_CHANNEL
+                        CASPAR_LOG(trace) << "channel state: " << state->debug_name_ << ": destroy sender";
+#endif
+                        state->sender_destroyed_ = true;
+                    } else {
+#ifdef CASPARCG_DEBUG_CHANNEL
+                        CASPAR_LOG(trace) << "channel state: " << state->debug_name_ << ": destroy receiver";
+#endif
+                        state->receiver_destroyed_ = true;
+                    }
+                    if (!state->sender_destroyed_ || !state->receiver_destroyed_) {
+                        state->cond_.notify_all();
+                        return;
+                    }
+                }
+                delete state;
+            }
+        };
+    };
+    using Deleter = typename State::template Deleter<false>;
+    explicit Receiver(std::unique_ptr<State, Deleter> state) noexcept
+        : state_(std::move(state))
+    {
+    }
+    std::unique_ptr<State, Deleter> state_;
+};
+
+template <typename T>
+class Sender final
+{
+    template <typename T2>
+    friend std::pair<Sender<T2>, Receiver<T2>> channel(std::size_t capacity, std::string debug_name);
+
+    template <typename T2>
+    friend std::pair<Sender<T2>, Receiver<T2>>
+    channel(std::size_t capacity, channel_capacity_is_hint_t, std::string debug_name);
+
+  public:
+    Sender() noexcept
+        : state_()
+    {
+    }
+    Sender(const Sender&)                = delete;
+    Sender(Sender&&) noexcept            = default;
+    Sender& operator=(const Sender&)     = delete;
+    Sender& operator=(Sender&&) noexcept = default;
+
+    using TrySendResult = typename Receiver<T>::TrySendResult;
+
+    bool closed() const
+    {
+        if (!state_)
+            return true;
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->receiver_destroyed_;
+    }
+    bool full() const
+    {
+        if (!state_)
+            return true;
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->receiver_destroyed_ || state_->queue_.size() >= state_->capacity_;
+    }
+    std::size_t capacity() const
+    {
+        if (!state_)
+            return 0;
+        return state_->capacity_;
+    }
+    TrySendResult try_send(T v)
+    {
+        if (!state_)
+            return {std::move(v), true};
+        auto lock = boost::unique_lock(state_->lock_);
+        return state_->try_send_locked(std::move(v));
+    }
+    /// not named `send` since that would imply throwing an exception when closed.
+    /// returns the passed-in value if closed, otherwise returns nullopt
+    std::optional<T> try_send_blocking(T v)
+    {
+        if (!state_)
+            return std::move(v);
+        auto lock = boost::unique_lock(state_->lock_);
+
+        TrySendResult try_send_result{std::move(v), false};
+        state_->cond_.wait(lock, [&]() {
+            try_send_result = state_->try_send_locked(std::move(*try_send_result.unsent));
+            return try_send_result.closed || !try_send_result.unsent;
+        });
+        return std::move(try_send_result.unsent);
+    }
+
+  private:
+    using State   = typename Receiver<T>::State;
+    using Deleter = typename State::template Deleter<true>;
+    explicit Sender(std::unique_ptr<State, Deleter> state) noexcept
+        : state_(std::move(state))
+    {
+    }
+    std::unique_ptr<State, Deleter> state_;
+};
+
+template <typename T>
+std::pair<Sender<T>, Receiver<T>> channel(std::size_t capacity, std::string debug_name)
+{
+    using State = typename Receiver<T>::State;
+    auto state  = new State(capacity, false, std::move(debug_name));
+    return {Sender<T>(std::unique_ptr<State, typename Sender<T>::Deleter>(state)),
+            Receiver<T>(std::unique_ptr<State, typename Receiver<T>::Deleter>(state))};
+}
+
+template <typename T>
+std::pair<Sender<T>, Receiver<T>> channel(std::size_t capacity, channel_capacity_is_hint_t, std::string debug_name)
+{
+    using State = typename Receiver<T>::State;
+    auto state  = new State(capacity, true, std::move(debug_name));
+    return {Sender<T>(std::unique_ptr<State, typename Sender<T>::Deleter>(state)),
+            Receiver<T>(std::unique_ptr<State, typename Receiver<T>::Deleter>(state))};
+}
+} // namespace caspar

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -14,6 +14,7 @@
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/mutex.hpp>
 
+#include <common/channel.h>
 #include <common/diagnostics/graph.h>
 #include <common/env.h>
 #include <common/except.h>
@@ -100,19 +101,11 @@ class Decoder
     Decoder(const Decoder&)            = delete;
     Decoder& operator=(const Decoder&) = delete;
 
-    AVStream*         st       = nullptr;
-    int64_t           next_pts = AV_NOPTS_VALUE;
-    std::atomic<bool> eof      = {false};
+    AVStream* st       = nullptr;
+    int64_t   next_pts = AV_NOPTS_VALUE;
 
-    std::queue<std::shared_ptr<AVPacket>> input;
-    mutable boost::mutex                  input_mutex;
-    boost::condition_variable             input_cond;
-    int                                   input_capacity = 2;
-
-    std::queue<std::shared_ptr<AVFrame>> output;
-    mutable boost::mutex                 output_mutex;
-    boost::condition_variable            output_cond;
-    int                                  output_capacity = 8;
+    Sender<std::shared_ptr<AVPacket>>  input;
+    Receiver<std::shared_ptr<AVFrame>> output;
 
     boost::thread thread;
 
@@ -124,6 +117,17 @@ class Decoder
     explicit Decoder(AVStream* stream)
         : st(stream)
     {
+        auto debug_stream_kind = stream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO   ? "video"
+                                 : stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO ? "audio"
+                                                                                      : "unknown";
+        auto input_channel     = channel<std::shared_ptr<AVPacket>>(
+            2, channel_capacity_is_hint, (boost::format("Decoder-%i-%s-in") % stream->index % debug_stream_kind).str());
+        auto output_channel = channel<std::shared_ptr<AVFrame>>(
+            8, (boost::format("Decoder-%i-%s-out") % stream->index % debug_stream_kind).str());
+
+        input  = std::move(input_channel.first);
+        output = std::move(output_channel.second);
+
         const auto codec = get_decoder(stream->codecpar->codec_id);
 
         if (!codec) {
@@ -158,32 +162,28 @@ class Decoder
 
         FF(avcodec_open2(ctx.get(), codec, nullptr));
 
-        thread = boost::thread([this]() {
+        thread = boost::thread([=,
+                                this,
+                                input_receiver = std::move(input_channel.second),
+                                output_sender  = std::move(output_channel.first)]() mutable {
             try {
                 while (!thread.interruption_requested()) {
                     auto av_frame = alloc_frame();
                     auto ret      = avcodec_receive_frame(ctx.get(), av_frame.get());
 
                     if (ret == AVERROR(EAGAIN)) {
-                        std::shared_ptr<AVPacket> packet;
-                        {
-                            boost::unique_lock<boost::mutex> lock(input_mutex);
-                            input_cond.wait(lock, [&]() { return !input.empty(); });
-                            packet = std::move(input.front());
-                            input.pop();
+                        auto packet_opt = input_receiver.try_receive_blocking();
+                        FF(avcodec_send_packet(ctx.get(), packet_opt.value_or(nullptr).get()));
+                        if (!packet_opt) {
+                            break; // no sender -- we're done
                         }
-                        FF(avcodec_send_packet(ctx.get(), packet.get()));
                     } else if (ret == AVERROR_EOF) {
                         avcodec_flush_buffers(ctx.get());
                         av_frame->pts = next_pts;
                         next_pts      = AV_NOPTS_VALUE;
-                        eof           = true;
-
-                        {
-                            boost::unique_lock<boost::mutex> lock(output_mutex);
-                            output_cond.wait(lock, [&]() { return output.size() < output_capacity; });
-                            output.push(std::move(av_frame));
-                        }
+                        // we don't care if there's no receiver anymore, we're done anyway
+                        static_cast<void>(output_sender.try_send_blocking(av_frame));
+                        break; // we're done
                     } else {
                         FF_RET(ret, "avcodec_receive_frame");
 
@@ -231,17 +231,14 @@ class Decoder
                             next_pts = AV_NOPTS_VALUE;
                         }
 
-                        {
-                            boost::unique_lock<boost::mutex> lock(output_mutex);
-                            output_cond.wait(lock, [&]() { return output.size() < output_capacity; });
-                            output.push(std::move(av_frame));
+                        if (output_sender.try_send_blocking(av_frame)) {
+                            break; // no receiver -- we're done
                         }
                     }
                 }
             } catch (boost::thread_interrupted&) {
                 // Do nothing...
             } catch (...) {
-                eof = true;
                 CASPAR_LOG_CURRENT_EXCEPTION();
             }
         });
@@ -259,52 +256,19 @@ class Decoder
         }
     }
 
-    bool want_packet() const
-    {
-        if (eof) {
-            return false;
-        }
-
-        {
-            boost::lock_guard<boost::mutex> lock(input_mutex);
-            return input.size() < input_capacity;
-        }
-    }
+    bool want_packet() const { return !input.full(); }
 
     void push(std::shared_ptr<AVPacket> packet)
     {
-        if (eof) {
-            return;
-        }
-
-        {
-            boost::lock_guard<boost::mutex> lock(input_mutex);
-            input.push(std::move(packet));
-        }
-
-        input_cond.notify_all();
+        input.try_send_blocking(packet); // ignore if we fail to send
     }
 
     std::shared_ptr<AVFrame> pop()
     {
-        std::shared_ptr<AVFrame> frame;
-
-        {
-            boost::lock_guard<boost::mutex> lock(output_mutex);
-
-            if (!output.empty()) {
-                frame = std::move(output.front());
-                output.pop();
-            }
-        }
-
-        if (frame) {
-            output_cond.notify_all();
-        } else if (eof) {
-            frame = alloc_frame();
-        }
-
-        return frame;
+        auto try_receive_result = output.try_receive();
+        if (try_receive_result.closed)
+            return alloc_frame();
+        return std::move(try_receive_result.value).value_or(nullptr);
     }
 };
 


### PR DESCRIPTION
This is split out from #1637.

This adds a channels API loosely inspired by [Rust's mpsc channels](https://doc.rust-lang.org/std/sync/mpsc/), though it only supports a single sender and receiver per channel, unlike the Rust channels.

Changing `ffmpeg::Decoder` over to use channels is needed because #1637 depends on it and because I think it makes it much easier to reason about. (#1637 does a bunch of redirecting channels which can't easily be done with the old mutex/cond-var implementation of `Decoder`).