### PR TITLE
work around gcc 14 bug when inlining std::string("...") + "..."

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -45,7 +45,7 @@
     do {                                                                                                               \
         if (!(expr)) {                                                                                                 \
             CASPAR_THROW_EXCEPTION(programming_error()                                                                 \
-                                   << msg_info(std::string("Assertion Failed: ") + CASPAR_VERIFY_EXPR_STR(expr)));     \
+                                   << msg_info(std::string("Assertion Failed: " CASPAR_VERIFY_EXPR_STR(expr))));       \
         }                                                                                                              \
     } while (0);
 


### PR DESCRIPTION
This is split out from #1637 
I ran into this while working on that -- basically gcc incorrectly detects string sizes and emits warnings, those warnings are marked to cause errors.

idk if there's a gcc bug report, but I found:
https://issues.apache.org/jira/projects/THRIFT/issues/THRIFT-6076?filter=allopenissues