### PR TITLE
Add new APIs for creating `[a]buffersink`s and switch to using them

### DIFF
--- a/src/modules/decklink/producer/decklink_producer.cpp
+++ b/src/modules/decklink/producer/decklink_producer.cpp
@@ -213,56 +213,19 @@ struct Filter
         }
 
         if (type == AVMEDIA_TYPE_VIDEO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("buffersink"), "out"));
-
-            AVPixelFormat pix_fmts[] = {pix_fmt, AV_PIX_FMT_NONE};
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            FF(av_opt_set_array(sink,
-                                "pixel_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(pix_fmts) - 1,
-                                AV_OPT_TYPE_PIXEL_FMT,
-                                pix_fmts));
-#else
-            FF(av_opt_set_int_list(sink, "pix_fmts", pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-#endif
+            sink = create_buffersink(graph.get(), "out", av_opt_array_ref{pix_fmt});
         } else if (type == AVMEDIA_TYPE_AUDIO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
-
-            AVSampleFormat sample_fmts[]  = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
-            int            sample_rates[] = {format_desc.audio_sample_rate, 0};
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            FF(av_opt_set_array(sink,
-                                "sample_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(sample_fmts) - 1,
-                                AV_OPT_TYPE_SAMPLE_FMT,
-                                sample_fmts));
-            FF(av_opt_set_array(sink,
-                                "samplerates",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(sample_rates) - 1,
-                                AV_OPT_TYPE_INT,
-                                sample_rates));
-#else
-            FF(av_opt_set_int_list(sink, "sample_fmts", sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-            FF(av_opt_set_int_list(sink, "sample_rates", sample_rates, 0, AV_OPT_SEARCH_CHILDREN));
-#endif
-
+            std::optional<av_opt_array_ref<AVChannelLayout>> channel_layouts;
             // TODO - we might want to force the filter to produce 16 channels
             // But this segfaults (changing the property name causes it to fail with an error)
             // As 16 channel packets are fed into the filter, with the filter set to the same, that is what we get out
-            /*
-            AVChannelLayout channel_layout = AV_CHANNEL_LAYOUT_STEREO;
-            av_channel_layout_default(&channel_layout, format_desc.audio_channels);
-
-            FF(av_opt_set_chlayout(sink, "ch_layouts", &channel_layout, AV_OPT_SEARCH_CHILDREN));
-            av_channel_layout_uninit(&channel_layout);
-             */
-
+            //
+            // channel_layouts = {get_channel_layout_default(format_desc.audio_channels)};
+            sink = create_abuffersink(graph.get(),
+                                      "out",
+                                      av_opt_array_ref{AV_SAMPLE_FMT_S32},
+                                      av_opt_array_ref{format_desc.audio_sample_rate},
+                                      channel_layouts);
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
                                    << boost::errinfo_errno(EINVAL) << msg_info_t("invalid output media type"));

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -202,72 +202,20 @@ struct Stream
         }
 
         if (codec->type == AVMEDIA_TYPE_VIDEO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("buffersink"), "out"));
-
             // TODO codec->profiles
-            // TODO FF(av_opt_set_int_list(sink, "framerates", codec->supported_framerates, { 0, 0 },
-            // AV_OPT_SEARCH_CHILDREN));
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            const void* pix_fmts;
-            int         nb_pix_fmts = 0;
-            FF(avcodec_get_supported_config(nullptr, codec, AV_CODEC_CONFIG_PIX_FORMAT, 0, &pix_fmts, &nb_pix_fmts));
-
-            FF(av_opt_set_array(sink,
-                                "pixel_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                nb_pix_fmts,
-                                AV_OPT_TYPE_PIXEL_FMT,
-                                pix_fmts));
-#else
-            FF(av_opt_set_int_list(sink, "pix_fmts", codec->pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-#endif
-
+            // TODO codec->supported_framerates
+            sink = create_buffersink(graph.get(), "out", get_supported_pixel_formats(nullptr, codec));
         } else if (codec->type == AVMEDIA_TYPE_AUDIO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
             // TODO codec->profiles
-
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            const void* sample_fmts;
-            int         nb_sample_fmts = 0;
-            FF(avcodec_get_supported_config(
-                nullptr, codec, AV_CODEC_CONFIG_SAMPLE_FORMAT, 0, &sample_fmts, &nb_sample_fmts));
-
-            FF(av_opt_set_array(sink,
-                                "sample_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                nb_sample_fmts,
-                                AV_OPT_TYPE_SAMPLE_FMT,
-                                sample_fmts));
-
-            const void* sample_rates;
-            int         nb_sample_rates = 0;
-            FF(avcodec_get_supported_config(
-                nullptr, codec, AV_CODEC_CONFIG_SAMPLE_RATE, 0, &sample_rates, &nb_sample_rates));
-
-            FF(av_opt_set_array(sink,
-                                "samplerates",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                nb_sample_rates,
-                                AV_OPT_TYPE_INT,
-                                sample_rates));
-#else
-            FF(av_opt_set_int_list(sink, "sample_fmts", codec->sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-            FF(av_opt_set_int_list(sink, "sample_rates", codec->supported_samplerates, 0, AV_OPT_SEARCH_CHILDREN));
-#endif
-
-            // TODO: need to translate codec->ch_layouts into something that can be passed via av_opt_set_*
-            // FF(av_opt_set_chlayout(sink, "ch_layouts", codec->ch_layouts, AV_OPT_SEARCH_CHILDREN));
-
+            sink = create_abuffersink(graph.get(),
+                                      "out",
+                                      get_supported_sample_formats(nullptr, codec),
+                                      get_supported_sample_rates(nullptr, codec),
+                                      get_supported_channel_layouts(nullptr, codec));
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
                                    << boost::errinfo_errno(EINVAL) << msg_info_t("invalid output media type"));
         }
-
-        FF(avfilter_init_str(sink, nullptr));
-
         {
             const auto cur = outputs;
 

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -45,7 +45,7 @@ extern "C" {
 #include <deque>
 #include <iomanip>
 #include <memory>
-#include <queue>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -545,80 +545,47 @@ struct Filter
         }
 
         if (media_type == AVMEDIA_TYPE_VIDEO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("buffersink"), "out"));
-
-            const AVPixelFormat pix_fmts[] = {AV_PIX_FMT_RGB24,
-                                              AV_PIX_FMT_BGR24,
-                                              AV_PIX_FMT_BGRA,
-                                              AV_PIX_FMT_ARGB,
-                                              AV_PIX_FMT_RGBA,
-                                              AV_PIX_FMT_ABGR,
-                                              AV_PIX_FMT_YUV444P,
-                                              AV_PIX_FMT_YUV444P10,
-                                              AV_PIX_FMT_YUV444P12,
-                                              AV_PIX_FMT_YUV422P,
-                                              AV_PIX_FMT_YUV422P10,
-                                              AV_PIX_FMT_YUV422P12,
-                                              AV_PIX_FMT_YUV420P,
-                                              AV_PIX_FMT_YUV420P10,
-                                              AV_PIX_FMT_YUV420P12,
-                                              AV_PIX_FMT_YUV410P,
-                                              AV_PIX_FMT_YUVA444P,
-                                              AV_PIX_FMT_YUVA422P,
-                                              AV_PIX_FMT_YUVA420P,
-                                              AV_PIX_FMT_UYVY422,
-                                              // bwdif needs planar rgb
-                                              AV_PIX_FMT_GBRP,
-                                              AV_PIX_FMT_GBRP10,
-                                              AV_PIX_FMT_GBRP12,
-                                              AV_PIX_FMT_GBRP16,
-                                              AV_PIX_FMT_GBRAP,
-                                              AV_PIX_FMT_GBRAP16,
-                                              AV_PIX_FMT_NONE};
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            FF(av_opt_set_array(sink,
-                                "pixel_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(pix_fmts) - 1,
-                                AV_OPT_TYPE_PIXEL_FMT,
-                                pix_fmts));
-#else
-            FF(av_opt_set_int_list(sink, "pix_fmts", pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-#endif
+            sink = create_buffersink(graph.get(),
+                                     "out",
+                                     av_opt_array_ref{
+                                         AV_PIX_FMT_RGB24,
+                                         AV_PIX_FMT_BGR24,
+                                         AV_PIX_FMT_BGRA,
+                                         AV_PIX_FMT_ARGB,
+                                         AV_PIX_FMT_RGBA,
+                                         AV_PIX_FMT_ABGR,
+                                         AV_PIX_FMT_YUV444P,
+                                         AV_PIX_FMT_YUV444P10,
+                                         AV_PIX_FMT_YUV444P12,
+                                         AV_PIX_FMT_YUV422P,
+                                         AV_PIX_FMT_YUV422P10,
+                                         AV_PIX_FMT_YUV422P12,
+                                         AV_PIX_FMT_YUV420P,
+                                         AV_PIX_FMT_YUV420P10,
+                                         AV_PIX_FMT_YUV420P12,
+                                         AV_PIX_FMT_YUV410P,
+                                         AV_PIX_FMT_YUVA444P,
+                                         AV_PIX_FMT_YUVA422P,
+                                         AV_PIX_FMT_YUVA420P,
+                                         AV_PIX_FMT_UYVY422,
+                                         // bwdif needs planar rgb
+                                         AV_PIX_FMT_GBRP,
+                                         AV_PIX_FMT_GBRP10,
+                                         AV_PIX_FMT_GBRP12,
+                                         AV_PIX_FMT_GBRP16,
+                                         AV_PIX_FMT_GBRAP,
+                                         AV_PIX_FMT_GBRAP16,
+                                     });
         } else if (media_type == AVMEDIA_TYPE_AUDIO) {
-            sink = FFMEM(avfilter_graph_alloc_filter(graph.get(), avfilter_get_by_name("abuffersink"), "out"));
-
-            const AVSampleFormat sample_fmts[]  = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
-            const int            sample_rates[] = {format_desc.audio_sample_rate, -1};
-
-            FF(av_opt_set_int(sink, "all_channel_counts", 1, AV_OPT_SEARCH_CHILDREN));
-
-#if LIBAVUTIL_VERSION_MAJOR >= 60 // FFmpeg 8
-            FF(av_opt_set_array(sink,
-                                "sample_formats",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(sample_fmts) - 1,
-                                AV_OPT_TYPE_SAMPLE_FMT,
-                                sample_fmts));
-            FF(av_opt_set_array(sink,
-                                "samplerates",
-                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
-                                0,
-                                FF_ARRAY_ELEMS(sample_rates) - 1,
-                                AV_OPT_TYPE_INT,
-                                sample_rates));
-#else
-            FF(av_opt_set_int_list(sink, "sample_fmts", sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
-            FF(av_opt_set_int_list(sink, "sample_rates", sample_rates, -1, AV_OPT_SEARCH_CHILDREN));
-#endif
+            sink = create_abuffersink(graph.get(),
+                                      "out",
+                                      av_opt_array_ref{AV_SAMPLE_FMT_S32},
+                                      av_opt_array_ref{format_desc.audio_sample_rate},
+                                      std::nullopt);
         } else {
             CASPAR_THROW_EXCEPTION(ffmpeg_error_t()
                                    << boost::errinfo_errno(EINVAL) << msg_info_t("invalid output media type"));
         }
-
-        FF(avfilter_init_str(sink, nullptr));
 
         // output
         {

--- a/src/modules/ffmpeg/util/av_util.cpp
+++ b/src/modules/ffmpeg/util/av_util.cpp
@@ -2,6 +2,9 @@
 #include "av_assert.h"
 
 #include <common/bit_depth.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -9,10 +12,10 @@ extern "C" {
 #include <libavutil/channel_layout.h>
 #include <libavutil/frame.h>
 #include <libavutil/imgutils.h>
+#include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>
 }
 
-#include <array>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_invoke.h>
 
@@ -414,4 +417,163 @@ uint64_t get_channel_layout_mask_for_channels(int channel_count)
     return channel_layout;
 }
 
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(10, 6, 0)
+#define GET_SET_ATTRIBUTE(                                                                                             \
+    ty, fn_suffix, config_type, opt_type, old_config_name, new_config_name, codec_type, field, terminator)             \
+    av_opt_array_ref<ty> get_supported_##fn_suffix(const AVCodecContext* avctx, const AVCodec* codec)                  \
+    {                                                                                                                  \
+        if (!codec)                                                                                                    \
+            codec = avctx->codec;                                                                                      \
+        if (codec->type != codec_type)                                                                                 \
+            FF_RET(AVERROR(EINVAL), THROW_ON_ERROR_STR(get_supported_##fn_suffix));                                    \
+        return av_opt_array_ref<ty>::terminated(codec->field, terminator);                                             \
+    }                                                                                                                  \
+                                                                                                                       \
+    void set_##fn_suffix(AVFilterContext* target, av_opt_array_ref<ty> array_ref)                                      \
+    {                                                                                                                  \
+        std::size_t size = sizeof(ty) * array_ref.size();                                                              \
+        if (size > static_cast<std::size_t>(INT_MAX))                                                                  \
+            CASPAR_THROW_EXCEPTION(caspar::bad_alloc() << boost::errinfo_api_function("set_" #fn_suffix));             \
+        FF(av_opt_set_bin(target,                                                                                      \
+                          old_config_name,                                                                             \
+                          reinterpret_cast<const uint8_t*>(array_ref.data()),                                          \
+                          static_cast<int>(size),                                                                      \
+                          AV_OPT_SEARCH_CHILDREN));                                                                    \
+    }
+
+#else
+#define GET_SET_ATTRIBUTE(                                                                                             \
+    ty, fn_suffix, config_type, opt_type, old_config_name, new_config_name, codec_type, field, terminator)             \
+    av_opt_array_ref<ty> get_supported_##fn_suffix(const AVCodecContext* avctx, const AVCodec* codec)                  \
+    {                                                                                                                  \
+        const ty* data = nullptr;                                                                                      \
+        int       size = 0;                                                                                            \
+        FF(avcodec_get_supported_config(avctx, codec, config_type, 0, reinterpret_cast<const void**>(&data), &size));  \
+        return av_opt_array_ref<ty>(data, size);                                                                       \
+    }                                                                                                                  \
+                                                                                                                       \
+    void set_##fn_suffix(AVFilterContext* target, av_opt_array_ref<ty> array_ref)                                      \
+    {                                                                                                                  \
+        if (array_ref.size() > static_cast<std::size_t>(UINT_MAX))                                                     \
+            CASPAR_THROW_EXCEPTION(caspar::bad_alloc() << boost::errinfo_api_function("set_" #fn_suffix));             \
+        FF(av_opt_set_array(target,                                                                                    \
+                            new_config_name,                                                                           \
+                            AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,                                             \
+                            0,                                                                                         \
+                            static_cast<unsigned>(array_ref.size()),                                                   \
+                            opt_type,                                                                                  \
+                            array_ref.data()));                                                                        \
+    }
+#endif
+
+GET_SET_ATTRIBUTE(AVPixelFormat,
+                  pixel_formats,
+                  AV_CODEC_CONFIG_PIX_FORMAT,
+                  AV_OPT_TYPE_PIXEL_FMT,
+                  "pix_fmts",
+                  "pixel_formats",
+                  AVMEDIA_TYPE_VIDEO,
+                  pix_fmts,
+                  AV_PIX_FMT_NONE)
+
+GET_SET_ATTRIBUTE(AVSampleFormat,
+                  sample_formats,
+                  AV_CODEC_CONFIG_SAMPLE_FORMAT,
+                  AV_OPT_TYPE_SAMPLE_FMT,
+                  "sample_fmts",
+                  "sample_formats",
+                  AVMEDIA_TYPE_AUDIO,
+                  sample_fmts,
+                  AV_SAMPLE_FMT_NONE)
+
+GET_SET_ATTRIBUTE(int,
+                  sample_rates,
+                  AV_CODEC_CONFIG_SAMPLE_RATE,
+                  AV_OPT_TYPE_INT,
+                  "sample_rates",
+                  "samplerates",
+                  AVMEDIA_TYPE_AUDIO,
+                  supported_samplerates,
+                  0)
+
+av_opt_array_ref<AVChannelLayout> get_supported_channel_layouts(const AVCodecContext* avctx, const AVCodec* codec)
+{
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(10, 6, 0)
+    if (!codec)
+        codec = avctx->codec;
+    if (codec->type != AVMEDIA_TYPE_AUDIO)
+        FF_RET(AVERROR(EINVAL), THROW_ON_ERROR_STR(get_supported_channel_layouts));
+    static constexpr AVChannelLayout terminator = {};
+    return av_opt_array_ref<AVChannelLayout>::terminated(codec->ch_layouts, [](const AVChannelLayout& v) {
+        return 0 == std::memcmp(&v, &terminator, sizeof(terminator));
+    });
+#else
+    const AVChannelLayout* data = nullptr;
+    int                    size = 0;
+    FF(avcodec_get_supported_config(
+        avctx, codec, AV_CODEC_CONFIG_CHANNEL_LAYOUT, 0, reinterpret_cast<const void**>(&data), &size));
+    return av_opt_array_ref<AVChannelLayout>(data, size);
+#endif
+}
+
+void set_channel_layouts(AVFilterContext* target, av_opt_array_ref<AVChannelLayout> array_ref)
+{
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(10, 6, 0)
+    // TODO: need to translate into something that can be passed via av_opt_set_*
+    // FF(av_opt_set_chlayout(sink, "ch_layouts", ch_layouts, AV_OPT_SEARCH_CHILDREN));
+#else
+    if (array_ref.size() > static_cast<std::size_t>(UINT_MAX))
+        CASPAR_THROW_EXCEPTION(caspar::bad_alloc() << boost::errinfo_api_function("set_channel_layouts"));
+    FF(av_opt_set_array(target,
+                        "channel_layouts",
+                        AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                        0,
+                        static_cast<unsigned>(array_ref.size()),
+                        AV_OPT_TYPE_CHLAYOUT,
+                        array_ref.data()));
+#endif
+}
+
+AVChannelLayout get_channel_layout_default(int nb_channels)
+{
+    AVChannelLayout retval{};
+    av_channel_layout_default(&retval, nb_channels);
+    return retval;
+}
+
+AVFilterContext*
+create_buffersink(AVFilterGraph* graph, const char* name, std::optional<av_opt_array_ref<AVPixelFormat>> pixel_formats)
+{
+    AVFilterContext* retval = FFMEM(avfilter_graph_alloc_filter(graph, avfilter_get_by_name("buffersink"), name));
+    if (pixel_formats) {
+        set_pixel_formats(retval, *pixel_formats);
+    }
+    FF(avfilter_init_str(retval, nullptr));
+    return retval;
+}
+
+AVFilterContext* create_abuffersink(AVFilterGraph*                                   graph,
+                                    const char*                                      name,
+                                    std::optional<av_opt_array_ref<AVSampleFormat>>  sample_formats,
+                                    std::optional<av_opt_array_ref<int>>             sample_rates,
+                                    std::optional<av_opt_array_ref<AVChannelLayout>> channel_layouts)
+{
+    AVFilterContext* retval = FFMEM(avfilter_graph_alloc_filter(graph, avfilter_get_by_name("abuffersink"), name));
+    if (sample_formats) {
+        set_sample_formats(retval, *sample_formats);
+    }
+    if (sample_rates) {
+        set_sample_rates(retval, *sample_rates);
+    }
+    if (channel_layouts) {
+        set_channel_layouts(retval, *channel_layouts);
+    }
+#if LIBAVFILTER_VERSION_INT < AV_VERSION_INT(10, 6, 0)
+    else {
+        FF(av_opt_set_int(retval, "all_channel_counts", 1, AV_OPT_SEARCH_CHILDREN));
+    }
+#endif
+    FF(avfilter_init_str(retval, nullptr));
+    return retval;
+}
 }} // namespace caspar::ffmpeg

--- a/src/modules/ffmpeg/util/av_util.h
+++ b/src/modules/ffmpeg/util/av_util.h
@@ -1,7 +1,11 @@
 #pragma once
 
 extern "C" {
+#define __STDC_CONSTANT_MACROS
+#define __STDC_LIMIT_MACROS
+#include <libavfilter/avfilter.h>
 #include <libavutil/pixfmt.h>
+#include <libavutil/samplefmt.h>
 }
 
 #include <core/frame/frame.h>
@@ -10,13 +14,19 @@ extern "C" {
 #include <core/frame/pixel_format.h>
 #include <core/video_format.h>
 
+#include <cstdint>
+#include <initializer_list>
 #include <map>
 #include <memory>
+#include <optional>
+#include <type_traits>
 #include <vector>
 
 struct AVFrame;
 struct AVPacket;
 struct AVFilterContext;
+struct AVFilterGraph;
+struct AVCodec;
 struct AVCodecContext;
 struct AVDictionary;
 
@@ -47,5 +57,78 @@ AVDictionary*                      to_dict(std::map<std::string, std::string>&& 
 std::map<std::string, std::string> to_map(AVDictionary** dict);
 
 uint64_t get_channel_layout_mask_for_channels(int channel_count);
+
+template <typename T>
+class av_opt_array_ref final
+{
+  private:
+    const T*    data_;
+    std::size_t size_;
+
+  public:
+    constexpr av_opt_array_ref() noexcept
+        : av_opt_array_ref(nullptr, 0)
+    {
+    }
+    constexpr av_opt_array_ref(const T* data, std::size_t size) noexcept
+        : data_(size == 0 ? nullptr : data)
+        , size_(size)
+    {
+    }
+    constexpr av_opt_array_ref(std::initializer_list<T> data) noexcept
+        : av_opt_array_ref(data.begin(), data.size())
+    {
+    }
+    template <typename = std::enable_if<std::is_integral_v<T> || std::is_enum_v<T>>>
+    static constexpr av_opt_array_ref terminated(const T* data, T terminator)
+    {
+        if (!data) {
+            return av_opt_array_ref();
+        }
+        std::size_t size = 0;
+        while (data[size] != terminator)
+            size++;
+        return av_opt_array_ref(data, size);
+    }
+    template <typename F,
+              typename = std::enable_if<std::is_same_v<bool, decltype(std::declval<F&>()(std::declval<const T&>()))>>>
+    static constexpr av_opt_array_ref terminated(const T* data, F&& is_terminator)
+    {
+        if (!data) {
+            return av_opt_array_ref();
+        }
+        std::size_t size = 0;
+        while (!is_terminator(data[size]))
+            size++;
+        return av_opt_array_ref(data, size);
+    }
+    constexpr const T*    begin() const noexcept { return data_; }
+    constexpr const T*    end() const noexcept { return data_ + size_; }
+    constexpr const T*    data() const noexcept { return data_; }
+    constexpr std::size_t size() const noexcept { return size_; }
+    constexpr bool        empty() const noexcept { return size_ == 0; }
+};
+
+av_opt_array_ref<AVPixelFormat> get_supported_pixel_formats(const AVCodecContext* avctx, const AVCodec* codec);
+void set_pixel_formats(AVFilterContext* target, av_opt_array_ref<AVPixelFormat> pixel_formats);
+
+av_opt_array_ref<AVSampleFormat> get_supported_sample_formats(const AVCodecContext* avctx, const AVCodec* codec);
+void set_sample_formats(AVFilterContext* target, av_opt_array_ref<AVSampleFormat> sample_formats);
+
+av_opt_array_ref<int> get_supported_sample_rates(const AVCodecContext* avctx, const AVCodec* codec);
+void                  set_sample_rates(AVFilterContext* target, av_opt_array_ref<int> sample_rates);
+
+av_opt_array_ref<AVChannelLayout> get_supported_channel_layouts(const AVCodecContext* avctx, const AVCodec* codec);
+void            set_channel_layouts(AVFilterContext* target, av_opt_array_ref<AVChannelLayout> channel_layouts);
+AVChannelLayout get_channel_layout_default(int nb_channels);
+
+AVFilterContext*
+create_buffersink(AVFilterGraph* graph, const char* name, std::optional<av_opt_array_ref<AVPixelFormat>> pixel_formats);
+
+AVFilterContext* create_abuffersink(AVFilterGraph*                                   graph,
+                                    const char*                                      name,
+                                    std::optional<av_opt_array_ref<AVSampleFormat>>  sample_formats,
+                                    std::optional<av_opt_array_ref<int>>             sample_rates,
+                                    std::optional<av_opt_array_ref<AVChannelLayout>> channel_layouts);
 
 }} // namespace caspar::ffmpeg


### PR DESCRIPTION
The existing code does a bunch of creating buffersinks in different spots and that makes it easy for them to become inconsistent, this PR creates one common API that can be easily used by the rest of the project.

This is split out from #1637 